### PR TITLE
Issue 348

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -270,9 +270,9 @@ N.B. To run tests for the `regex!` macro, use:
 
 The benchmarking in this crate is made up of many micro-benchmarks. Currently,
 there are two primary sets of benchmarks: the benchmarks that were adopted
-at this library's inception (in `benches/src/misc.rs`) and a newer set of
+at this library's inception (in `bench/src/misc.rs`) and a newer set of
 benchmarks meant to test various optimizations. Specifically, the latter set
-contain some analysis and are in `benches/src/sherlock.rs`. Also, the latter
+contain some analysis and are in `bench/src/sherlock.rs`. Also, the latter
 set are all executed on the same lengthy input whereas the former benchmarks
 are executed on strings of varying length.
 
@@ -299,17 +299,17 @@ library benchmarks (especially RE2).
 If you're hacking on one of the matching engines and just want to see
 benchmarks, then all you need to run is:
 
-    $ ./run-bench rust
+    $ ./bench/run rust
 
 If you want to compare your results with older benchmarks, then try:
 
-    $ ./run-bench rust | tee old
+    $ ./bench/run rust | tee old
     $ ... make it faster
-    $ ./run-bench rust | tee new
-    $ cargo-benchcmp old new --improvements
+    $ ./bench/run rust | tee new
+    $ cargo benchcmp old new --improvements
 
 The `cargo-benchcmp` utility is available here:
 https://github.com/BurntSushi/cargo-benchcmp
 
-The `run-bench` utility can run benchmarks for PCRE and Oniguruma too. See
-`./run-bench --help`.
+The `./bench/run` utility can run benchmarks for PCRE and Oniguruma too. See
+`./bench/bench --help`.

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -40,8 +40,7 @@ bench = false
 # Doing anything else will probably result in weird "duplicate definition"
 # compiler errors.
 #
-# Tip: use the run-bench script in the root of this repository to run
-# benchmarks.
+# Tip: use the `bench/run` script (in this directory) to run benchmarks.
 [features]
 re-pcre1 = ["libpcre-sys"]
 re-pcre2 = []

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -236,6 +236,41 @@ macro_rules! bench_find {
     }
 }
 
+// USAGE: bench_captures!(name, pattern, groups, haystack);
+//
+// CONTRACT:
+//   Given:
+//     ident, the desired benchmarking function name
+//     pattern : ::Regex, the regular expression to be executed
+//     groups : usize, the number of capture groups
+//     haystack : String, the string to search
+//   bench_captures will benchmark how fast re.captures() produces
+//   the capture groups in question.
+macro_rules! bench_captures {
+    ($name:ident, $pattern:expr, $count:expr, $haystack:expr) => {
+
+        #[cfg(feature = "re-rust")]
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            use std::sync::Mutex;
+
+            lazy_static! {
+                static ref RE: Mutex<Regex> = Mutex::new($pattern);
+                static ref TEXT: Mutex<Text> = Mutex::new(text!($haystack));
+            };
+            let re = RE.lock().unwrap();
+            let text = TEXT.lock().unwrap();
+            b.bytes = text.len() as u64;
+            b.iter(|| {
+                match re.captures(&text) {
+                    None => assert!(false, "no captures"),
+                    Some(caps) => assert_eq!($count + 1, caps.len()),
+                }
+            });
+        }
+    }
+}
+
 mod ffi;
 mod misc;
 mod regexdna;

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -554,12 +554,16 @@ impl<'c> RegularExpression for ExecNoSync<'c> {
                 })
             }
             MatchType::Dfa => {
-                match self.find_dfa_forward(text, start) {
-                    dfa::Result::Match((s, e)) => {
-                        self.captures_nfa_with_match(slots, text, s, e)
+                if self.ro.nfa.is_anchored_start {
+                    self.captures_nfa(slots, text, start)
+                } else {
+                    match self.find_dfa_forward(text, start) {
+                        dfa::Result::Match((s, e)) => {
+                            self.captures_nfa_with_match(slots, text, s, e)
+                        }
+                        dfa::Result::NoMatch(_) => None,
+                        dfa::Result::Quit => self.captures_nfa(slots, text, start),
                     }
-                    dfa::Result::NoMatch(_) => None,
-                    dfa::Result::Quit => self.captures_nfa(slots, text, start),
                 }
             }
             MatchType::DfaAnchoredReverse => {


### PR DESCRIPTION
I took a crack at implimenting #348, but ended up running into some squirrly results with the benchmark that I wrote. During some runs the optimization behaved as expected, but for most there was no real corrilation between input size and performance. I suspect I'm missing some benchmarking trick, so an insight would be appreciated. The steps I used to test the benchmark are outlined in a comment above the new benchmarks I added (in `bench/src/misc.rs`).

For now I've just done the anchor optimization.

As I was learning about the code base I also noticed a few documentation references that had drifted out of date, so I fixed those.