### PR TITLE
literal: fix bug in TBM

### DIFF
--- a/src/literals.rs
+++ b/src/literals.rs
@@ -599,7 +599,9 @@ impl BoyerMooreSearch {
     /// in `haystack`.
     #[inline]
     fn find(&self, haystack: &[u8]) -> Option<usize> {
-        debug_assert!(haystack.len() >= self.pattern.len());
+        if haystack.len() < self.pattern.len() {
+            return None;
+        }
 
         let mut window_end = self.pattern.len() - 1;
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -90,3 +90,10 @@ ismatch!(strange_anchor_non_complete_suffix, r"${2}a", "", false);
 // See: https://github.com/rust-lang/regex/issues/334
 mat!(captures_after_dfa_premature_end, r"a(b*(X|$))?", "abcbX",
      Some((0, 1)), None, None);
+
+// See: https://github.com/rust-lang/regex/issues/437
+ismatch!(
+    literal_panic,
+    r"typename type\-parameter\-\d+\-\d+::.+",
+    "test",
+    false);


### PR DESCRIPTION
The TBM implementation tripped an assertion in debug mode if its
haystack was smaller than its query. This is incorrect. The correct
behavior is for TBM to report that no match can be found.

Fixes #437