### PR TITLE
Remove all public reexports

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -11,63 +11,62 @@
 // Enable this to squash warnings due to exporting pieces of the representation
 // for use with the regex! macro. See lib.rs for explanation.
 
-pub use self::Inst::*;
+use self::Inst::*;
 
 use std::cmp;
 use parse;
-use parse::{
-    Flags, FLAG_EMPTY,
-    Nothing, Literal, Dot, AstClass, Begin, End, WordBoundary, Capture, Cat, Alt,
-    Rep,
-    ZeroOne, ZeroMore, OneMore,
-};
+use parse::{Flags, FLAG_EMPTY};
+use parse::Ast::{Nothing, Literal, Dot, AstClass, Begin, End, WordBoundary, Capture, Cat, Alt,
+                 Rep};
+use parse::Repeater::{ZeroOne, ZeroMore, OneMore};
 
-type InstIdx = uint;
+pub type InstIdx = uint;
 
+/// An instruction, the underlying unit of a compiled regular expression
 #[deriving(Show, Clone)]
 pub enum Inst {
-    // When a Match instruction is executed, the current thread is successful.
+    /// When a Match instruction is executed, the current thread is successful.
     Match,
 
-    // The OneChar instruction matches a literal character.
-    // The flags indicate whether to do a case insensitive match.
+    /// The OneChar instruction matches a literal character.
+    /// The flags indicate whether to do a case insensitive match.
     OneChar(char, Flags),
 
-    // The CharClass instruction tries to match one input character against
-    // the range of characters given.
-    // The flags indicate whether to do a case insensitive match and whether
-    // the character class is negated or not.
+    /// The CharClass instruction tries to match one input character against
+    /// the range of characters given.
+    /// The flags indicate whether to do a case insensitive match and whether
+    /// the character class is negated or not.
     CharClass(Vec<(char, char)>, Flags),
 
-    // Matches any character except new lines.
-    // The flags indicate whether to include the '\n' character.
+    /// Matches any character except new lines.
+    /// The flags indicate whether to include the '\n' character.
     Any(Flags),
 
-    // Matches the beginning of the string, consumes no characters.
-    // The flags indicate whether it matches if the preceding character
-    // is a new line.
+    /// Matches the beginning of the string, consumes no characters.
+    /// The flags indicate whether it matches if the preceding character
+    /// is a new line.
     EmptyBegin(Flags),
 
-    // Matches the end of the string, consumes no characters.
-    // The flags indicate whether it matches if the proceeding character
-    // is a new line.
+    /// Matches the end of the string, consumes no characters.
+    /// The flags indicate whether it matches if the proceeding character
+    /// is a new line.
     EmptyEnd(Flags),
 
-    // Matches a word boundary (\w on one side and \W \A or \z on the other),
-    // and consumes no character.
-    // The flags indicate whether this matches a word boundary or something
-    // that isn't a word boundary.
+    /// Matches a word boundary (\w on one side and \W \A or \z on the other),
+    /// and consumes no character.
+    /// The flags indicate whether this matches a word boundary or something
+    /// that isn't a word boundary.
     EmptyWordBoundary(Flags),
 
-    // Saves the current position in the input string to the Nth save slot.
+    /// Saves the current position in the input string to the Nth save slot.
     Save(uint),
 
-    // Jumps to the instruction at the index given.
+    /// Jumps to the instruction at the index given.
     Jump(InstIdx),
 
-    // Jumps to the instruction at the first index given. If that leads to
-    // a panic state, then the instruction at the second index given is
-    // tried.
+    /// Jumps to the instruction at the first index given. If that leads to
+    /// a panic state, then the instruction at the second index given is
+    /// tried.
     Split(InstIdx, InstIdx),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,19 +400,16 @@ pub mod native {
     //
     // On the bright side, `rustdoc` lets us hide this from the public API
     // documentation.
-    pub use compile::{
-        Program,
-        OneChar, CharClass, Any, Save, Jump, Split,
-        Match, EmptyBegin, EmptyEnd, EmptyWordBoundary,
-    };
+    pub use compile::Program;
+    pub use compile::Inst::{Match, OneChar, CharClass, Any, EmptyBegin, EmptyEnd,
+                            EmptyWordBoundary, Save, Jump, Split};
     pub use parse::{
         FLAG_EMPTY, FLAG_NOCASE, FLAG_MULTI, FLAG_DOTNL,
         FLAG_SWAP_GREED, FLAG_NEGATED,
     };
-    pub use re::{Dynamic, ExDynamic, Native, ExNative};
-    pub use vm::{
-        MatchKind, Exists, Location, Submatches,
-        StepState, StepMatchEarlyReturn, StepMatch, StepContinue,
-        CharReader, find_prefix,
-    };
+    pub use re::{ExDynamic, ExNative};
+    pub use re::Regex::{Dynamic, Native};
+    pub use vm::{CharReader, find_prefix};
+    pub use vm::MatchKind::{mod, Exists, Location, Submatches};
+    pub use vm::StepState::{mod, StepMatchEarlyReturn, StepMatch, StepContinue};
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub use self::Ast::*;
-pub use self::Repeater::*;
-pub use self::Greed::*;
+use self::Ast::*;
+use self::Repeater::*;
+use self::Greed::*;
 use self::BuildAst::*;
 
 use std::char;

--- a/src/re.rs
+++ b/src/re.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub use self::NamesIter::*;
-pub use self::Regex::*;
+use self::NamesIter::*;
+use self::Regex::*;
 
 use std::collections::HashMap;
 use std::fmt;
@@ -18,7 +18,8 @@ use std::str::CowString;
 use compile::Program;
 use parse;
 use vm;
-use vm::{CaptureLocs, MatchKind, Exists, Location, Submatches};
+use vm::CaptureLocs;
+use vm::MatchKind::{mod, Exists, Location, Submatches};
 
 /// Escapes all regular expression meta characters in `text`.
 ///

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -33,17 +33,15 @@
 //
 // [1] - http://swtch.com/~rsc/regex/regex3.html
 
-pub use self::MatchKind::*;
-pub use self::StepState::*;
+use self::MatchKind::*;
+use self::StepState::*;
 
 use std::cmp;
 use std::mem;
 use std::slice::SliceExt;
-use compile::{
-    Program,
-    Match, OneChar, CharClass, Any, EmptyBegin, EmptyEnd, EmptyWordBoundary,
-    Save, Jump, Split,
-};
+use compile::Program;
+use compile::Inst::{Match, OneChar, CharClass, Any, EmptyBegin, EmptyEnd, EmptyWordBoundary,
+                    Save, Jump, Split};
 use parse::{FLAG_NOCASE, FLAG_MULTI, FLAG_DOTNL, FLAG_NEGATED};
 use unicode::regex::PERLW;
 


### PR DESCRIPTION
They're leftovers from the enum namespacing transition

Other than removing public reexports, I also had to publicize a type
(compile::InstIdx). It should have always been public but no
error was ever given because of this bug:

https://github.com/rust-lang/rust/issues/6477

I also had to enable documentation for compile::Ist because it was
complaining that there wasn't any.
