### PR TITLE
Resync TBM should_use comment

### DIFF
--- a/src/literals.rs
+++ b/src/literals.rs
@@ -680,9 +680,7 @@ impl BoyerMooreSearch {
     /// A third case is if the pattern is sufficiently long. The idea
     /// here is that once the pattern gets long enough the Tuned
     /// Boyer-Moore skip loop will start making strides long enough
-    /// to beat the asm deep magic that is memchr. Unfortunately,
-    /// I had trouble proving a useful turnover point. Hopefully,
-    /// we can find one in the future.
+    /// to beat the asm deep magic that is memchr.
     fn should_use(pattern: &[u8]) -> bool {
         // The minimum pattern length required to use TBM.
         const MIN_LEN: usize = 9;


### PR DESCRIPTION
The TBM `should_use` comment drifted slightly
out of sync with the code when a better usage huristic
was added. I've shaved the yak.

Very low priority PR, but I couldn't resist.