### PR TITLE
Fix example in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ fn main() {
 ").unwrap();
     let caps = re.captures("2010-03-14").unwrap();
 
-    assert_eq!("2010", caps["year"]);
-    assert_eq!("03", caps["month"]);
-    assert_eq!("14", caps["day"]);
+    assert_eq!("2010", &caps["year"]);
+    assert_eq!("03", &caps["month"]);
+    assert_eq!("14", &caps["day"]);
 }
 ```
 


### PR DESCRIPTION
see https://github.com/rust-lang/regex/issues/359

I choose to write:

```rust
assert_eq!("2010".to_string(), caps["year"]);
```

But I could have choose:

```rust
assert_eq!("2010", &caps["year"]);
```

Not sure which one is the best (maybe none of them)