### PR TITLE
Remove sub-expressions from parsing error

### DIFF
--- a/regex-syntax/src/lib.rs
+++ b/regex-syntax/src/lib.rs
@@ -1589,8 +1589,7 @@ impl fmt::Display for ErrorKind {
             RepeaterExpectsExpr =>
                 write!(f, "Missing expression for repetition operator."),
             RepeaterUnexpectedExpr(ref e) =>
-                write!(f, "Invalid application of repetition operator to: \
-                          '{}'.", e),
+                write!(f, "Invalid application of repetition operator."),
             UnclosedCaptureName(ref s) =>
                 write!(f, "Capture name group for '{}' is not closed. \
                            (Missing a '>'.)", s),

--- a/regex-syntax/src/lib.rs
+++ b/regex-syntax/src/lib.rs
@@ -1574,9 +1574,8 @@ impl fmt::Display for ErrorKind {
                 write!(f, "Invalid character class range '{}-{}'. \
                            Character class ranges must start with the smaller \
                            character, but {} > {}", start, end, start, end),
-            InvalidClassEscape(ref e) =>
-                write!(f, "Invalid escape sequence in character \
-                           class: '{}'.", e),
+            InvalidClassEscape(_) =>
+                write!(f, "Invalid escape sequence in character class."),
             InvalidRepeatRange { min, max } =>
                 write!(f, "Invalid counted repetition range: {{{}, {}}}. \
                            Counted repetition ranges must start with the \

--- a/regex-syntax/src/lib.rs
+++ b/regex-syntax/src/lib.rs
@@ -1588,7 +1588,7 @@ impl fmt::Display for ErrorKind {
                 write!(f, "Missing maximum in counted repetition operator."),
             RepeaterExpectsExpr =>
                 write!(f, "Missing expression for repetition operator."),
-            RepeaterUnexpectedExpr(ref e) =>
+            RepeaterUnexpectedExpr(_) =>
                 write!(f, "Invalid application of repetition operator."),
             UnclosedCaptureName(ref s) =>
                 write!(f, "Capture name group for '{}' is not closed. \


### PR DESCRIPTION
This PR skips printing sub-expressions in the error message.

This should avoid situations where the error message contains an AST with unreadable characters, as shown [here](https://github.com/BurntSushi/ripgrep/issues/395).

<img width="1030" alt="unreadable-chars" src="https://user-images.githubusercontent.com/12599697/29924193-02147d0c-8e11-11e7-8b36-a97b63f802b4.png">
