### PR TITLE
docs: Fix unescaped `[` in character class

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,7 +430,7 @@ These classes are based on the definitions provided in
 [[:graph:]]    graphical ([!-~])
 [[:lower:]]    lower case ([a-z])
 [[:print:]]    printable ([ -~])
-[[:punct:]]    punctuation ([!-/:-@[-`{-~])
+[[:punct:]]    punctuation ([!-/:-@\[-`{-~])
 [[:space:]]    whitespace ([\t\n\v\f\r ])
 [[:upper:]]    upper case ([A-Z])
 [[:word:]]     word characters ([0-9A-Za-z_])


### PR DESCRIPTION
Compiling the regex as it was documented before results in:

> Syntax("Error parsing regex near \'-/:-@[-`{-\' at character offset 7: Use of unescaped \'[\' in character class is not allowed.")