### PR TITLE
[doc] Fix get() function name

### DIFF
--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -250,7 +250,7 @@ impl Regex {
     /// with a `usize`.
     ///
     /// The `0`th capture group is always unnamed, so it must always be
-    /// accessed with `at(0)` or `[0]`.
+    /// accessed with `get(0)` or `[0]`.
     pub fn captures<'t>(&self, text: &'t [u8]) -> Option<Captures<'t>> {
         let mut locs = self.locations();
         self.read_captures_at(&mut locs, text, 0).map(|_| Captures {

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -331,7 +331,7 @@ impl Regex {
     /// with a `usize`.
     ///
     /// The `0`th capture group is always unnamed, so it must always be
-    /// accessed with `at(0)` or `[0]`.
+    /// accessed with `get(0)` or `[0]`.
     pub fn captures<'t>(&self, text: &'t str) -> Option<Captures<'t>> {
         let mut locs = self.locations();
         self.read_captures_at(&mut locs, text, 0).map(|_| Captures {


### PR DESCRIPTION
It feels like it's a left-over after some codemod, since there's no `at()` method on this type.