### PR TITLE
Fix Bug in `rure_captures_len`

### DIFF
--- a/regex-capi/ctest/test.c
+++ b/regex-capi/ctest/test.c
@@ -102,6 +102,19 @@ bool test_captures() {
         }
         passed = false;
     }
+    size_t expect_captures_len = 3;
+    size_t captures_len = rure_captures_len(caps);
+    if (captures_len != expect_captures_len) {
+        if (DEBUG) {
+            fprintf(stderr,
+                    "[test_captures] "
+                    "expected capture group lenght to be %zd, but "
+                    "got %zd\n",
+                    expect_captures_len, captures_len);
+        }
+        passed = false;
+        goto done;
+    }
     int32_t expect_capture_index = 2;
     int32_t capture_index = rure_capture_name_index(re, "snowman");
     if (capture_index != expect_capture_index) {

--- a/regex-capi/src/rure.rs
+++ b/regex-capi/src/rure.rs
@@ -434,7 +434,7 @@ ffi_fn! {
 
 ffi_fn! {
     fn rure_captures_len(captures: *const Captures) -> size_t {
-        unsafe { (*captures).0.len() / 2 }
+        unsafe { (*captures).0.len() }
     }
 }
 


### PR DESCRIPTION
It looks like at some point in the past the captures were refactored
from being a vector of start and end positions into a list of location
structures. The C API still had a conversion of the lenght which
corrected for the captures being twice the length of the number of
captures.

This updates the length calculation in `rure.rs` to return the
correct length, and adds an assertion to the test case.