### PR TITLE
Fix replace_all when only match is at start and replacement is empty.

### DIFF
--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -493,7 +493,7 @@ impl Regex {
                 new.extend_from_slice(&rep);
                 last_match = m.end();
             }
-            if new.is_empty() {
+            if last_match == 0 {
                 return Cow::Borrowed(text);
             }
             new.extend_from_slice(&text[last_match..]);

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -569,7 +569,7 @@ impl Regex {
                 new.push_str(&rep);
                 last_match = m.end();
             }
-            if new.is_empty() {
+            if last_match == 0 {
                 return Cow::Borrowed(text);
             }
             new.push_str(&text[last_match..]);

--- a/tests/replace.rs
+++ b/tests/replace.rs
@@ -33,3 +33,6 @@ replace!(no_expand1, replace,
          r"(\S+)\s+(\S+)", "w1 w2", no_expand!("$2 $1"), "$2 $1");
 replace!(no_expand2, replace,
          r"(\S+)\s+(\S+)", "w1 w2", no_expand!("$$1"), "$$1");
+
+// See https://github.com/rust-lang/regex/issues/314
+replace!(match_at_start_replace_with_empty, replace_all, r"foo", "foobar", t!(""), "bar");


### PR DESCRIPTION
Fixes #314.

All old tests and the new test I added pass, and I also confirmed manually that the test case reported in #314 passes with this change. Let me know if you can think of any case that my change doesn't handle!