### PR TITLE
Closes #446

### DIFF
--- a/src/literals.rs
+++ b/src/literals.rs
@@ -627,7 +627,9 @@ impl BoyerMooreSearch {
                 if self.check_match(haystack, window_end) {
                     return Some(window_end - (self.pattern.len() - 1));
                 } else {
-                    window_end += self.md2_shift;
+                    let skip = self.skip_table[haystack[window_end] as usize];
+                    window_end +=
+                        if skip == 0 { self.md2_shift } else { skip };
                     continue;
                 }
             }
@@ -946,7 +948,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn bm_backstop_boundary() {
         let haystack = b"\
 // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
Thanks @BurntSushi for doing all the legwork on cutting down the failing test case and laying out a clear set of execution steps. It really helped me zero in on the bug.

This patch fixes an issue where skip resolution would go strait
to the default value (the md2_shift) on a match failure after
the shift_loop. Now we do the right thing, and first check in
the skip table. The problem with going strait to the md2_shift
is that you can accidentally shift to far when `window_end`
actually is in the pattern (as is the case for the failing
match).

In the issue thread I promised better modularity, but it turns
out that shift resolution was a bit too decomposed in the other
places I had mentioned. Sorry :(.