### PR TITLE
Bump dep versions and release 0.2.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+0.2.1
+=====
+One major bug with `replace_all` has been fixed along with a couple of other
+touchups.
+
+* [BUG #312](https://github.com/rust-lang/regex/issues/312):
+  Fix documentation for `NoExpand` to reference correct lifetime parameter.
+* [BUG #314](https://github.com/rust-lang/regex/issues/314):
+  Fix a bug with `replace_all` when replacing a match with the empty string.
+* [BUG #316](https://github.com/rust-lang/regex/issues/316):
+  Note a missing breaking change from the `0.2.0` CHANGELOG entry.
+  (`RegexBuilder::compile` was renamed to `RegexBuilder::build`.)
+* [BUG #324](https://github.com/rust-lang/regex/issues/324):
+  Compiling `regex` should only require one version of `memchr` crate.
+
 0.2.0
 =====
 This is a new major release of the regex crate, and is an implementation of the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regex"
-version = "0.2.0"  #:version
+version = "0.2.1"  #:version
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -14,17 +14,17 @@ finite automata and guarantees linear time matching on all inputs.
 
 [dependencies]
 # For very fast prefix literal matching.
-aho-corasick = "0.5.3"
+aho-corasick = "0.6.0"
 # For skipping along search text quickly when a leading byte is known.
-memchr = "1"
+memchr = "1.0.0"
 # For managing regex caches quickly across multiple threads.
 thread_local = "0.3.2"
 # For parsing regular expressions.
 regex-syntax = { path = "regex-syntax", version = "0.4.0" }
 # For accelerating text search.
-simd = { version = "0.1.0", optional = true }
+simd = { version = "0.1.1", optional = true }
 # For compiling UTF-8 decoding into automata.
-utf8-ranges = "1"
+utf8-ranges = "1.0.0"
 
 [dev-dependencies]
 # For examples.

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -24,7 +24,7 @@ cargo doc --verbose --manifest-path regex-syntax/Cargo.toml
 # Run tests on regex-capi crate.
 cargo build --verbose --manifest-path regex-capi/Cargo.toml
 (cd regex-capi/ctest && ./compile && LD_LIBRARY_PATH=../target/debug ./test)
-(cd regex-capi/examples && ./compile && LD_LIBRARY_PATH=../target/release ./iter)
+(cd regex-capi/examples && ./compile && LD_LIBRARY_PATH=../target/debug ./iter)
 
 # Make sure benchmarks compile. Don't run them though because they take a
 # very long time.

--- a/regex-capi/examples/compile
+++ b/regex-capi/examples/compile
@@ -2,7 +2,8 @@
 
 set -ex
 
-cargo build --release --manifest-path ../Cargo.toml
-gcc -O3 -DDEBUG -o iter iter.c -ansi -Wall -I../include -L../target/release -lrure
+# N.B. Add `--release` flag to `cargo build` to make the example run faster.
+cargo build --manifest-path ../Cargo.toml
+gcc -O3 -DDEBUG -o iter iter.c -ansi -Wall -I../include -L../target/debug -lrure
 # If you're using librure.a, then you'll need to link other stuff:
 # -lutil -ldl -lpthread -lgcc_s -lc -lm -lrt -lutil -lrure


### PR DESCRIPTION
Specifically, we bump the dep on aho-corasick to 0.6.0, which includes a
dep on memchr 1.0.0. This avoids compiling two distinct versions of
memchr into every regex build.