### PR TITLE
Fix docs referring to a wrong variable

### DIFF
--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -828,8 +828,8 @@ impl<'t> Captures<'t> {
         }
     }
 
-    /// Expands all instances of `$name` in `text` to the corresponding capture
-    /// group `name`, and writes them to the `dst` buffer given.
+    /// Expands all instances of `$name` in `replacement` to the corresponding
+    /// capture group `name`, and writes them to the `dst` buffer given.
     ///
     /// `name` may be an integer corresponding to the index of the
     /// capture group (counted by order of opening parenthesis where `0` is the

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -979,8 +979,8 @@ impl<'t> Captures<'t> {
         }
     }
 
-    /// Expands all instances of `$name` in `text` to the corresponding capture
-    /// group `name`, and writes them to the `dst` buffer given.
+    /// Expands all instances of `$name` in `replacement` to the corresponding
+    /// capture group `name`, and writes them to the `dst` buffer given.
     ///
     /// `name` may be an integer corresponding to the index of the
     /// capture group (counted by order of opening parenthesis where `0` is the


### PR DESCRIPTION
The [variable name was changed](https://github.com/rust-lang/regex/commit/ebd26e9bbed4407c5e460772d9e79cb43dac25e2#diff-e76c21ee73748c8e0f6c9a32c9467a30L965) but the documentation wasn't, making it confusing.