### PR TITLE
Move str::Pattern impl behind a feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 script:
   - cargo build --verbose
   - cargo test --verbose
+  - cargo test --verbose --features pattern
   - cargo doc
   - cargo bench --verbose
   - cargo test --verbose --manifest-path=regex_macros/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ bench = true
 
 [dev-dependencies]
 rand = "0.1"
+
+[features]
+pattern = []

--- a/regex_macros/Cargo.toml
+++ b/regex_macros/Cargo.toml
@@ -30,6 +30,7 @@ bench = true
 [dependencies.regex]
 path = ".."
 version = "0.1.0"
+features = ["pattern"]
 
 [dev-dependencies]
 rand = "0.1"

--- a/regex_macros/tests/test_dynamic.rs
+++ b/regex_macros/tests/test_dynamic.rs
@@ -25,4 +25,9 @@ macro_rules! regex(
     );
 );
 
+#[cfg(feature = "pattern")]
+macro_rules! searcher_expr { ($e:expr) => ($e) }
+#[cfg(not(feature = "pattern"))]
+macro_rules! searcher_expr { ($e:expr) => ({}) }
+
 mod tests;

--- a/regex_macros/tests/test_native.rs
+++ b/regex_macros/tests/test_native.rs
@@ -14,5 +14,7 @@
 extern crate regex;
 extern crate test;
 
+macro_rules! searcher_expr { ($e:expr) => ($e) }
+
 mod tests;
 mod native_static;

--- a/regex_macros/tests/tests.rs
+++ b/regex_macros/tests/tests.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::str::{Pattern, Searcher};
-use std::str::SearchStep::{Match, Reject, Done};
 use regex::{Regex, NoExpand};
 
 #[test]
@@ -119,17 +117,22 @@ macro_rules! searcher {
     );
     ($name:ident, $re:expr, $haystack:expr, vec $expect_steps:expr) => (
         #[test]
+        #[allow(unused_imports)]
         fn $name() {
-            let re = regex!($re);
-            let mut se = re.into_searcher($haystack);
-            let mut got_steps = vec![];
-            loop {
-                match se.next() {
-                    Done => break,
-                    step => { got_steps.push(step); }
+            searcher_expr! {{
+                use std::str::{Pattern, Searcher};
+                use std::str::SearchStep::{Match, Reject, Done};
+                let re = regex!($re);
+                let mut se = re.into_searcher($haystack);
+                let mut got_steps = vec![];
+                loop {
+                    match se.next() {
+                        Done => break,
+                        step => { got_steps.push(step); }
+                    }
                 }
-            }
-            assert_eq!(got_steps, $expect_steps);
+                assert_eq!(got_steps, $expect_steps);
+            }}
         }
     );
 }

--- a/src/re.rs
+++ b/src/re.rs
@@ -12,6 +12,7 @@ use std::borrow::{IntoCow, Cow};
 use std::collections::HashMap;
 use std::collections::hash_map::Iter;
 use std::fmt;
+#[cfg(feature = "pattern")]
 use std::str::{Pattern, Searcher, SearchStep};
 
 use compile::Program;
@@ -82,6 +83,9 @@ pub fn is_match(regex: &str, text: &str) -> Result<bool, parse::Error> {
 ///
 /// # Using the `std::str::StrExt` methods with `Regex`
 ///
+/// > **Note**: This section requires that this crate is currently compiled with
+/// >           the `pattern` Cargo feature enabled.
+///
 /// Since `Regex` implements `Pattern`, you can use regexes with methods
 /// defined on `std::str::StrExt`. For example, `is_match`, `find`, `find_iter`
 /// and `split` can be replaced with `StrExt::contains`, `StrExt::find`,
@@ -89,7 +93,7 @@ pub fn is_match(regex: &str, text: &str) -> Result<bool, parse::Error> {
 ///
 /// Here are some examples:
 ///
-/// ```rust
+/// ```rust,ignore
 /// # use regex::Regex;
 /// let re = Regex::new(r"\d+").unwrap();
 /// let haystack = "a111b222c";
@@ -950,12 +954,14 @@ impl<'r, 't> Iterator for FindMatches<'r, 't> {
     }
 }
 
+#[cfg(feature = "pattern")]
 pub struct RegexSearcher<'r, 't> {
     it: FindMatches<'r, 't>,
     last_step_end: usize,
     next_match: Option<(usize, usize)>,
 }
 
+#[cfg(feature = "pattern")]
 impl<'r, 't> Pattern<'t> for &'r Regex {
     type Searcher = RegexSearcher<'r, 't>;
 
@@ -968,6 +974,7 @@ impl<'r, 't> Pattern<'t> for &'r Regex {
     }
 }
 
+#[cfg(feature = "pattern")]
 unsafe impl<'r, 't> Searcher<'t> for RegexSearcher<'r, 't> {
     #[inline]
     fn haystack(&self) -> &'t str {


### PR DESCRIPTION
It's not clear whether this API of the standard library will be stable at 1.0 so
in the meantime this implementation can be put behind a Cargo feature so users
of the crate are not required to use nightly Rust by default. The feature will
still be available to users of nightly Rust, however.