### PR TITLE
Fix regression in travis coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false
+sudo: required
 language: rust
 rust:
 - 1.20.0


### PR DESCRIPTION
A recent change to the travis-ci `sudo: false` environment
broke kcov. The temporary solution that travis has recomended
is to switch to the `sudo: required` environment. The tradeoff
here is that the build will take longer to start, so
it might also be reasonable to just stop collecting coverage
info until travis finishes `sudo: false`.

See: https://github.com/travis-ci/travis-ci/issues/9061