### PR TITLE
Add support for C++ `std::regex` to benchmarks

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -46,6 +46,7 @@ bench = false
 re-pcre1 = ["libpcre-sys"]
 re-pcre2 = []
 re-onig = ["onig"]
+re-stdcpp = []
 re-re2 = []
 re-dphobos = []
 re-dphobos-dmd = ["re-dphobos"]

--- a/bench/build.rs
+++ b/bench/build.rs
@@ -18,6 +18,13 @@ fn main() {
     if env::var("CARGO_FEATURE_RE_PCRE2").is_ok() {
         pkg_config::probe_library("libpcre2-8").unwrap();
     }
+    if env::var("CARGO_FEATURE_RE_STDCPP").is_ok() {
+        // stdcpp is a C++ library, so we need to compile our shim layer.
+        cc::Build::new()
+            .cpp(true)
+            .file("src/ffi/stdcpp.cpp")
+            .compile("libcstdcpp.a");
+    }
     if env::var("CARGO_FEATURE_RE_RE2").is_ok() {
         // RE2 is a C++ library, so we need to compile our shim layer.
         cc::Build::new()

--- a/bench/compile
+++ b/bench/compile
@@ -2,5 +2,5 @@
 
 exec cargo build \
   --release \
-  --features 're-re2 re-onig re-pcre1 re-pcre2 re-rust re-rust-bytes re-tcl re-dphobos-dmd re-dphobos-ldc' \
+  --features 're-stdcpp re-re2 re-onig re-pcre1 re-pcre2 re-rust re-rust-bytes re-tcl re-dphobos-dmd re-dphobos-ldc' \
   "$@"

--- a/bench/run
+++ b/bench/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 usage() {
-  echo "Usage: $(basename $0) [dphobos-dmd | dphobos-ldc | dphobos-dmd-ct | dphobos-ldc-ct | rust | rust-bytes | pcre1 | pcre2 | re2 | onig | tcl ]" >&2
+  echo "Usage: $(basename $0) [dphobos-dmd | dphobos-ldc | dphobos-dmd-ct | dphobos-ldc-ct | rust | rust-bytes | pcre1 | pcre2 | stdcpp | re2 | onig | tcl ]" >&2
   exit 1
 }
 
@@ -29,6 +29,9 @@ case $which in
     ;;
   rust-bytes)
     exec cargo bench --bench bench --features re-rust-bytes "$@"
+    ;;
+  stdcpp)
+    exec cargo bench --bench bench --features re-stdcpp "$@"
     ;;
   re2)
     exec cargo bench --bench bench --features re-re2 "$@"

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -35,6 +35,8 @@ pub use ffi::onig::Regex;
 pub use ffi::pcre1::Regex;
 #[cfg(feature = "re-pcre2")]
 pub use ffi::pcre2::Regex;
+#[cfg(feature = "re-stdcpp")]
+pub use ffi::stdcpp::Regex;
 #[cfg(feature = "re-re2")]
 pub use ffi::re2::Regex;
 #[cfg(feature = "re-dphobos")]
@@ -90,6 +92,7 @@ macro_rules! text {
     feature = "re-onig",
     feature = "re-pcre1",
     feature = "re-pcre2",
+    feature = "re-stdcpp",
     feature = "re-re2",
     feature = "re-dphobos",
     feature = "re-rust",
@@ -107,6 +110,7 @@ type Text = Vec<u8>;
     feature = "re-onig",
     feature = "re-pcre1",
     feature = "re-pcre2",
+    feature = "re-stdcpp",
     feature = "re-re2",
     feature = "re-dphobos",
     feature = "re-rust",

--- a/bench/src/ffi/mod.rs
+++ b/bench/src/ffi/mod.rs
@@ -20,6 +20,8 @@ pub mod onig;
 pub mod pcre1;
 #[cfg(feature = "re-pcre2")]
 pub mod pcre2;
+#[cfg(feature = "re-stdcpp")]
+pub mod stdcpp;
 #[cfg(feature = "re-re2")]
 pub mod re2;
 #[cfg(feature = "re-tcl")]

--- a/bench/src/ffi/stdcpp.cpp
+++ b/bench/src/ffi/stdcpp.cpp
@@ -1,0 +1,42 @@
+#include <regex>
+
+extern "C" {
+    typedef void stdcpp_regexp;
+
+    typedef struct stdcpp_string {
+        const char *text;
+        int len;
+    } stdcpp_string;
+
+    stdcpp_regexp* stdcpp_regexp_new(stdcpp_string pat) {
+        return reinterpret_cast<stdcpp_regexp*>(new std::regex(pat.text,
+							       pat.len,
+							       std::regex::optimize));
+    }
+
+    void stdcpp_regexp_free(stdcpp_regexp *re) {
+        delete reinterpret_cast<std::regex*>(re);
+    }
+
+    bool stdcpp_regexp_match(stdcpp_regexp *re, stdcpp_string text,
+			     int startpos, int endpos) {
+	std::regex cpp_re(*reinterpret_cast<std::regex*>(re));
+        return std::regex_search(text.text + startpos, text.text + endpos,
+				 cpp_re);
+    }
+
+    bool stdcpp_regexp_find(stdcpp_regexp *re, stdcpp_string text,
+			    int startpos, int endpos,
+			    int *match_start, int *match_end) {
+	std::regex cpp_re(*reinterpret_cast<std::regex*>(re));
+	std::cmatch result;
+        bool matched;
+        matched = std::regex_search(text.text + startpos, text.text + endpos,
+				    result, cpp_re);
+        if (matched) {
+	    *match_start = result[0].first - text.text;
+	    *match_end = *match_start + result.length(0);
+        }
+        return matched;
+    }
+}

--- a/bench/src/ffi/stdcpp.rs
+++ b/bench/src/ffi/stdcpp.rs
@@ -1,0 +1,163 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(non_camel_case_types)]
+
+use libc::{c_uchar, c_int, c_void};
+
+/// Regex wraps a std::regex regular expression.
+///
+/// It cannot be used safely from multiple threads simultaneously.
+pub struct Regex {
+    re: *mut stdcpp_regexp,
+}
+
+unsafe impl Send for Regex {}
+
+impl Drop for Regex {
+    fn drop(&mut self) {
+        unsafe { stdcpp_regexp_free(self.re); }
+    }
+}
+
+#[derive(Debug)]
+pub struct Error(());
+
+impl Regex {
+    pub fn new(pattern: &str) -> Result<Regex, Error> {
+        unsafe { Ok(Regex { re: stdcpp_regexp_new(pattern.into()) }) }
+    }
+
+    pub fn is_match(&self, text: &str) -> bool {
+        unsafe {
+            stdcpp_regexp_match(self.re, text.into(), 0, text.len() as c_int)
+        }
+    }
+
+    pub fn find_iter<'r, 't>(&'r self, text: &'t str) -> FindMatches<'r, 't> {
+        FindMatches {
+            re: self,
+            text: text,
+            last_end: 0,
+            last_match: None,
+        }
+    }
+
+    fn find_at(&self, text: &str, start: usize) -> Option<(usize, usize)> {
+        let (mut s, mut e): (c_int, c_int) = (0, 0);
+        let matched = unsafe {
+            stdcpp_regexp_find(
+                self.re,
+                text.into(),
+                start as c_int,
+                text.len() as c_int,
+                &mut s,
+                &mut e,
+            )
+        };
+        if matched {
+            Some((s as usize, e as usize))
+        } else {
+            None
+        }
+    }
+}
+
+pub struct FindMatches<'r, 't> {
+    re: &'r Regex,
+    text: &'t str,
+    last_end: usize,
+    last_match: Option<usize>,
+}
+
+// This implementation is identical to the one Rust uses, since both Rust's
+// regex engine and std::regex handle empty matches in the same way.
+impl<'r, 't> Iterator for FindMatches<'r, 't> {
+    type Item = (usize, usize);
+
+    fn next(&mut self) -> Option<(usize, usize)> {
+        fn next_after_empty(text: &str, i: usize) -> usize {
+            let b = match text.as_bytes().get(i) {
+                None => return text.len() + 1,
+                Some(&b) => b,
+            };
+            let inc = if b <= 0x7F {
+                1
+            } else if b <= 0b110_11111 {
+                2
+            } else if b <= 0b1110_1111 {
+                3
+            } else {
+                4
+            };
+            i + inc
+        }
+
+        if self.last_end > self.text.len() {
+            return None;
+        }
+        let (s, e) = match self.re.find_at(self.text, self.last_end) {
+            None => return None,
+            Some((s, e)) => (s, e),
+        };
+        assert!(s >= self.last_end);
+        if s == e {
+            // This is an empty match. To ensure we make progress, start
+            // the next search at the smallest possible starting position
+            // of the next match following this one.
+            self.last_end = next_after_empty(&self.text, e);
+            // Don't accept empty matches immediately following a match.
+            // Just move on to the next match.
+            if Some(e) == self.last_match {
+                return self.next();
+            }
+        } else {
+            self.last_end = e;
+        }
+        self.last_match = Some(self.last_end);
+        Some((s, e))
+    }
+}
+
+// stdcpp FFI is below. Note that this uses a hand-rolled C API that is defined
+// in stdcpp.cpp.
+
+type stdcpp_regexp = c_void;
+
+#[repr(C)]
+struct stdcpp_string {
+    text: *const c_uchar,
+    len: c_int,
+}
+
+impl<'a> From<&'a str> for stdcpp_string {
+    fn from(s: &'a str) -> stdcpp_string {
+        stdcpp_string { text: s.as_ptr(), len: s.len() as c_int }
+    }
+}
+
+extern {
+    fn stdcpp_regexp_new(pat: stdcpp_string) -> *mut stdcpp_regexp;
+    fn stdcpp_regexp_free(re: *mut stdcpp_regexp);
+    fn stdcpp_regexp_match(
+        re: *mut stdcpp_regexp,
+        text: stdcpp_string,
+        startpos: c_int,
+        endpos: c_int,
+    ) -> bool;
+    fn stdcpp_regexp_find(
+        re: *mut stdcpp_regexp,
+        text: stdcpp_string,
+        startpos: c_int,
+        endpos: c_int,
+        match_start: *mut c_int,
+        match_end: *mut c_int,
+    ) -> bool;
+}

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -45,7 +45,7 @@ Since this tool includes compilation of the <pattern>, sufficiently large
 haystacks should be used to amortize the cost of compilation. (e.g., >1MB.)
 
 Usage:
-    regex-run-one [options] [onig | pcre1 | pcre2 | re2 | rust | rust-bytes | tcl] <file> <pattern>
+    regex-run-one [options] [onig | pcre1 | pcre2 | stdcpp | re2 | rust | rust-bytes | tcl] <file> <pattern>
     regex-run-one [options] (-h | --help)
 
 Options:
@@ -59,6 +59,7 @@ struct Args {
     cmd_onig: bool,
     cmd_pcre1: bool,
     cmd_pcre2: bool,
+    cmd_stdcpp: bool,
     cmd_re2: bool,
     cmd_rust: bool,
     cmd_rust_bytes: bool,
@@ -87,6 +88,8 @@ impl Args {
             count_pcre1(pat, haystack)
         } else if self.cmd_pcre2 {
             count_pcre2(pat, haystack)
+        } else if self.cmd_stdcpp {
+            count_stdcpp(pat, haystack)
         } else if self.cmd_re2 {
             count_re2(pat, haystack)
         } else if self.cmd_rust {
@@ -129,6 +132,13 @@ nada!("re-pcre2", count_pcre2);
 #[cfg(feature = "re-pcre2")]
 fn count_pcre2(pat: &str, haystack: &str) -> usize {
     use ffi::pcre2::Regex;
+    Regex::new(pat).unwrap().find_iter(haystack).count()
+}
+
+nada!("re-stdcpp", count_stdcpp);
+#[cfg(feature = "re-stdcpp")]
+fn count_stdcpp(pat: &str, haystack: &str) -> usize {
+    use ffi::stdcpp::Regex;
     Regex::new(pat).unwrap().find_iter(haystack).count()
 }
 

--- a/bench/src/misc.rs
+++ b/bench/src/misc.rs
@@ -19,6 +19,7 @@ use {Regex, Text};
 #[cfg(not(feature = "re-onig"))]
 #[cfg(not(feature = "re-pcre1"))]
 #[cfg(not(feature = "re-pcre2"))]
+#[cfg(not(feature = "re-stdcpp"))]
 #[cfg(not(feature = "re-dphobos-dmd-ct"))]
 #[cfg(not(feature = "re-dphobos-ldc-ct"))]
 bench_match!(no_exponential, {
@@ -45,6 +46,7 @@ bench_match!(match_class_in_range, "[ac]", {
 });
 
 #[cfg(not(feature = "re-rust-bytes"))]
+#[cfg(not(feature = "re-stdcpp"))]
 #[cfg(not(feature = "re-tcl"))]
 bench_match!(match_class_unicode, r"\p{L}", {
     format!("{}a", repeat("☃5☃5").take(20).collect::<String>())

--- a/bench/src/sherlock.rs
+++ b/bench/src/sherlock.rs
@@ -35,8 +35,14 @@ sherlock!(name_sherlock_holmes, r"Sherlock Holmes", 91);
 // Like the above, except case insensitively. The prefix detector will extract
 // multiple *cut* prefix literals for each of the following before hitting its
 // limit. All of these should be able to use either memchr2 or memchr3.
+// std C++ does not support inline modifier syntax
+#[cfg(not(feature = "re-stdcpp"))]
 sherlock!(name_sherlock_nocase, r"(?i)Sherlock", 102);
+// std C++ does not support inline modifier syntax
+#[cfg(not(feature = "re-stdcpp"))]
 sherlock!(name_holmes_nocase, r"(?i)Holmes", 467);
+// std C++ does not support inline modifier syntax
+#[cfg(not(feature = "re-stdcpp"))]
 sherlock!(name_sherlock_holmes_nocase, r"(?i)Sherlock Holmes", 96);
 
 // Will quickly find instances of 'Sherlock', but then needs to fall back to
@@ -55,6 +61,8 @@ sherlock!(name_alt2, r"Sherlock|Holmes", 558);
 // also can't use any memchr variant.
 sherlock!(name_alt3, r"Sherlock|Holmes|Watson|Irene|Adler|John|Baker", 740);
 // Still using Aho-Corasick, but needs the lazy DFA.
+// std C++ does not support inline modifier syntax
+#[cfg(not(feature = "re-stdcpp"))]
 sherlock!(
     name_alt3_nocase,
     r"(?i)Sherlock|Holmes|Watson|Irene|Adler|John|Baker",
@@ -62,9 +70,13 @@ sherlock!(
 // Should still use Aho-Corasick for the prefixes in each alternate, but
 // we need to use the lazy DFA to complete it.
 sherlock!(name_alt4, r"Sher[a-z]+|Hol[a-z]+", 582);
+// std C++ does not support inline modifier syntax
+#[cfg(not(feature = "re-stdcpp"))]
 sherlock!(name_alt4_nocase, r"(?i)Sher[a-z]+|Hol[a-z]+", 697);
 // Uses Aho-Corasick, but can use memchr3 (unlike name_alt3).
 sherlock!(name_alt5, r"Sherlock|Holmes|Watson", 639);
+// std C++ does not support inline modifier syntax
+#[cfg(not(feature = "re-stdcpp"))]
 sherlock!(name_alt5_nocase, r"(?i)Sherlock|Holmes|Watson", 650);
 
 // How long does it take to discover that there's no match? In the first two
@@ -80,6 +92,8 @@ sherlock!(no_match_really_common, r"aei", 0);
 // matching engines.)
 sherlock!(the_lower, r"the", 7218);
 sherlock!(the_upper, r"The", 741);
+// std C++ does not support inline modifier syntax
+#[cfg(not(feature = "re-stdcpp"))]
 sherlock!(the_nocase, r"(?i)the", 7987);
 
 // Process whitespace after a very common word.
@@ -91,30 +105,41 @@ sherlock!(the_whitespace, r"the\s+\w+", 5410);
 #[cfg(not(feature = "re-dphobos"))]
 #[cfg(not(feature = "re-pcre1"))]
 #[cfg(not(feature = "re-pcre2"))]
+#[cfg(not(feature = "re-stdcpp"))]
 #[cfg(not(feature = "re-tcl"))]
 sherlock!(everything_greedy, r".*", 13053);
+// std::regex . does not match \r
+#[cfg(feature = "re-stdcpp")]
+sherlock!(everything_greedy, r"[^\n]*", 13053);
 #[cfg(not(feature = "re-dphobos"))]
 #[cfg(not(feature = "re-onig"))]
 #[cfg(not(feature = "re-pcre1"))]
 #[cfg(not(feature = "re-pcre2"))]
+// std C++ does not support inline modifier syntax
+#[cfg(not(feature = "re-stdcpp"))]
 #[cfg(not(feature = "re-tcl"))]
 sherlock!(everything_greedy_nl, r"(?s).*", 1);
 
 // How fast can we match every letter? This also defeats any clever prefix
 // tricks.
+#[cfg(not(feature = "re-stdcpp"))]
 #[cfg(not(feature = "re-tcl"))]
 sherlock!(letters, r"\p{L}", 447160);
 
+#[cfg(not(feature = "re-stdcpp"))]
 #[cfg(not(feature = "re-tcl"))]
 sherlock!(letters_upper, r"\p{Lu}", 14180);
 
+#[cfg(not(feature = "re-stdcpp"))]
 #[cfg(not(feature = "re-tcl"))]
 sherlock!(letters_lower, r"\p{Ll}", 432980);
 
 // Similarly, for words.
 #[cfg(not(feature = "re-re2"))]
+#[cfg(not(feature = "re-stdcpp"))]
 sherlock!(words, r"\w+", 109214);
 #[cfg(feature = "re-re2")]
+#[cfg(feature = "re-stdcpp")]
 sherlock!(words, r"\w+", 109222); // hmm, why does RE2 diverge here?
 
 // Find complete words before Holmes. The `\w` defeats any prefix
@@ -136,6 +161,7 @@ sherlock!(holmes_cochar_watson, r"Holmes.{0,25}Watson|Watson.{0,25}Holmes", 7);
 #[cfg(not(feature = "re-onig"))]
 #[cfg(not(feature = "re-pcre1"))]
 #[cfg(not(feature = "re-pcre2"))]
+#[cfg(not(feature = "re-stdcpp"))]
 #[cfg(not(feature = "re-tcl"))]
 sherlock!(
     holmes_coword_watson,
@@ -150,6 +176,8 @@ sherlock!(quotes, r#"["'][^"']{0,30}[?!.]["']"#, 767);
 // Finds all occurrences of Sherlock Holmes at the beginning or end of a line.
 // The empty assertions defeat any detection of prefix literals, so it's the
 // lazy DFA the entire way.
+// std C++ does not support multiline until C++17 nor the inline modifier syntax
+#[cfg(not(feature = "re-stdcpp"))]
 #[cfg(not(feature = "re-dphobos"))]
 sherlock!(
     line_boundary_sherlock_holmes,


### PR DESCRIPTION
### Detailed changes
* bench/Cargo.toml: add `re-stdcpp` feature
* bench/build.rs: add `cstdcpp` library to bench build
* bench/compile: add `re-stdcpp` feature to bench compile script
* bench/run: add `re-stdcpp` feature to bench run script
* bench/src/bench.rs: use `ffi::stdcpp::Regex`, define its `text!` macro, and `Text` type
* bench/src/ffi/mod.rs: declare `stdcpp` module
* bench/src/ffi/stdcpp.cpp: implement C API using C++ `std::regex`
* bench/src/ffi/stdcpp.rs: Rust `Regex` API implementation using C++ `std::regex` C API wrapper
* bench/src/main.rs: add stdcpp to bench main
* bench/src/misc.rs:
   - do not run `no_exponential` benchmark for `re-stdcpp` feature because `libstdc++` `std::regex` implementation currently seems to have exponential behavior here
   - do not run `match_class_unicode` benchmark for `re-stdcpp` feature because `std::regex` ECMAScript grammar does not support unicode character classes
* bench/src/sherlock.rs:
   - do not run `name_sherlock_nocase`, `name_holmes_nocase`, `name_sherlock_holmes_nocase`, `name_alt3_nocase`, `name_alt4_nocase`, `name_alt5_nocase`, `the_nocase`, `everything_greedy_nl`, and `line_boundary_sherlock_holmes` benchmarks for `re-stdcpp` feature because `std::regex` ECMAScript grammar does not support inline modifier syntax
   - do not run `letters`, `letters_upper`, and `letters_lower` benchmarks for `re-stdcpp` feature because `std::regex` ECMAScript grammar does not support unicode character classes
   - use a different regex for `everything_greedy` benchmark because `std::regex` '.' does not match '\r'
   - `words` benchmark for `std::regex` matches RE2 test result, so use that test for `re-stdcpp` feature as well
   - do not run `holmes_coword_watson` benchmark for `re-stdcpp` feature because `libstdc++` `std::regex` implementation currently seems to have exponential behavior here

### Results
Unfortunately, the `libstdc++` `std::regex` implementation (version 7.3.1) on my machine did not do too well, often being tens or hundreds of times slower than PCRE2 or RE2. Some example results for `libstdc++` are shown here:
```
running 81 tests
test misc::anchored_literal_long_match      ... bench:         326 ns/iter (+/- 0) = 1196 MB/s
test misc::anchored_literal_long_non_match  ... bench:      14,983 ns/iter (+/- 13) = 26 MB/s
test misc::anchored_literal_short_match     ... bench:         316 ns/iter (+/- 1) = 82 MB/s
test misc::anchored_literal_short_non_match ... bench:       1,186 ns/iter (+/- 1) = 21 MB/s
test misc::easy0_1K                         ... bench:      39,988 ns/iter (+/- 72) = 26 MB/s
test misc::easy0_1MB                        ... bench:  40,376,744 ns/iter (+/- 30,603) = 25 MB/s
test misc::easy0_32                         ... bench:       1,794 ns/iter (+/- 2) = 32 MB/s
test misc::easy0_32K                        ... bench:   1,262,276 ns/iter (+/- 1,227) = 25 MB/s
test misc::easy1_1K                         ... bench:      39,959 ns/iter (+/- 48) = 26 MB/s
test misc::easy1_1MB                        ... bench:  40,379,174 ns/iter (+/- 27,276) = 25 MB/s
test misc::easy1_32                         ... bench:       1,833 ns/iter (+/- 1) = 28 MB/s
test misc::easy1_32K                        ... bench:   1,262,166 ns/iter (+/- 1,186) = 25 MB/s
test misc::hard_1K                          ... bench:     999,561 ns/iter (+/- 16,814) = 1 MB/s
test misc::hard_1MB                         ... bench: 1,059,059,453 ns/iter (+/- 5,881,158)
test misc::hard_32                          ... bench:      30,532 ns/iter (+/- 493) = 1 MB/s
test misc::hard_32K                         ... bench:  34,627,995 ns/iter (+/- 490,957)
test misc::literal                          ... bench:       2,146 ns/iter (+/- 1) = 23 MB/s
test misc::long_needle1                     ... bench:  29,212,899 ns/iter (+/- 12,436) = 3 MB/s
test misc::long_needle2                     ... bench:  29,231,653 ns/iter (+/- 17,311) = 3 MB/s
test misc::match_class                      ... bench:       3,404 ns/iter (+/- 3) = 23 MB/s
test misc::match_class_in_range             ... bench:       3,399 ns/iter (+/- 3) = 23 MB/s
test misc::medium_1K                        ... bench:      41,221 ns/iter (+/- 107) = 25 MB/s
test misc::medium_1MB                       ... bench:  41,618,788 ns/iter (+/- 24,107) = 25 MB/s
test misc::medium_32                        ... bench:       1,862 ns/iter (+/- 2) = 32 MB/s
test misc::medium_32K                       ... bench:   1,300,733 ns/iter (+/- 1,304) = 25 MB/s
test misc::not_literal                      ... bench:       2,888 ns/iter (+/- 11) = 17 MB/s
test misc::one_pass_long_prefix             ... bench:         571 ns/iter (+/- 3) = 45 MB/s
test misc::one_pass_long_prefix_not         ... bench:         580 ns/iter (+/- 0) = 44 MB/s
test misc::one_pass_short                   ... bench:       1,733 ns/iter (+/- 37) = 9 MB/s
test misc::one_pass_short_not               ... bench:       1,717 ns/iter (+/- 50) = 9 MB/s
test misc::reallyhard2_1K                   ... bench:     996,324 ns/iter (+/- 45,664) = 1 MB/s
test misc::reallyhard_1K                    ... bench:   1,012,203 ns/iter (+/- 1,485) = 1 MB/s
test misc::reallyhard_1MB                   ... bench: 1,053,934,632 ns/iter (+/- 4,977,685)
test misc::reallyhard_32                    ... bench:      30,234 ns/iter (+/- 464) = 1 MB/s
test misc::reallyhard_32K                   ... bench:  34,378,406 ns/iter (+/- 487,743)
test misc::reverse_suffix_no_quadratic      ... bench:     331,368 ns/iter (+/- 434) = 24 MB/s
test regexdna::find_new_lines               ... bench: 307,181,237 ns/iter (+/- 78,961) = 16 MB/s
test regexdna::subst1                       ... bench: 201,886,931 ns/iter (+/- 97,655) = 25 MB/s
test regexdna::subst10                      ... bench: 207,618,870 ns/iter (+/- 178,302) = 24 MB/s
test regexdna::subst11                      ... bench: 201,880,614 ns/iter (+/- 116,389) = 25 MB/s
test regexdna::subst2                       ... bench: 201,861,384 ns/iter (+/- 125,616) = 25 MB/s
test regexdna::subst3                       ... bench: 207,640,785 ns/iter (+/- 268,453) = 24 MB/s
test regexdna::subst4                       ... bench: 201,919,815 ns/iter (+/- 114,920) = 25 MB/s
test regexdna::subst5                       ... bench: 201,899,802 ns/iter (+/- 108,025) = 25 MB/s
test regexdna::subst6                       ... bench: 201,878,177 ns/iter (+/- 204,125) = 25 MB/s
test regexdna::subst7                       ... bench: 201,941,772 ns/iter (+/- 523,708) = 25 MB/s
test regexdna::subst8                       ... bench: 201,896,316 ns/iter (+/- 135,968) = 25 MB/s
test regexdna::subst9                       ... bench: 201,911,005 ns/iter (+/- 196,632) = 25 MB/s
test regexdna::variant1                     ... bench: 336,160,741 ns/iter (+/- 257,036) = 15 MB/s
test regexdna::variant2                     ... bench: 392,650,258 ns/iter (+/- 2,880,460) = 12 MB/s
test regexdna::variant3                     ... bench: 351,431,623 ns/iter (+/- 285,862) = 14 MB/s
test regexdna::variant4                     ... bench: 338,043,444 ns/iter (+/- 91,547,961) = 15 MB/s
test regexdna::variant5                     ... bench: 334,627,689 ns/iter (+/- 264,418) = 15 MB/s
test regexdna::variant6                     ... bench: 336,059,615 ns/iter (+/- 5,423,345) = 15 MB/s
test regexdna::variant7                     ... bench: 338,298,685 ns/iter (+/- 523,873) = 15 MB/s
test regexdna::variant8                     ... bench: 348,758,502 ns/iter (+/- 258,051) = 14 MB/s
test regexdna::variant9                     ... bench: 401,088,309 ns/iter (+/- 482,367) = 12 MB/s
test sherlock::before_after_holmes          ... bench: 103,667,977 ns/iter (+/- 205,097) = 5 MB/s
test sherlock::before_holmes                ... bench: 103,809,888 ns/iter (+/- 209,549) = 5 MB/s
test sherlock::everything_greedy            ... bench:  30,140,710 ns/iter (+/- 121,690) = 19 MB/s
test sherlock::holmes_cochar_watson         ... bench:  34,338,985 ns/iter (+/- 33,550) = 17 MB/s
test sherlock::ing_suffix                   ... bench:  83,871,295 ns/iter (+/- 153,065) = 7 MB/s
test sherlock::ing_suffix_limited_space     ... bench:  48,593,384 ns/iter (+/- 43,535) = 12 MB/s
test sherlock::name_alt1                    ... bench:  33,965,251 ns/iter (+/- 25,075) = 17 MB/s
test sherlock::name_alt2                    ... bench:  34,131,786 ns/iter (+/- 27,935) = 17 MB/s
test sherlock::name_alt3                    ... bench:  74,160,916 ns/iter (+/- 29,644) = 8 MB/s
test sherlock::name_alt4                    ... bench:  34,333,961 ns/iter (+/- 26,138) = 17 MB/s
test sherlock::name_alt5                    ... bench:  41,481,282 ns/iter (+/- 32,529) = 14 MB/s
test sherlock::name_holmes                  ... bench:  22,940,321 ns/iter (+/- 16,953) = 25 MB/s
test sherlock::name_sherlock                ... bench:  22,915,858 ns/iter (+/- 22,849) = 25 MB/s
test sherlock::name_sherlock_holmes         ... bench:  22,899,246 ns/iter (+/- 23,669) = 25 MB/s
test sherlock::name_whitespace              ... bench:  22,901,419 ns/iter (+/- 18,870) = 25 MB/s
test sherlock::no_match_common              ... bench:  23,403,282 ns/iter (+/- 20,850) = 25 MB/s
test sherlock::no_match_really_common       ... bench:  23,404,467 ns/iter (+/- 28,693) = 25 MB/s
test sherlock::no_match_uncommon            ... bench:  22,917,887 ns/iter (+/- 27,731) = 25 MB/s
test sherlock::quotes                       ... bench:  29,375,307 ns/iter (+/- 60,734) = 20 MB/s
test sherlock::repeated_class_negation      ... bench:  53,412,556 ns/iter (+/- 28,818) = 11 MB/s
test sherlock::the_lower                    ... bench:  26,024,165 ns/iter (+/- 33,233) = 22 MB/s
test sherlock::the_upper                    ... bench:  23,689,507 ns/iter (+/- 21,524) = 25 MB/s
test sherlock::the_whitespace               ... bench:  24,354,227 ns/iter (+/- 30,471) = 24 MB/s
test sherlock::word_ending_n                ... bench: 163,437,469 ns/iter (+/- 157,966) = 3 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 81 measured; 0 filtered out
```