### PR TITLE
Changed quote to escape

### DIFF
--- a/regex-syntax/src/lib.rs
+++ b/regex-syntax/src/lib.rs
@@ -1619,7 +1619,7 @@ fn binary_search<T, F>(xs: &[T], mut pred: F) -> usize
 ///
 /// The string returned may be safely used as a literal in a regular
 /// expression.
-pub fn quote(text: &str) -> String {
+pub fn escape(text: &str) -> String {
     let mut quoted = String::with_capacity(text.len());
     for c in text.chars() {
         if parser::is_punct(c) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,7 +469,7 @@ pub use re_unicode::{
     Regex, Captures, SubCaptures, SubCapturesPos, SubCapturesNamed,
     CaptureNames, FindCaptures, FindMatches,
     Replacer, NoExpand, RegexSplits, RegexSplitsN,
-    quote, is_match,
+    escape, is_match,
 };
 
 /**

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -27,8 +27,8 @@ use re_trait::{self, RegularExpression, Slot};
 ///
 /// The string returned may be safely used as a literal in a regular
 /// expression.
-pub fn quote(text: &str) -> String {
-    syntax::quote(text)
+pub fn escape(text: &str) -> String {
+    syntax::escape(text)
 }
 
 /// Tests if the given regular expression matches somewhere in the text given.


### PR DESCRIPTION
Escape is a much more familiar name to this type of operation.

The function will now also only allocate a `String` when there are actual meta characters to escape, rather than allocating on every call.