### PR TITLE
Fix `Regex::replacen` when replacing an empty match.

### DIFF
--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -494,18 +494,19 @@ impl Regex {
         mut rep: R,
     ) -> Cow<'t, [u8]> {
         if let Some(rep) = rep.no_expansion() {
+            let mut it = self.find_iter(text).enumerate().peekable();
+            if it.peek().is_none() {
+                return Cow::Borrowed(text);
+            }
             let mut new = Vec::with_capacity(text.len());
             let mut last_match = 0;
-            for (i, m) in self.find_iter(text).enumerate() {
+            for (i, m) in it {
                 if limit > 0 && i >= limit {
                     break
                 }
                 new.extend_from_slice(&text[last_match..m.start()]);
                 new.extend_from_slice(&rep);
                 last_match = m.end();
-            }
-            if last_match == 0 {
-                return Cow::Borrowed(text);
             }
             new.extend_from_slice(&text[last_match..]);
             return Cow::Owned(new);

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -583,18 +583,19 @@ impl Regex {
         //      replacements inside the replacement string. We just push it
         //      at each match and be done with it.
         if let Some(rep) = rep.no_expansion() {
+            let mut it = self.find_iter(text).enumerate().peekable();
+            if it.peek().is_none() {
+                return Cow::Borrowed(text);
+            }
             let mut new = String::with_capacity(text.len());
             let mut last_match = 0;
-            for (i, m) in self.find_iter(text).enumerate() {
+            for (i, m) in it {
                 if limit > 0 && i >= limit {
                     break
                 }
                 new.push_str(&text[last_match..m.start()]);
                 new.push_str(&rep);
                 last_match = m.end();
-            }
-            if last_match == 0 {
-                return Cow::Borrowed(text);
             }
             new.push_str(&text[last_match..]);
             return Cow::Owned(new);

--- a/tests/replace.rs
+++ b/tests/replace.rs
@@ -36,3 +36,6 @@ replace!(no_expand2, replace,
 
 // See https://github.com/rust-lang/regex/issues/314
 replace!(match_at_start_replace_with_empty, replace_all, r"foo", "foobar", t!(""), "bar");
+
+// See https://github.com/rust-lang/regex/issues/393
+replace!(single_empty_match, replace, r"^", "bar", t!("foo"), "foobar");


### PR DESCRIPTION
Fixes #393, #394.

There was some logic error when deciding to return `Cow::Borrowed` vs `Cow::Owned` in the fast-path. I took the same solution as the slow-path, ie use `peekable` on the iterator. I'm not sure this is the most efficient way (maybe just add `mut did_replace = false` and set it to true in the loop), but it does the job.