### PR TITLE
compiler: fix a byte class bug

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1033,11 +1033,16 @@ impl ByteClassSet {
         // (0usize..256).map(|x| x as u8).collect()
         let mut byte_classes = vec![0; 256];
         let mut class = 0u8;
-        for i in 0..256 {
-            byte_classes[i] = class;
+        let mut i = 0;
+        loop {
+            byte_classes[i] = class as u8;
+            if i >= 255 {
+                break;
+            }
             if self.0[i] {
                 class = class.checked_add(1).unwrap();
             }
+            i += 1;
         }
         byte_classes
     }
@@ -1083,5 +1088,14 @@ mod tests {
         assert_eq!(classes[6], 2);
         assert_eq!(classes[7], 3);
         assert_eq!(classes[255], 3);
+    }
+
+    #[test]
+    fn full_byte_classes() {
+        let mut set = ByteClassSet::new();
+        for i in 0..256u16 {
+            set.set_range(i as u8, i as u8);
+        }
+        assert_eq!(set.byte_classes().len(), 256);
     }
 }


### PR DESCRIPTION
The code that computes the byte classes had a bug that was only tripped
when the maximum number of equivalence classes was necessary (256). This
commit fixes that by rewriting the loop such that we never uselessly
increment outside the bounds of `u8`.

Fixes #367