### PR TITLE
Fix Noncharacter_Code_Point_table

### DIFF
--- a/scripts/unicode.py
+++ b/scripts/unicode.py
@@ -176,8 +176,8 @@ def format_table_content(f, content, indent):
 def load_properties(f, interestingprops):
     fetch(f)
     props = {}
-    re1 = re.compile("^([0-9A-F]+) +; (\w+)")
-    re2 = re.compile("^([0-9A-F]+)\.\.([0-9A-F]+) +; (\w+)")
+    re1 = re.compile("^ *([0-9A-F]+) *; *(\w+)")
+    re2 = re.compile("^ *([0-9A-F]+)\.\.([0-9A-F]+) *; *(\w+)")
 
     for line in fileinput.input(f):
         prop = None
@@ -324,7 +324,7 @@ def optimize_width_table(wtable):
     return wtable_out
 
 if __name__ == "__main__":
-    r = "tables.rs"
+    r = "unicode.rs"
     if os.path.exists(r):
         os.remove(r)
     with open(r, "w") as rf:

--- a/src/unicode.rs
+++ b/src/unicode.rs
@@ -4923,7 +4923,8 @@ pub mod property {
         '\u{6ffff}'), ('\u{7fffe}', '\u{7ffff}'), ('\u{8fffe}', '\u{8ffff}'),
         ('\u{9fffe}', '\u{9ffff}'), ('\u{afffe}', '\u{affff}'), ('\u{bfffe}',
         '\u{bffff}'), ('\u{cfffe}', '\u{cffff}'), ('\u{dfffe}', '\u{dffff}'),
-        ('\u{efffe}', '\u{effff}'), ('\u{ffffe}', '\u{fffff}')
+        ('\u{efffe}', '\u{effff}'), ('\u{ffffe}', '\u{fffff}'), ('\u{10fffe}',
+        '\u{10ffff}')
     ];
 
     pub const White_Space_table: &'static [(char, char)] = &[


### PR DESCRIPTION
rust-lang/rust#22690 describes a bug in `unicode.py`, where U+10FFFE and U+10FFFF are not put in `Noncharacter_Code_Point_table`. The bug is present in the version of the script recently copied to `regex`. This commit fixes the bug by parsing Unicode data files in accordance with [UAX #44](http://www.unicode.org/reports/tr44/#Data_Fields).