### PR TITLE
Updating link to raw string literal documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ it to match anywhere in the text. Anchors can be used to ensure that the
 full text matches an expression.
 
 This example also demonstrates the utility of
-[raw strings](https://doc.rust-lang.org/stable/reference.html#raw-string-literals)
+[raw strings](https://doc.rust-lang.org/stable/reference/tokens.html#raw-string-literals)
 in Rust, which
 are just like regular strings except they are prefixed with an `r` and do
 not process any escape sequences. For example, `"\\d"` is the same


### PR DESCRIPTION
The current link to the raw string literal documentation goes to a page that contains the following.

![image](https://user-images.githubusercontent.com/933552/34325082-242d0398-e83c-11e7-8c89-d6dd0b665cb7.png)

This PR updates it to the currently-working URL.