### PR TITLE
Avoid depending on expression Debug stringifier in release builds

### DIFF
--- a/regex-syntax/src/parser.rs
+++ b/regex-syntax/src/parser.rs
@@ -1227,7 +1227,7 @@ impl Parser {
                             return Err(self.errat(
                                 chari, ErrorKind::UnclosedParen));
                         }
-                        e => unreachable!("{:?}", e),
+                        _ => unreachable!(),
                     }
                 }
                 Some(Build::Expr(e)) => { concat.push(e); }


### PR DESCRIPTION
The code weighs over a kilobyte, which doesn't seem worth it for an unreachable.