### PR TITLE
Remove stray newline from fmt::Display for MissingBase10.

### DIFF
--- a/regex-syntax/src/lib.rs
+++ b/regex-syntax/src/lib.rs
@@ -1585,8 +1585,7 @@ impl fmt::Display for ErrorKind {
                 write!(f, "Number does not correspond to a Unicode scalar \
                            value: '{}'.", c),
             MissingBase10 =>
-                write!(f, "Missing maximum in counted
-repetition operator."),
+                write!(f, "Missing maximum in counted repetition operator."),
             RepeaterExpectsExpr =>
                 write!(f, "Missing expression for repetition operator."),
             RepeaterUnexpectedExpr(ref e) =>


### PR DESCRIPTION
Introduced in 45ad9237.