### PR TITLE
Keep version in README in sync with latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-regex = "0.1.0"
+regex = "0.1.7"
 ```
 
 and this to your crate root:


### PR DESCRIPTION
The current version in the Cargo.toml and on crates.io is 0.1.7, so the README should have the same version... right?