### PR TITLE
Avoid repeated memchr in SingleSearch

### DIFF
--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -203,10 +203,6 @@ impl SingleSearch {
                 return Some(i);
             }
             i += self.shift[b as usize];
-            i += match memchr(pat[0], &haystack[i..]) {
-                None => return None,
-                Some(i) => i,
-            };
         }
         None
     }


### PR DESCRIPTION
Avoid repeated memchr in SingleSearch

Repeated memchr in BMH slows down the literal search dramatically in
certain corner cases.