### PR TITLE
Tiny PR: update a the ByteInput comment

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -223,10 +223,6 @@ impl<'t> Input for CharInput<'t> {
 }
 
 /// An input reader over bytes.
-///
-/// N.B. We represent the reader with a string for now, since that gives us
-/// easy access to necessary Unicode decoding (used for word boundary look
-/// ahead/look behind).
 #[derive(Clone, Copy, Debug)]
 pub struct ByteInput<'t> {
     text: &'t [u8],


### PR DESCRIPTION
At some ByteInput switched to being backed by actual bytes
rather than a string. This commit just removes the dangling
reference to the old representation.

I just noticed this while reading through code, so I thought I would send the patch your way.