### PR TITLE
Resolve #17 optimize use of '^' / '\A'

### DIFF
--- a/regex_macros/src/lib.rs
+++ b/regex_macros/src/lib.rs
@@ -191,6 +191,11 @@ fn exec<'t>(which: ::regex::native::MatchKind, input: &'t str,
                     if matched {
                         break
                     }
+
+                    if $prefix_anchor && self.ic != 0 {
+                        break
+                    }
+
                     $check_prefix
                 }
                 if clist.size == 0 || (!$prefix_anchor && !matched) {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -144,12 +144,18 @@ impl<'r, 't> Nfa<'r, 't> {
                     break
                 }
 
+                // If the expression starts with a '^' we can terminate as soon
+                // as the last thread dies.
+                if self.ic != 0 && prefix_anchor {
+                    break;
+                }
+                
                 // If there are no threads to try, then we'll have to start
                 // over at the beginning of the regex.
                 // BUT, if there's a literal prefix for the program, try to
                 // jump ahead quickly. If it can't be found, then we can bail
                 // out early.
-                if self.prog.prefix.len() > 0 && clist.size == 0 {
+                if self.prog.prefix.len() > 0 {
                     let needle = self.prog.prefix.as_bytes();
                     let haystack = &self.input.as_bytes()[self.ic..];
                     match find_prefix(needle, haystack) {


### PR DESCRIPTION
The problem was that a regular expression like `^x` would take linear time to is_match a string `aaa....` when all it needed to do was check the first character then bail out. This PR makes it so if the regex begins with `^` (without multiline) or `\A`, then it stops iterating over characters as soon as there are no possible matches.

Benchmarks:

```
dynamic:
anchored_literal_long_non_match: 7492 ns/iter => 435 ns/iter
anchored_literal_short_non_match: 917 ns/iter => 431 ns/iter

native:
anchored_literal_long_non_match: 5020 ns/iter => 50 ns/iter
anchored_literal_short_non_match: 375 ns/iter => 50 ns/iter
```