### PR TITLE
Reduce cargo test parallelism.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ script:
   - cargo build --verbose
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
       cargo build --verbose --manifest-path=regex-debug/Cargo.toml;
-      RUSTFLAGS="-C target-feature=+ssse3" cargo test --verbose --features 'simd-accel pattern';
+      RUSTFLAGS="-C target-feature=+ssse3" cargo test --verbose --features 'simd-accel pattern' --jobs 2;
     else
-      travis_wait cargo test --verbose;
+      travis_wait cargo test --verbose --jobs 2;
     fi
   - ./run-shootout-test
   - cargo doc --verbose


### PR DESCRIPTION
It looks like `cargo test` is getting SIGKILL'ed on travis and I'm not
sure why. One possibility is that it's running out of memory. Try to fix
this by reducing the number of jobs `cargo test` does in parallel.