### PR TITLE
Fix $$ -> $ when there are no expansions.

### DIFF
--- a/src/re.rs
+++ b/src/re.rs
@@ -599,7 +599,10 @@ impl Regex {
         if rep.no_expand().is_some() {
             // borrow checker pains. `rep` is borrowed mutably in the `else`
             // branch below.
-            let rep = rep.no_expand().unwrap();
+
+            // A replacement for a literal $ will be on this branch if that is
+            // the only replacement, so replace the $$ with a $.
+            let rep = rep.no_expand().unwrap().replace("$$", "$");
             for (i, (s, e)) in self.find_iter(text).enumerate() {
                 if limit > 0 && i >= limit {
                     break


### PR DESCRIPTION
The docs mention that `$$` will produce a single `$` in the output however if there are no expansions in the replace string you still get `$$` in the output. Some test cases:

```
let re = Regex::new("world").unwrap();
println!("{}", re.replace_all("Hello world!", "$10"));  // Hello !
println!("{}", re.replace_all("Hello world!", "$$10"));  // Hello $$10!
println!("{}", re.replace_all("Hello world!", "\\$10"));  // Hello \!
let re = Regex::new(r"(!)").unwrap();
// This case does not change with this patch because of the expansions
println!("{}", re.replace_all("Hello world!", "$1 $$expand $1"));  // Hello world! $expand !
```

This patch should fix the second println without effecting the others.