### PR TITLE
Implement Eq for Regex

### DIFF
--- a/regex_macros/tests/tests.rs
+++ b/regex_macros/tests/tests.rs
@@ -11,6 +11,11 @@
 use regex::{Regex, NoExpand};
 
 #[test]
+fn eq() {
+    assert_eq!(regex!(r"[a-z]+"), Regex::new("[a-z]+").unwrap());
+}
+
+#[test]
 fn splitn() {
     let re = regex!(r"\d+");
     let text = "cauchy123plato456tyler789binx";

--- a/src/re.rs
+++ b/src/re.rs
@@ -160,7 +160,7 @@ impl fmt::Debug for Regex {
 }
 
 /// Equality comparison is based on the original string. It is possible that different regular
-/// expressions have the same matching behaviour, but are still compared inequal.  For example,
+/// expressions have the same matching behavior, but are still compared unequal.  For example,
 /// `\d+` and `\d\d*` match the same set of strings, but are not considered equal.
 impl PartialEq for Regex {
     fn eq(&self, other: &Regex) -> bool {

--- a/src/re.rs
+++ b/src/re.rs
@@ -159,6 +159,9 @@ impl fmt::Debug for Regex {
     }
 }
 
+/// Equality comparison is based on the original string. It is possible that different regular
+/// expressions have the same matching behaviour, but are still compared inequal.  For example,
+/// `\d+` and `\d\d*` match the same set of strings, but are not considered equal.
 impl PartialEq for Regex {
     fn eq(&self, other: &Regex) -> bool {
         self.as_str() == other.as_str()

--- a/src/re.rs
+++ b/src/re.rs
@@ -159,6 +159,14 @@ impl fmt::Debug for Regex {
     }
 }
 
+impl PartialEq for Regex {
+    fn eq(&self, other: &Regex) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for Regex {}
+
 impl FromStr for Regex {
     type Err = parse::Error;
 


### PR DESCRIPTION
Note that this is just a comparison of the original strings, it's still possible that two different strings result in the same matching behaviour.