### PR TITLE
Revert "Avoid repeated memchr in SingleSearch"

### DIFF
--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -203,6 +203,10 @@ impl SingleSearch {
                 return Some(i);
             }
             i += self.shift[b as usize];
+            i += match memchr(pat[0], &haystack[i..]) {
+                None => return None,
+                Some(i) => i,
+            };
         }
         None
     }


### PR DESCRIPTION
Revert "Avoid repeated memchr in SingleSearch"

This reverts commit 77a72f9f1bbaf19ef707b4e51a6a9d9670b3a4cf,
PR #105.

I went and looked some super simple ascii string searches (for my own code)
and they all degraded with PR #105, now that I evaluated it for regex too.
(While the original issue remains, that repeated memchr is 10x worse for certain
periodic patterns).

So this is not good, the "natural language" cases were all made worse, while the
silly pathologies were improved.

To be careful, I'd like to revert the change.