### PR TITLE
clarify license wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,11 @@ examples](https://doc.rust-lang.org/regex/regex_syntax/index.html).
 
 # License
 
-`regex` is primarily distributed under the terms of both the MIT license and
-the Apache License (Version 2.0), with portions covered by various BSD-like
-licenses.
+This project is licensed under either of
 
-See LICENSE-APACHE, and LICENSE-MIT for details.
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+   http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+   http://opensource.org/licenses/MIT)
+
+at your option.


### PR DESCRIPTION
This text historically was copied verbatim from rust-lang/rust's own
README [1] with the intention of licensing projects the same as rustc's
own license, namely a dual MIT/Apache-2.0 license. The clause about
"various BSD-like licenses" isn't actually correct for almost all
projects other than rust-lang/rust and the wording around "both" was
slightly ambiguous.

This commit updates the wording to match more precisely what's in the
standard library [2], namely clarifying that there aren't any BSD-like
licenses in this repository and that the source is licensable under
either license, at your own discretion.[3]

Fixes #411

[1]: https://github.com/rust-lang/rust/tree/f0fe716dbcbf2363ab8f929325d32a17e51039d0#license
[2]: https://github.com/rust-lang/rust/blob/f0fe716dbcbf2363ab8f929325d32a17e51039d0/src/libstd/lib.rs#L5-L9
[3]: https://github.com/alexcrichton/flate2-rs/commit/baf66689e22055bb896656f34c45cbab8dfb244b