### PR TITLE
goodbye simd crate, hello std::arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bench-log
 wiki
 tags
 examples/debug.rs
+tmp/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,6 @@ memchr = "2.0.0"
 thread_local = "0.3.2"
 # For parsing regular expressions.
 regex-syntax = { path = "regex-syntax", version = "0.5.1" }
-# For accelerating text search.
-simd = { version = "0.2.1", optional = true }
 # For compiling UTF-8 decoding into automata.
 utf8-ranges = "1.0.0"
 
@@ -45,10 +43,20 @@ quickcheck = { version = "0.6", default-features = false }
 rand = "0.4"
 
 [features]
-# Enable to use the unstable pattern traits defined in std.
+# We don't enable any features by default currently, but if the compiler
+# supports a specific type of feature, then regex's build.rs might enable
+# some default features.
+default = []
+# A blanket feature that governs whether unstable features are enabled or not.
+# Unstable features are disabled by default, and typically rely on unstable
+# features in rustc itself.
+unstable = ["pattern"]
+# Enable to use the unstable pattern traits defined in std. This is enabled
+# by default if the unstable feature is enabled.
 pattern = []
 # Enable to use simd acceleration.
-simd-accel = ["simd"]
+# Note that this is deprecated and is a no-op.
+simd-accel = []
 
 [lib]
 # There are no benchmarks in the library code itself

--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ assert!(!matches.matched(5));
 assert!(matches.matched(6));
 ```
 
+### Usage: enable SIMD optimizations
+
+This crate provides an `unstable` feature that can only be enabled on nightly
+Rust. When this feature is enabled, the regex crate will use SIMD optimizations
+if your CPU supports them. No additional compile time flags are required; the
+regex crate will detect your CPU support at runtime.
+
+When `std::arch` becomes stable, then these optimizations will be enabled
+automatically.
+
 
 ### Usage: a regular expression parser
 

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -18,7 +18,7 @@ libc = "0.2"
 onig = { version = "3", optional = true }
 libpcre-sys = { version = "0.2", optional = true }
 memmap = "0.6"
-regex = { version = "0.2.0", path = "..", features = ["simd-accel"] }
+regex = { version = "0.2.0", path = "..", features = ["unstable"] }
 regex-syntax = { version = "0.5.0", path = "../regex-syntax" }
 serde = "1"
 serde_derive = "1"

--- a/bench/compile
+++ b/bench/compile
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# Enable SIMD.
-export RUSTFLAGS="-C target-cpu=native"
-
 exec cargo build \
   --release \
   --features 're-re2 re-onig re-pcre1 re-pcre2 re-rust re-rust-bytes re-tcl re-dphobos-dmd re-dphobos-ldc' \

--- a/bench/run
+++ b/bench/run
@@ -9,11 +9,6 @@ if [ $# = 0 ] || [ $1 = '-h' ] || [ $1 = '--help' ]; then
   usage
 fi
 
-# Enable SIMD, unless we're in CI, then we inherit RUSTLFAGS.
-if [ -z "$TRAVIS_RUST_VERSION" ]; then
-  export RUSTFLAGS="-C target-cpu=native"
-fi
-
 which="$1"
 shift
 case $which in

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,26 @@
+use std::env;
+use std::ffi::OsString;
+use std::process::Command;
+
+fn main() {
+    let rustc = env::var_os("RUSTC").unwrap_or(OsString::from("rustc"));
+    let output = Command::new(&rustc)
+        .arg("--version")
+        .output()
+        .unwrap()
+        .stdout;
+    let version = String::from_utf8(output).unwrap();
+
+    // If we're using nightly Rust, then we can enable vector optimizations.
+    // Note that these aren't actually activated unless the `nightly` feature
+    // is enabled.
+    //
+    // We also don't activate these if we've explicitly disabled auto
+    // optimizations. Disabling auto optimizations is intended for use in
+    // tests, so that we can reliably test fallback implementations.
+    if env::var_os("CARGO_CFG_REGEX_DISABLE_AUTO_OPTIMIZATIONS").is_none() {
+        if version.contains("nightly") {
+            println!("cargo:rustc-cfg=regex_runtime_teddy_ssse3");
+        }
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,7 @@ fn main() {
     if env::var_os("CARGO_CFG_REGEX_DISABLE_AUTO_OPTIMIZATIONS").is_none() {
         if version.contains("nightly") {
             println!("cargo:rustc-cfg=regex_runtime_teddy_ssse3");
+            println!("cargo:rustc-cfg=regex_runtime_teddy_avx2");
         }
     }
 }

--- a/ci/after_success.sh
+++ b/ci/after_success.sh
@@ -9,7 +9,6 @@ if [ "$TRAVIS_RUST_VERSION" != "nightly" ] || [ "$TRAVIS_PULL_REQUEST" != "false
   exit 0
 fi
 
-export RUSTFLAGS="-C target-feature=+ssse3"
 env
 
 # Install kcov.

--- a/ci/run-kcov
+++ b/ci/run-kcov
@@ -28,7 +28,7 @@ while true; do
   esac
 done
 
-cargo test --no-run --verbose --jobs 4
+cargo test --no-run --verbose --jobs 4 --features unstable
 for t in ${tests[@]}; do
   kcov \
     --verify \

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,12 +4,6 @@
 
 set -ex
 
-if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-  # We set this once so that all invocations share this setting. This should
-  # help with build times by avoiding excessive re-compiles.
-  export RUSTFLAGS="-C target-feature=+ssse3"
-fi
-
 # Builds the regex crate and runs tests.
 cargo build --verbose
 cargo doc --verbose
@@ -25,7 +19,7 @@ fi
 
 # Run tests. If we have nightly, then enable our nightly features.
 if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-  cargo test --verbose --features 'simd-accel pattern'
+  cargo test --verbose --features unstable
 else
   cargo test --verbose
 fi

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -23,7 +23,7 @@ use compile::Compiler;
 use dfa;
 use error::Error;
 use input::{ByteInput, CharInput};
-use literals::LiteralSearcher;
+use literal::LiteralSearcher;
 use pikevm;
 use prog::Program;
 use re_builder::RegexOptions;

--- a/src/input.rs
+++ b/src/input.rs
@@ -16,7 +16,7 @@ use std::u32;
 
 use syntax;
 
-use literals::LiteralSearcher;
+use literal::LiteralSearcher;
 use prog::InstEmptyLook;
 use utf8::{decode_utf8, decode_last_utf8};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,14 +520,15 @@ another matching engine with fixed memory requirements.
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(feature = "pattern", feature(pattern))]
-#![cfg_attr(feature = "simd-accel", feature(cfg_target_feature))]
+#![cfg_attr(feature = "unstable", feature(target_feature, stdsimd))]
 
 extern crate aho_corasick;
 extern crate memchr;
 extern crate thread_local;
-#[macro_use] #[cfg(test)] extern crate quickcheck;
+#[cfg(test)]
+#[macro_use]
+extern crate quickcheck;
 extern crate regex_syntax as syntax;
-#[cfg(feature = "simd-accel")] extern crate simd;
 extern crate utf8_ranges;
 
 pub use error::Error;
@@ -645,7 +646,7 @@ mod exec;
 mod expand;
 mod freqs;
 mod input;
-mod literals;
+mod literal;
 #[cfg(feature = "pattern")]
 mod pattern;
 mod pikevm;
@@ -655,12 +656,9 @@ mod re_bytes;
 mod re_set;
 mod re_trait;
 mod re_unicode;
-#[cfg(feature = "simd-accel")]
-mod simd_accel;
-#[cfg(not(feature = "simd-accel"))]
-#[path = "simd_fallback/mod.rs"]
-mod simd_accel;
 mod sparse;
+#[cfg(feature = "unstable")]
+mod vector;
 
 /// The `internal` module exists to support suspicious activity, such as
 /// testing different matching engines and supporting the `regex-debug` CLI
@@ -670,6 +668,6 @@ pub mod internal {
     pub use compile::Compiler;
     pub use exec::{Exec, ExecBuilder};
     pub use input::{Char, Input, CharInput, InputAt};
-    pub use literals::LiteralSearcher;
+    pub use literal::LiteralSearcher;
     pub use prog::{Program, Inst, EmptyLook, InstRanges};
 }

--- a/src/literal/mod.rs
+++ b/src/literal/mod.rs
@@ -16,8 +16,9 @@ use memchr::{memchr, memchr2, memchr3};
 use syntax::hir::literal::{Literal, Literals};
 
 use freqs::BYTE_FREQUENCIES;
+use self::teddy_ssse3::Teddy;
 
-use simd_accel::teddy128::{Teddy, is_teddy_128_available};
+mod teddy_ssse3;
 
 /// A prefix extracted from a compiled regular expression.
 ///
@@ -219,7 +220,7 @@ impl Matcher {
             }
         }
         let is_aho_corasick_fast = sset.dense.len() == 1 && sset.all_ascii;
-        if is_teddy_128_available() && !is_aho_corasick_fast {
+        if Teddy::available() && !is_aho_corasick_fast {
             // Only try Teddy if Aho-Corasick can't use memchr on an ASCII
             // byte. Also, in its current form, Teddy doesn't scale well to
             // lots of literals.

--- a/src/literal/teddy_avx2/fallback.rs
+++ b/src/literal/teddy_avx2/fallback.rs
@@ -1,0 +1,20 @@
+use syntax::hir::literal::Literals;
+
+#[derive(Debug, Clone)]
+pub struct Teddy(());
+
+#[derive(Debug, Clone)]
+pub struct Match {
+    pub pat: usize,
+    pub start: usize,
+    pub end: usize,
+}
+
+impl Teddy {
+    pub fn available() -> bool { false }
+    pub fn new(_pats: &Literals) -> Option<Teddy> { None }
+    pub fn patterns(&self) -> &[Vec<u8>] { &[] }
+    pub fn len(&self) -> usize { 0 }
+    pub fn approximate_size(&self) -> usize { 0 }
+    pub fn find(&self, _haystack: &[u8]) -> Option<Match> { None }
+}

--- a/src/literal/teddy_avx2/imp.rs
+++ b/src/literal/teddy_avx2/imp.rs
@@ -1,0 +1,467 @@
+/*!
+This is the Teddy searcher, but ported to AVX2.
+
+See the module comments in the SSSE3 Teddy searcher for a more in depth
+explanation of how this algorithm works. For the most part, this port is
+basically the same as the SSSE3 version, but using 256-bit vectors instead of
+128-bit vectors, which increases throughput.
+*/
+
+use std::cmp;
+
+use aho_corasick::{Automaton, AcAutomaton, FullAcAutomaton};
+use syntax::hir::literal::Literals;
+
+use vector::avx2::{AVX2VectorBuilder, u8x32};
+
+/// Corresponds to the number of bytes read at a time in the haystack.
+const BLOCK_SIZE: usize = 32;
+
+/// Match reports match information.
+#[derive(Debug, Clone)]
+pub struct Match {
+    /// The index of the pattern that matched. The index is in correspondence
+    /// with the order of the patterns given at construction.
+    pub pat: usize,
+    /// The start byte offset of the match.
+    pub start: usize,
+    /// The end byte offset of the match. This is always `start + pat.len()`.
+    pub end: usize,
+}
+
+/// A SIMD accelerated multi substring searcher.
+#[derive(Debug, Clone)]
+pub struct Teddy {
+    /// A builder for AVX2 empowered vectors.
+    vb: AVX2VectorBuilder,
+    /// A list of substrings to match.
+    pats: Vec<Vec<u8>>,
+    /// An Aho-Corasick automaton of the patterns. We use this when we need to
+    /// search pieces smaller than the Teddy block size.
+    ac: FullAcAutomaton<Vec<u8>>,
+    /// A set of 8 buckets. Each bucket corresponds to a single member of a
+    /// bitset. A bucket contains zero or more substrings. This is useful
+    /// when the number of substrings exceeds 8, since our bitsets cannot have
+    /// more than 8 members.
+    buckets: Vec<Vec<usize>>,
+    /// Our set of masks. There's one mask for each byte in the fingerprint.
+    masks: Masks,
+}
+
+impl Teddy {
+    /// Returns true if and only if Teddy is supported on this platform.
+    ///
+    /// If this returns `false`, then `Teddy::new(...)` is guaranteed to
+    /// return `None`.
+    pub fn available() -> bool {
+        AVX2VectorBuilder::new().is_some()
+    }
+
+    /// Create a new `Teddy` multi substring matcher.
+    ///
+    /// If a `Teddy` matcher could not be created (e.g., `pats` is empty or has
+    /// an empty substring), then `None` is returned.
+    pub fn new(pats: &Literals) -> Option<Teddy> {
+        let vb = match AVX2VectorBuilder::new() {
+            None => return None,
+            Some(vb) => vb,
+        };
+        if !Teddy::available() {
+            return None;
+        }
+
+        let pats: Vec<_> = pats.literals().iter().map(|p|p.to_vec()).collect();
+        let min_len = pats.iter().map(|p| p.len()).min().unwrap_or(0);
+        // Don't allow any empty patterns and require that we have at
+        // least one pattern.
+        if min_len < 1 {
+            return None;
+        }
+        // Pick the largest mask possible, but no larger than 3.
+        let nmasks = cmp::min(3, min_len);
+        let mut masks = Masks::new(vb, nmasks);
+        let mut buckets = vec![vec![]; 8];
+        // Assign a substring to each bucket, and add the bucket's bitfield to
+        // the appropriate position in the mask.
+        for (pati, pat) in pats.iter().enumerate() {
+            let bucket = pati % 8;
+            buckets[bucket].push(pati);
+            masks.add(bucket as u8, pat);
+        }
+        Some(Teddy {
+            vb: vb,
+            pats: pats.to_vec(),
+            ac: AcAutomaton::new(pats.to_vec()).into_full(),
+            buckets: buckets,
+            masks: masks,
+        })
+    }
+
+    /// Returns all of the substrings matched by this `Teddy`.
+    pub fn patterns(&self) -> &[Vec<u8>] {
+        &self.pats
+    }
+
+    /// Returns the number of substrings in this matcher.
+    pub fn len(&self) -> usize {
+        self.pats.len()
+    }
+
+    /// Returns the approximate size on the heap used by this matcher.
+    pub fn approximate_size(&self) -> usize {
+        self.pats.iter().fold(0, |a, b| a + b.len())
+    }
+
+    /// Searches `haystack` for the substrings in this `Teddy`. If a match was
+    /// found, then it is returned. Otherwise, `None` is returned.
+    pub fn find(&self, haystack: &[u8]) -> Option<Match> {
+        // This is safe because the only way we can construct a Teddy type
+        // is if AVX2 is available.
+        unsafe { self.find_impl(haystack) }
+    }
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn find_impl(&self, haystack: &[u8]) -> Option<Match> {
+        // If our haystack is smaller than the block size, then fall back to
+        // a naive brute force search.
+        if haystack.is_empty() || haystack.len() < (BLOCK_SIZE + 2) {
+            return self.slow(haystack, 0);
+        }
+        match self.masks.len() {
+            0 => None,
+            1 => self.find1(haystack),
+            2 => self.find2(haystack),
+            3 => self.find3(haystack),
+            _ => unreachable!(),
+        }
+    }
+
+    /// `find1` is used when there is only 1 mask. This is the easy case and is
+    /// pretty much as described in the module documentation.
+    #[inline(always)]
+    fn find1(&self, haystack: &[u8]) -> Option<Match> {
+        let mut pos = 0;
+        let zero = self.vb.u8x32_splat(0);
+        let len = haystack.len();
+        debug_assert!(len >= BLOCK_SIZE);
+        while pos <= len - BLOCK_SIZE {
+            let h = unsafe {
+                // I tried and failed to eliminate bounds checks in safe code.
+                // This is safe because of our loop invariant: pos is always
+                // <= len-32.
+                let p = haystack.get_unchecked(pos..);
+                self.vb.u8x32_load_unchecked_unaligned(p)
+            };
+            // N.B. `res0` is our `C` in the module documentation.
+            let res0 = self.masks.members1(h);
+            // Only do expensive verification if there are any non-zero bits.
+            let bitfield = res0.ne(zero).movemask();
+            if bitfield != 0 {
+                if let Some(m) = self.verify(haystack, pos, res0, bitfield) {
+                    return Some(m);
+                }
+            }
+            pos += BLOCK_SIZE;
+        }
+        self.slow(haystack, pos)
+    }
+
+    /// `find2` is used when there are 2 masks, e.g., the fingerprint is 2 bytes
+    /// long.
+    #[inline(always)]
+    fn find2(&self, haystack: &[u8]) -> Option<Match> {
+        // This is an exotic way to right shift a SIMD vector across lanes.
+        // See below at use for more details.
+        let zero = self.vb.u8x32_splat(0);
+        let len = haystack.len();
+        // The previous value of `C` (from the module documentation) for the
+        // *first* byte in the fingerprint. On subsequent iterations, we take
+        // the last bitset from the previous `C` and insert it into the first
+        // position of the current `C`, shifting all other bitsets to the right
+        // one lane. This causes `C` for the first byte to line up with `C` for
+        // the second byte, so that they can be `AND`'d together.
+        let mut prev0 = self.vb.u8x32_splat(0xFF);
+        let mut pos = 1;
+        debug_assert!(len >= BLOCK_SIZE);
+        while pos <= len - BLOCK_SIZE {
+            let h = unsafe {
+                // I tried and failed to eliminate bounds checks in safe code.
+                // This is safe because of our loop invariant: pos is always
+                // <= len-32.
+                let p = haystack.get_unchecked(pos..);
+                self.vb.u8x32_load_unchecked_unaligned(p)
+            };
+            let (res0, res1) = self.masks.members2(h);
+
+            // Do this:
+            //
+            //     (prev0 << 15) | (res0 >> 1)
+            //
+            // This lets us line up our C values for each byte.
+            let res0prev0 = res0.alignr_15(prev0);
+
+            // `AND`'s our `C` values together.
+            let res = res0prev0.and(res1);
+            prev0 = res0;
+
+            let bitfield = res.ne(zero).movemask();
+            if bitfield != 0 {
+                let pos = pos.checked_sub(1).unwrap();
+                if let Some(m) = self.verify(haystack, pos, res, bitfield) {
+                    return Some(m);
+                }
+            }
+            pos += BLOCK_SIZE;
+        }
+        // The windowing above doesn't check the last byte in the last
+        // window, so start the slow search at the last byte of the last
+        // window.
+        self.slow(haystack, pos.checked_sub(1).unwrap())
+    }
+
+    /// `find3` is used when there are 3 masks, e.g., the fingerprint is 3 bytes
+    /// long.
+    ///
+    /// N.B. This is a straight-forward extrapolation of `find2`. The only
+    /// difference is that we need to keep track of two previous values of `C`,
+    /// since we now need to align for three bytes.
+    #[inline(always)]
+    fn find3(&self, haystack: &[u8]) -> Option<Match> {
+        let zero = self.vb.u8x32_splat(0);
+        let len = haystack.len();
+        let mut prev0 = self.vb.u8x32_splat(0xFF);
+        let mut prev1 = self.vb.u8x32_splat(0xFF);
+        let mut pos = 2;
+
+        while pos <= len - BLOCK_SIZE {
+            let h = unsafe {
+                // I tried and failed to eliminate bounds checks in safe code.
+                // This is safe because of our loop invariant: pos is always
+                // <= len-32.
+                let p = haystack.get_unchecked(pos..);
+                self.vb.u8x32_load_unchecked_unaligned(p)
+            };
+            let (res0, res1, res2) = self.masks.members3(h);
+
+            let res0prev0 = res0.alignr_14(prev0);
+            let res1prev1 = res1.alignr_15(prev1);
+            let res = res0prev0.and(res1prev1).and(res2);
+
+            prev0 = res0;
+            prev1 = res1;
+
+            let bitfield = res.ne(zero).movemask();
+            if bitfield != 0 {
+                let pos = pos.checked_sub(2).unwrap();
+                if let Some(m) = self.verify(haystack, pos, res, bitfield) {
+                    return Some(m);
+                }
+            }
+            pos += BLOCK_SIZE;
+        }
+        // The windowing above doesn't check the last two bytes in the last
+        // window, so start the slow search at the penultimate byte of the
+        // last window.
+        // self.slow(haystack, pos.saturating_sub(2))
+        self.slow(haystack, pos.checked_sub(2).unwrap())
+    }
+
+    /// Runs the verification procedure on `res` (i.e., `C` from the module
+    /// documentation), where the haystack block starts at `pos` in
+    /// `haystack`. `bitfield` has ones in the bit positions that `res` has
+    /// non-zero bytes.
+    ///
+    /// If a match exists, it returns the first one.
+    #[inline(always)]
+    fn verify(
+        &self,
+        haystack: &[u8],
+        pos: usize,
+        res: u8x32,
+        mut bitfield: u32,
+    ) -> Option<Match> {
+        while bitfield != 0 {
+            // The next offset, relative to pos, where some fingerprint
+            // matched.
+            let byte_pos = bitfield.trailing_zeros() as usize;
+            bitfield &= !(1 << byte_pos);
+
+            // Offset relative to the beginning of the haystack.
+            let start = pos + byte_pos;
+
+            // The bitfield telling us which patterns had fingerprints that
+            // match at this starting position.
+            let mut patterns = res.extract(byte_pos);
+            while patterns != 0 {
+                let bucket = patterns.trailing_zeros() as usize;
+                patterns &= !(1 << bucket);
+
+                // Actual substring search verification.
+                if let Some(m) = self.verify_bucket(haystack, bucket, start) {
+                    return Some(m);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Verifies whether any substring in the given bucket matches in haystack
+    /// at the given starting position.
+    #[inline(always)]
+    fn verify_bucket(
+        &self,
+        haystack: &[u8],
+        bucket: usize,
+        start: usize,
+    ) -> Option<Match> {
+        // This cycles through the patterns in the bucket in the order that
+        // the patterns were given. Therefore, we guarantee leftmost-first
+        // semantics.
+        for &pati in &self.buckets[bucket] {
+            let pat = &*self.pats[pati];
+            if start + pat.len() > haystack.len() {
+                continue;
+            }
+            if pat == &haystack[start..start + pat.len()] {
+                return Some(Match {
+                    pat: pati,
+                    start: start,
+                    end: start + pat.len(),
+                });
+            }
+        }
+        None
+    }
+
+    /// Slow substring search through all patterns in this matcher.
+    ///
+    /// This is used when we don't have enough bytes in the haystack for our
+    /// block based approach.
+    #[inline(never)]
+    fn slow(&self, haystack: &[u8], pos: usize) -> Option<Match> {
+        self.ac.find(&haystack[pos..]).next().map(|m| {
+            Match {
+                pat: m.pati,
+                start: pos + m.start,
+                end: pos + m.end,
+            }
+        })
+    }
+}
+
+/// A list of masks. This has length equal to the length of the fingerprint.
+/// The length of the fingerprint is always `min(3, len(smallest_substring))`.
+#[derive(Debug, Clone)]
+struct Masks {
+    vb: AVX2VectorBuilder,
+    masks: [Mask; 3],
+    size: usize,
+}
+
+impl Masks {
+    /// Create a new set of masks of size `n`, where `n` corresponds to the
+    /// number of bytes in a fingerprint.
+    fn new(vb: AVX2VectorBuilder, n: usize) -> Masks {
+        Masks {
+            vb: vb,
+            masks: [Mask::new(vb), Mask::new(vb), Mask::new(vb)],
+            size: n,
+        }
+    }
+
+    /// Returns the number of masks.
+    fn len(&self) -> usize {
+        self.size
+    }
+
+    /// Adds the given pattern to the given bucket. The bucket should be a
+    /// power of `2 <= 2^7`.
+    fn add(&mut self, bucket: u8, pat: &[u8]) {
+        for i in 0..self.len() {
+            self.masks[i].add(bucket, pat[i]);
+        }
+    }
+
+    /// Finds the fingerprints that are in the given haystack block. i.e., this
+    /// returns `C` as described in the module documentation.
+    ///
+    /// More specifically, `for i in 0..16` and `j in 0..8, C[i][j] == 1` if and
+    /// only if `haystack_block[i]` corresponds to a fingerprint that is part
+    /// of a pattern in bucket `j`.
+    #[inline(always)]
+    fn members1(&self, haystack_block: u8x32) -> u8x32 {
+        let masklo = self.vb.u8x32_splat(0xF);
+        let hlo = haystack_block.and(masklo);
+        let hhi = haystack_block.bit_shift_right_4().and(masklo);
+
+        self.masks[0].lo.shuffle(hlo).and(self.masks[0].hi.shuffle(hhi))
+    }
+
+    /// Like members1, but computes C for the first and second bytes in the
+    /// fingerprint.
+    #[inline(always)]
+    fn members2(&self, haystack_block: u8x32) -> (u8x32, u8x32) {
+        let masklo = self.vb.u8x32_splat(0xF);
+        let hlo = haystack_block.and(masklo);
+        let hhi = haystack_block.bit_shift_right_4().and(masklo);
+
+        let res0 =
+            self.masks[0].lo.shuffle(hlo).and(self.masks[0].hi.shuffle(hhi));
+        let res1 =
+            self.masks[1].lo.shuffle(hlo).and(self.masks[1].hi.shuffle(hhi));
+        (res0, res1)
+    }
+
+    /// Like `members1`, but computes `C` for the first, second and third bytes
+    /// in the fingerprint.
+    #[inline(always)]
+    fn members3(&self, haystack_block: u8x32) -> (u8x32, u8x32, u8x32) {
+        let masklo = self.vb.u8x32_splat(0xF);
+        let hlo = haystack_block.and(masklo);
+        let hhi = haystack_block.bit_shift_right_4().and(masklo);
+
+        let res0 =
+            self.masks[0].lo.shuffle(hlo).and(self.masks[0].hi.shuffle(hhi));
+        let res1 =
+            self.masks[1].lo.shuffle(hlo).and(self.masks[1].hi.shuffle(hhi));
+        let res2 =
+            self.masks[2].lo.shuffle(hlo).and(self.masks[2].hi.shuffle(hhi));
+        (res0, res1, res2)
+    }
+}
+
+/// A single mask.
+#[derive(Debug, Clone, Copy)]
+struct Mask {
+    /// Bitsets for the low nybbles in a fingerprint.
+    lo: u8x32,
+    /// Bitsets for the high nybbles in a fingerprint.
+    hi: u8x32,
+}
+
+impl Mask {
+    /// Create a new mask with no members.
+    fn new(vb: AVX2VectorBuilder) -> Mask {
+        Mask {
+            lo: vb.u8x32_splat(0),
+            hi: vb.u8x32_splat(0),
+        }
+    }
+
+    /// Adds the given byte to the given bucket.
+    fn add(&mut self, bucket: u8, byte: u8) {
+        // Split our byte into two nybbles, and add each nybble to our
+        // mask.
+        let byte_lo = (byte & 0xF) as usize;
+        let byte_hi = (byte >> 4) as usize;
+
+        let lo = self.lo.extract(byte_lo) | ((1 << bucket) as u8);
+        self.lo.replace(byte_lo, lo);
+        self.lo.replace(byte_lo + 16, lo);
+
+        let hi = self.hi.extract(byte_hi) | ((1 << bucket) as u8);
+        self.hi.replace(byte_hi, hi);
+        self.hi.replace(byte_hi + 16, hi);
+    }
+}

--- a/src/literal/teddy_avx2/mod.rs
+++ b/src/literal/teddy_avx2/mod.rs
@@ -1,0 +1,16 @@
+pub use self::imp::*;
+
+#[cfg(all(
+    feature = "unstable",
+    regex_runtime_teddy_avx2,
+    any(target_arch = "x86_64"),
+))]
+mod imp;
+
+#[cfg(not(all(
+    feature = "unstable",
+    regex_runtime_teddy_avx2,
+    any(target_arch = "x86_64"),
+)))]
+#[path = "fallback.rs"]
+mod imp;

--- a/src/literal/teddy_ssse3/fallback.rs
+++ b/src/literal/teddy_ssse3/fallback.rs
@@ -1,9 +1,5 @@
 use syntax::hir::literal::Literals;
 
-pub fn is_teddy_128_available() -> bool {
-    false
-}
-
 #[derive(Debug, Clone)]
 pub struct Teddy(());
 
@@ -15,6 +11,7 @@ pub struct Match {
 }
 
 impl Teddy {
+    pub fn available() -> bool { false }
     pub fn new(_pats: &Literals) -> Option<Teddy> { None }
     pub fn patterns(&self) -> &[Vec<u8>] { &[] }
     pub fn len(&self) -> usize { 0 }

--- a/src/literal/teddy_ssse3/mod.rs
+++ b/src/literal/teddy_ssse3/mod.rs
@@ -1,0 +1,16 @@
+pub use self::imp::*;
+
+#[cfg(all(
+    feature = "unstable",
+    regex_runtime_teddy_ssse3,
+    any(target_arch = "x86", target_arch = "x86_64"),
+))]
+mod imp;
+
+#[cfg(not(all(
+    feature = "unstable",
+    regex_runtime_teddy_ssse3,
+    any(target_arch = "x86", target_arch = "x86_64"),
+)))]
+#[path = "fallback.rs"]
+mod imp;

--- a/src/prog.rs
+++ b/src/prog.rs
@@ -7,7 +7,7 @@ use std::slice;
 use std::sync::Arc;
 
 use input::Char;
-use literals::LiteralSearcher;
+use literal::LiteralSearcher;
 
 /// `InstPtr` represents the index of an instruction in a regex program.
 pub type InstPtr = usize;

--- a/src/simd_accel/mod.rs
+++ b/src/simd_accel/mod.rs
@@ -1,5 +1,0 @@
-#[cfg(target_feature = "ssse3")]
-pub mod teddy128;
-#[cfg(not(target_feature = "ssse3"))]
-#[path = "../simd_fallback/teddy128.rs"]
-pub mod teddy128;

--- a/src/simd_fallback/mod.rs
+++ b/src/simd_fallback/mod.rs
@@ -1,1 +1,0 @@
-pub mod teddy128;

--- a/src/vector/avx2.rs
+++ b/src/vector/avx2.rs
@@ -1,0 +1,195 @@
+#![allow(dead_code)]
+
+use std::arch::x86_64::*;
+use std::fmt;
+
+#[derive(Clone, Copy, Debug)]
+pub struct AVX2VectorBuilder(());
+
+impl AVX2VectorBuilder {
+    pub fn new() -> Option<AVX2VectorBuilder> {
+        if is_target_feature_detected!("avx2") {
+            Some(AVX2VectorBuilder(()))
+        } else {
+            None
+        }
+    }
+
+    /// Create a new u8x32 AVX2 vector where all of the bytes are set to
+    /// the given value.
+    #[inline]
+    pub fn u8x32_splat(self, n: u8) -> u8x32 {
+        // Safe because we know AVX2 is enabled.
+        unsafe { u8x32::splat(n) }
+    }
+
+    /// Load 32 bytes from the given slice, with bounds checks.
+    #[inline]
+    pub fn u8x32_load_unaligned(self, slice: &[u8]) -> u8x32 {
+        // Safe because we know AVX2 is enabled.
+        unsafe { u8x32::load_unaligned(slice) }
+    }
+
+    /// Load 32 bytes from the given slice, without bounds checks.
+    #[inline]
+    pub unsafe fn u8x32_load_unchecked_unaligned(self, slice: &[u8]) -> u8x32 {
+        // Safe because we know AVX2 is enabled, but still unsafe
+        // because we aren't doing bounds checks.
+        u8x32::load_unchecked_unaligned(slice)
+    }
+
+    /// Load 32 bytes from the given slice, with bound and alignment checks.
+    #[inline]
+    pub fn u8x32_load(self, slice: &[u8]) -> u8x32 {
+        // Safe because we know AVX2 is enabled.
+        unsafe { u8x32::load(slice) }
+    }
+
+    /// Load 32 bytes from the given slice, without bound or alignment checks.
+    #[inline]
+    pub unsafe fn u8x32_load_unchecked(self, slice: &[u8]) -> u8x32 {
+        // Safe because we know AVX2 is enabled, but still unsafe
+        // because we aren't doing bounds checks.
+        u8x32::load_unchecked(slice)
+    }
+}
+
+// We define our union with a macro so that our code continues to compile on
+// Rust 1.12.
+macro_rules! defunion {
+    () => {
+        #[derive(Clone, Copy)]
+        #[allow(non_camel_case_types)]
+        pub union u8x32 {
+            vector: __m256i,
+            bytes: [u8; 32],
+        }
+    }
+}
+
+defunion!();
+
+impl u8x32 {
+    #[inline]
+    unsafe fn splat(n: u8) -> u8x32 {
+        u8x32 { vector: _mm256_set1_epi8(n as i8) }
+    }
+
+    #[inline]
+    unsafe fn load_unaligned(slice: &[u8]) -> u8x32 {
+        assert!(slice.len() >= 32);
+        u8x32::load_unchecked_unaligned(slice)
+    }
+
+    #[inline]
+    unsafe fn load_unchecked_unaligned(slice: &[u8]) -> u8x32 {
+        let p = slice.as_ptr() as *const u8 as *const __m256i;
+        u8x32 { vector: _mm256_loadu_si256(p) }
+    }
+
+    #[inline]
+    unsafe fn load(slice: &[u8]) -> u8x32 {
+        assert!(slice.len() >= 32);
+        assert!(slice.as_ptr() as usize % 32 == 0);
+        u8x32::load_unchecked(slice)
+    }
+
+    #[inline]
+    unsafe fn load_unchecked(slice: &[u8]) -> u8x32 {
+        let p = slice.as_ptr() as *const u8 as *const __m256i;
+        u8x32 { vector: _mm256_load_si256(p) }
+    }
+
+    #[inline]
+    pub fn extract(self, i: usize) -> u8 {
+        // Safe because `bytes` is always accessible.
+        unsafe { self.bytes[i] }
+    }
+
+    #[inline]
+    pub fn replace(&mut self, i: usize, byte: u8) {
+        // Safe because `bytes` is always accessible.
+        unsafe { self.bytes[i] = byte; }
+    }
+
+    #[inline]
+    pub fn shuffle(self, indices: u8x32) -> u8x32 {
+        // Safe because we know AVX2 is enabled.
+        unsafe {
+            u8x32 { vector: _mm256_shuffle_epi8(self.vector, indices.vector) }
+        }
+    }
+
+    #[inline]
+    pub fn ne(self, other: u8x32) -> u8x32 {
+        // Safe because we know AVX2 is enabled.
+        unsafe {
+            let boolv = _mm256_cmpeq_epi8(self.vector, other.vector);
+            let ones = _mm256_set1_epi8(0xFF as u8 as i8);
+            u8x32 { vector: _mm256_andnot_si256(boolv, ones) }
+        }
+    }
+
+    #[inline]
+    pub fn and(self, other: u8x32) -> u8x32 {
+        // Safe because we know AVX2 is enabled.
+        unsafe {
+            u8x32 { vector: _mm256_and_si256(self.vector, other.vector) }
+        }
+    }
+
+    #[inline]
+    pub fn movemask(self) -> u32 {
+        // Safe because we know AVX2 is enabled.
+        unsafe {
+            _mm256_movemask_epi8(self.vector) as u32
+        }
+    }
+
+    #[inline]
+    pub fn alignr_14(self, other: u8x32) -> u8x32 {
+        // Safe because we know AVX2 is enabled.
+        unsafe {
+            // Credit goes to jneem for figuring this out:
+            // https://github.com/jneem/teddy/blob/9ab5e899ad6ef6911aecd3cf1033f1abe6e1f66c/src/x86/teddy_simd.rs#L145-L184
+            //
+            // TL;DR avx2's PALIGNR instruction is actually just two 128-bit
+            // PALIGNR instructions, which is not what we want, so we need to
+            // do some extra shuffling.
+            let v = _mm256_permute2x128_si256(other.vector, self.vector, 0x21);
+            let v = _mm256_alignr_epi8(self.vector, v, 14);
+            u8x32 { vector: v }
+        }
+    }
+
+    #[inline]
+    pub fn alignr_15(self, other: u8x32) -> u8x32 {
+        // Safe because we know AVX2 is enabled.
+        unsafe {
+            // Credit goes to jneem for figuring this out:
+            // https://github.com/jneem/teddy/blob/9ab5e899ad6ef6911aecd3cf1033f1abe6e1f66c/src/x86/teddy_simd.rs#L145-L184
+            //
+            // TL;DR avx2's PALIGNR instruction is actually just two 128-bit
+            // PALIGNR instructions, which is not what we want, so we need to
+            // do some extra shuffling.
+            let v = _mm256_permute2x128_si256(other.vector, self.vector, 0x21);
+            let v = _mm256_alignr_epi8(self.vector, v, 15);
+            u8x32 { vector: v }
+        }
+    }
+
+    #[inline]
+    pub fn bit_shift_right_4(self) -> u8x32 {
+        // Safe because we know AVX2 is enabled.
+        unsafe {
+            u8x32 { vector: _mm256_srli_epi16(self.vector, 4) }
+        }
+    }
+}
+
+impl fmt::Debug for u8x32 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Safe because `bytes` is always accessible.
+        unsafe { self.bytes.fmt(f) }
+    }
+}

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub mod ssse3;

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(target_arch = "x86_64")]
+pub mod avx2;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub mod ssse3;

--- a/src/vector/ssse3.rs
+++ b/src/vector/ssse3.rs
@@ -1,0 +1,200 @@
+#![allow(dead_code)]
+
+use std::arch::x86_64::*;
+use std::fmt;
+
+/// A builder for SSSE3 empowered vectors.
+///
+/// This builder represents a receipt that the SSSE3 target feature is enabled
+/// on the currently running CPU. Namely, the only way to get a value of this
+/// type is if the SSSE3 feature is enabled.
+///
+/// This type can then be used to build vector types that use SSSE3 features
+/// safely.
+#[derive(Clone, Copy, Debug)]
+pub struct SSSE3VectorBuilder(());
+
+impl SSSE3VectorBuilder {
+    /// Create a new SSSE3 vector builder.
+    ///
+    /// If the SSSE3 feature is not enabled for the current target, then
+    /// return `None`.
+    pub fn new() -> Option<SSSE3VectorBuilder> {
+        if is_target_feature_detected!("ssse3") {
+            Some(SSSE3VectorBuilder(()))
+        } else {
+            None
+        }
+    }
+
+    /// Create a new u8x16 SSSE3 vector where all of the bytes are set to
+    /// the given value.
+    #[inline]
+    pub fn u8x16_splat(self, n: u8) -> u8x16 {
+        // Safe because we know SSSE3 is enabled.
+        unsafe { u8x16::splat(n) }
+    }
+
+    /// Load 16 bytes from the given slice, with bounds checks.
+    #[inline]
+    pub fn u8x16_load_unaligned(self, slice: &[u8]) -> u8x16 {
+        // Safe because we know SSSE3 is enabled.
+        unsafe { u8x16::load_unaligned(slice) }
+    }
+
+    /// Load 16 bytes from the given slice, without bounds checks.
+    #[inline]
+    pub unsafe fn u8x16_load_unchecked_unaligned(self, slice: &[u8]) -> u8x16 {
+        // Safe because we know SSSE3 is enabled, but still unsafe
+        // because we aren't doing bounds checks.
+        u8x16::load_unchecked_unaligned(slice)
+    }
+
+    /// Load 16 bytes from the given slice, with bound and alignment checks.
+    #[inline]
+    pub fn u8x16_load(self, slice: &[u8]) -> u8x16 {
+        // Safe because we know SSSE3 is enabled.
+        unsafe { u8x16::load(slice) }
+    }
+
+    /// Load 16 bytes from the given slice, without bound or alignment checks.
+    #[inline]
+    pub unsafe fn u8x16_load_unchecked(self, slice: &[u8]) -> u8x16 {
+        // Safe because we know SSSE3 is enabled, but still unsafe
+        // because we aren't doing bounds checks.
+        u8x16::load_unchecked(slice)
+    }
+}
+
+// We define our union with a macro so that our code continues to compile on
+// Rust 1.12.
+macro_rules! defunion {
+    () => {
+        /// A u8x16 is a 128-bit vector with 16 single-byte lanes.
+        ///
+        /// It provides a safe API that uses only SSE2 or SSSE3 instructions.
+        /// The only way for callers to construct a value of this type is
+        /// through the SSSE3VectorBuilder type, and the only way to get a
+        /// SSSE3VectorBuilder is if the `ssse3` target feature is enabled.
+        ///
+        /// Note that generally speaking, all uses of this type should get
+        /// inlined, otherwise you probably have a performance bug.
+        #[derive(Clone, Copy)]
+        #[allow(non_camel_case_types)]
+        pub union u8x16 {
+            vector: __m128i,
+            bytes: [u8; 16],
+        }
+    }
+}
+
+defunion!();
+
+impl u8x16 {
+    #[inline]
+    unsafe fn splat(n: u8) -> u8x16 {
+        u8x16 { vector: _mm_set1_epi8(n as i8) }
+    }
+
+    #[inline]
+    unsafe fn load_unaligned(slice: &[u8]) -> u8x16 {
+        assert!(slice.len() >= 16);
+        u8x16::load_unchecked(slice)
+    }
+
+    #[inline]
+    unsafe fn load_unchecked_unaligned(slice: &[u8]) -> u8x16 {
+        let v = _mm_loadu_si128(slice.as_ptr() as *const u8 as *const __m128i);
+        u8x16 { vector: v }
+    }
+
+    #[inline]
+    unsafe fn load(slice: &[u8]) -> u8x16 {
+        assert!(slice.len() >= 16);
+        assert!(slice.as_ptr() as usize % 16 == 0);
+        u8x16::load_unchecked(slice)
+    }
+
+    #[inline]
+    unsafe fn load_unchecked(slice: &[u8]) -> u8x16 {
+        let v = _mm_load_si128(slice.as_ptr() as *const u8 as *const __m128i);
+        u8x16 { vector: v }
+    }
+
+    #[inline]
+    pub fn extract(self, i: usize) -> u8 {
+        // Safe because `bytes` is always accessible.
+        unsafe { self.bytes[i] }
+    }
+
+    #[inline]
+    pub fn replace(&mut self, i: usize, byte: u8) {
+        // Safe because `bytes` is always accessible.
+        unsafe { self.bytes[i] = byte; }
+    }
+
+    #[inline]
+    pub fn shuffle(self, indices: u8x16) -> u8x16 {
+        // Safe because we know SSSE3 is enabled.
+        unsafe {
+            u8x16 { vector: _mm_shuffle_epi8(self.vector, indices.vector) }
+        }
+    }
+
+    #[inline]
+    pub fn ne(self, other: u8x16) -> u8x16 {
+        // Safe because we know SSSE3 is enabled.
+        unsafe {
+            let boolv = _mm_cmpeq_epi8(self.vector, other.vector);
+            let ones = _mm_set1_epi8(0xFF as u8 as i8);
+            u8x16 { vector: _mm_andnot_si128(boolv, ones) }
+        }
+    }
+
+    #[inline]
+    pub fn and(self, other: u8x16) -> u8x16 {
+        // Safe because we know SSSE3 is enabled.
+        unsafe {
+            u8x16 { vector: _mm_and_si128(self.vector, other.vector) }
+        }
+    }
+
+    #[inline]
+    pub fn movemask(self) -> u32 {
+        // Safe because we know SSSE3 is enabled.
+        unsafe {
+            _mm_movemask_epi8(self.vector) as u32
+        }
+    }
+
+    #[inline]
+    pub fn alignr_14(self, other: u8x16) -> u8x16 {
+        // Safe because we know SSSE3 is enabled.
+        unsafe {
+            u8x16 { vector: _mm_alignr_epi8(self.vector, other.vector, 14) }
+        }
+    }
+
+    #[inline]
+    pub fn alignr_15(self, other: u8x16) -> u8x16 {
+        // Safe because we know SSSE3 is enabled.
+        unsafe {
+            u8x16 { vector: _mm_alignr_epi8(self.vector, other.vector, 15) }
+        }
+    }
+
+    #[inline]
+    pub fn bit_shift_right_4(self) -> u8x16 {
+        // Safe because we know SSSE3 is enabled.
+        unsafe {
+            u8x16 { vector: _mm_srli_epi16(self.vector, 4) }
+        }
+    }
+}
+
+impl fmt::Debug for u8x16 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Safe because `bytes` is always accessible.
+        unsafe { self.bytes.fmt(f) }
+    }
+}


### PR DESCRIPTION
This PR ports the regex's crate use of SIMD to `std::arch`, which in turn drops the dependency on the `simd` crate and any compile time SIMD configuration requirements. As a bonus, we also add an AVX2 variant of what used to be an exclusively SSSE3 algorithm.

We do this by adding a new feature `unstable`, which when enabled, will cause the regex crate to automatically use SSSE3 or AVX2 optimized variants of certain literal algorithms (specifically, the Teddy multi-matcher), depending on which CPU features are available at runtime. Once `std::arch` is stabilized, these optimizations will be enabled automatically.

Performance improvements from no-SIMD to SSSE3 (which roughly match the status quo, when SSSE3 is enabled at compile time):

```
 sherlock::holmes_cochar_watson         193,079 (3081 MB/s)             160,996 (3695 MB/s)               -32,083  -16.62%   x 1.20
 sherlock::name_alt2                    166,895 (3564 MB/s)             126,387 (4707 MB/s)               -40,508  -24.27%   x 1.32
 sherlock::name_alt3                    1,090,127 (545 MB/s)            137,516 (4326 MB/s)              -952,611  -87.39%   x 7.93
 sherlock::name_alt4                    200,849 (2962 MB/s)             164,347 (3619 MB/s)               -36,502  -18.17%   x 1.22
 sherlock::name_alt4_nocase             1,155,389 (514 MB/s)            225,784 (2634 MB/s)              -929,605  -80.46%   x 5.12
 sherlock::name_alt5                    231,145 (2573 MB/s)             131,767 (4515 MB/s)               -99,378  -42.99%   x 1.75
 sherlock::name_alt5_nocase             1,158,401 (513 MB/s)            550,028 (1081 MB/s)              -608,373  -52.52%   x 2.11
 sherlock::name_holmes_nocase           943,570 (630 MB/s)              190,772 (3118 MB/s)              -752,798  -79.78%   x 4.95
 sherlock::name_sherlock_holmes_nocase  1,084,468 (548 MB/s)            170,387 (3491 MB/s)              -914,081  -84.29%   x 6.36
 sherlock::name_sherlock_nocase         1,077,668 (552 MB/s)            163,711 (3634 MB/s)              -913,957  -84.81%   x 6.58
 sherlock::the_nocase                   1,356,722 (438 MB/s)            392,886 (1514 MB/s)              -963,836  -71.04%   x 3.45
```

And then improvements from SSSE3 to AVX2:

```
 sherlock::holmes_cochar_watson         160,996 (3695 MB/s)          104,124 (5713 MB/s)              -56,872  -35.33%   x 1.55
 sherlock::holmes_coword_watson         554,179 (1073 MB/s)          495,262 (1201 MB/s)              -58,917  -10.63%   x 1.12
 sherlock::name_alt2                    126,387 (4707 MB/s)          85,083 (6992 MB/s)               -41,304  -32.68%   x 1.49
 sherlock::name_alt3                    137,516 (4326 MB/s)          94,820 (6274 MB/s)               -42,696  -31.05%   x 1.45
 sherlock::name_alt4                    164,347 (3619 MB/s)          120,466 (4938 MB/s)              -43,881  -26.70%   x 1.36
 sherlock::name_alt4_nocase             225,784 (2634 MB/s)          180,290 (3299 MB/s)              -45,494  -20.15%   x 1.25
 sherlock::name_alt5                    131,767 (4515 MB/s)          86,539 (6874 MB/s)               -45,228  -34.32%   x 1.52
 sherlock::name_holmes_nocase           190,772 (3118 MB/s)          147,946 (4021 MB/s)              -42,826  -22.45%   x 1.29
 sherlock::name_sherlock_holmes_nocase  170,387 (3491 MB/s)          124,611 (4774 MB/s)              -45,776  -26.87%   x 1.37
 sherlock::name_sherlock_nocase         163,711 (3634 MB/s)          121,786 (4885 MB/s)              -41,925  -25.61%   x 1.34
```

:tada: