### PR TITLE
gcc::Config -> gcc::Build

### DIFF
--- a/bench/build.rs
+++ b/bench/build.rs
@@ -41,7 +41,7 @@ fn main() {
             we!("re2 cannot be found by pkg-config");
             process::exit(1);
         }
-        gcc::Config::new()
+        gcc::Build::new()
             .cpp(true)
             .flag("-std=c++11")
             .file("src/ffi/re2.cpp")


### PR DESCRIPTION
gcc::Config has been depreciated since gcc 0.3.51.
The change was introduced by commit
dc7162fe40e6b31811e8879c9860fd9eafe6aa46 in the gcc
crate. This patch just changes the bench build script
to use the new name.