### PR TITLE
add benchmark for hyperscan

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -22,6 +22,7 @@ regex = { version = "1.0.0", path = "..", features = ["unstable"] }
 regex-syntax = { version = "0.6.0", path = "../regex-syntax" }
 serde = "1"
 serde_derive = "1"
+hyperscan = { version = "0.1", optional = true }
 
 [build-dependencies]
 cc = "1"
@@ -58,6 +59,7 @@ re-dphobos-ldc-ct = ["re-dphobos-ldc"]
 re-rust = []
 re-rust-bytes = []
 re-tcl = []
+re-hyperscan = ["hyperscan"]
 
 [[bench]]
 name = "bench"

--- a/bench/compile
+++ b/bench/compile
@@ -2,5 +2,5 @@
 
 exec cargo build \
   --release \
-  --features 're-stdcpp re-boost re-re2 re-onig re-pcre1 re-pcre2 re-rust re-rust-bytes re-tcl re-dphobos-dmd re-dphobos-ldc' \
+  --features 're-stdcpp re-boost re-re2 re-onig re-pcre1 re-pcre2 re-rust re-rust-bytes re-tcl re-dphobos-dmd re-dphobos-ldc re-hyperscan' \
   "$@"

--- a/bench/run
+++ b/bench/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 usage() {
-  echo "Usage: $(basename $0) [dphobos-dmd | dphobos-ldc | dphobos-dmd-ct | dphobos-ldc-ct | rust | rust-bytes | pcre1 | pcre2 | stdcpp | stdcpp-libcxx | boost | re2 | onig | tcl ]" >&2
+  echo "Usage: $(basename $0) [dphobos-dmd | dphobos-ldc | dphobos-dmd-ct | dphobos-ldc-ct | rust | rust-bytes | pcre1 | pcre2 | stdcpp | stdcpp-libcxx | boost | re2 | onig | tcl | hyperscan ]" >&2
   exit 1
 }
 
@@ -53,6 +53,9 @@ case $which in
     ;;
   tcl)
     exec cargo bench --bench bench --features re-tcl "$@"
+    ;;
+  hyperscan)
+    exec cargo bench --bench bench --features re-hyperscan "$@"
     ;;
   *)
     usage

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -17,6 +17,8 @@ extern crate lazy_static;
 extern crate libc;
 #[cfg(feature = "re-pcre1")]
 extern crate libpcre_sys;
+#[cfg(feature = "re-hyperscan")]
+extern crate hyperscan;
 #[cfg(feature = "re-onig")]
 extern crate onig;
 #[cfg(any(
@@ -49,6 +51,8 @@ pub use regex::Regex;
 pub use regex::bytes::Regex;
 #[cfg(feature = "re-tcl")]
 pub use ffi::tcl::Regex;
+#[cfg(feature = "re-hyperscan")]
+pub use ffi::hs::Regex;
 
 // Usage: regex!(pattern)
 //
@@ -99,6 +103,7 @@ macro_rules! text {
     feature = "re-re2",
     feature = "re-dphobos",
     feature = "re-rust",
+    feature = "re-hyperscan",
   ))]
 macro_rules! text {
     ($text:expr) => { $text }
@@ -118,6 +123,7 @@ type Text = Vec<u8>;
     feature = "re-re2",
     feature = "re-dphobos",
     feature = "re-rust",
+    feature = "re-hyperscan",
   ))]
 type Text = String;
 

--- a/bench/src/ffi/hs.rs
+++ b/bench/src/ffi/hs.rs
@@ -1,0 +1,74 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+use std::cell::RefCell;
+use std::vec::IntoIter;
+
+use hyperscan::Error;
+use hyperscan::{BlockDatabase, BlockScanner, DatabaseBuilder, HS_CPU_FEATURES_AVX2, Pattern,
+                RawScratch, ScratchAllocator, HS_FLAG_ALLOWEMPTY, HS_FLAG_SINGLEMATCH,
+                HS_FLAG_SOM_LEFTMOST};
+
+/// Regex wraps a hyperscan regular expression.
+///
+/// It can be used safely from multiple threads simultaneously.
+pub struct Regex {
+    db: BlockDatabase,
+    s: RefCell<RawScratch>,
+}
+
+unsafe impl Send for Regex {}
+
+impl Regex {
+    pub fn new(pattern: &str) -> Result<Regex, Error> {
+        let mut p = pattern.parse::<Pattern>()?;
+        p.flags.set(HS_FLAG_ALLOWEMPTY | HS_CPU_FEATURES_AVX2);
+        let db = p.build()?;
+        let s = RefCell::new(db.alloc()?);
+
+        Ok(Regex { db, s })
+    }
+
+    pub fn is_match(&self, text: &str) -> bool {
+        self.scan(text)
+            .ok()
+            .map_or(false, |matched| !matched.is_empty())
+    }
+
+    pub fn find_iter<'a>(&'a self, text: &str) -> FindMatches {
+        self.scan(text).ok().unwrap().into_iter()
+    }
+
+    fn scan(&self, text: &str) -> Result<Vec<(usize, usize)>, Error> {
+        let matches = RefCell::new(Vec::<(usize, usize)>::new());
+
+        self.db.scan(
+            text,
+            0,
+            &mut *self.s.borrow_mut(),
+            Some(on_matched),
+            Some(&matches),
+        )?;
+
+        Ok(matches.into_inner())
+    }
+}
+
+pub type FindMatches = IntoIter<(usize, usize)>;
+
+fn on_matched(
+    _id: u32,
+    from: u64,
+    to: u64,
+    _flags: u32,
+    matches: &RefCell<Vec<(usize, usize)>>,
+) -> u32 {
+    matches.borrow_mut().push((from as usize, to as usize));
+    0
+}

--- a/bench/src/ffi/mod.rs
+++ b/bench/src/ffi/mod.rs
@@ -29,3 +29,5 @@ pub mod stdcpp;
 pub mod re2;
 #[cfg(feature = "re-tcl")]
 pub mod tcl;
+#[cfg(feature = "re-hyperscan")]
+pub mod hs;

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -12,6 +12,8 @@ extern crate docopt;
 extern crate libc;
 #[cfg(feature = "re-pcre1")]
 extern crate libpcre_sys;
+#[cfg(feature = "re-hyperscan")]
+extern crate hyperscan;
 extern crate memmap;
 #[cfg(feature = "re-onig")]
 extern crate onig;
@@ -45,7 +47,7 @@ Since this tool includes compilation of the <pattern>, sufficiently large
 haystacks should be used to amortize the cost of compilation. (e.g., >1MB.)
 
 Usage:
-    regex-run-one [options] [onig | pcre1 | pcre2 | stdcpp | re2 | rust | rust-bytes | tcl] <file> <pattern>
+    regex-run-one [options] [onig | pcre1 | pcre2 | stdcpp | re2 | rust | rust-bytes | tcl | hyperscan] <file> <pattern>
     regex-run-one [options] (-h | --help)
 
 Options:
@@ -64,6 +66,7 @@ struct Args {
     cmd_rust: bool,
     cmd_rust_bytes: bool,
     cmd_tcl: bool,
+    cmd_hyperscan: bool,
 }
 
 fn main() {
@@ -98,6 +101,8 @@ impl Args {
             count_rust_bytes(pat, haystack)
         } else if self.cmd_tcl {
             count_tcl(pat, haystack)
+        } else if self.cmd_hyperscan {
+            count_hyperscan(pat, haystack)
         } else {
             panic!("unreachable")
         }
@@ -175,4 +180,11 @@ nada!("re-tcl", count_tcl);
 fn count_tcl(pat: &str, haystack: &str) -> usize {
     use ffi::tcl::{Regex, Text};
     Regex::new(pat).unwrap().find_iter(&Text::new(haystack.to_owned())).count()
+}
+
+nada!("re-hyperscan", count_hyperscan);
+#[cfg(feature = "re-hyperscan")]
+fn count_hyperscan(pat: &str, haystack: &str) -> usize {
+    use ffi::hs::Regex;
+    Regex::new(pat).unwrap().find_iter(haystack).count()
 }


### PR DESCRIPTION
Just added a fast benchmark for `hyperscan`. It seems some tests failed. I'm not sure it's the limitation of `hyperscan`, or because it use a different design, for example, haven't left of most by default.

```bash
$ cargo +nightly bench --bench bench --features re-hyperscan
```
>running 97 tests
test misc::anchored_literal_long_match       ... bench:         293 ns/iter (+/- 44) = 1331 MB/s
test misc::anchored_literal_long_non_match   ... bench:          80 ns/iter (+/- 8) = 4875 MB/s
test misc::anchored_literal_short_match      ... bench:          94 ns/iter (+/- 6) = 276 MB/s
test misc::anchored_literal_short_non_match  ... bench:          43 ns/iter (+/- 11) = 604 MB/s
test misc::easy0_1K                          ... bench:         232 ns/iter (+/- 52) = 4530 MB/s
test misc::easy0_1MB                         ... bench:      63,110 ns/iter (+/- 11,077) = 16615 MB/s
test misc::easy0_32                          ... bench:         144 ns/iter (+/- 37) = 409 MB/s
test misc::easy0_32K                         ... bench:       2,047 ns/iter (+/- 171) = 16021 MB/s
test misc::easy1_1K                          ... bench:         242 ns/iter (+/- 24) = 4314 MB/s
test misc::easy1_1MB                         ... bench:      52,766 ns/iter (+/- 3,143) = 19872 MB/s
test misc::easy1_32                          ... bench:         125 ns/iter (+/- 16) = 416 MB/s
test misc::easy1_32K                         ... bench:       1,855 ns/iter (+/- 284) = 17675 MB/s
test misc::hard_1K                           ... bench:         231 ns/iter (+/- 21) = 4549 MB/s
test misc::hard_1MB                          ... bench:      61,294 ns/iter (+/- 3,368) = 17107 MB/s
test misc::hard_32                           ... bench:         138 ns/iter (+/- 14) = 427 MB/s
test misc::hard_32K                          ... bench:       2,228 ns/iter (+/- 442) = 14719 MB/s
test misc::literal                           ... bench:          77 ns/iter (+/- 8) = 662 MB/s
test misc::long_needle1                      ... bench:       5,811 ns/iter (+/- 229) = 17208 MB/s
test misc::long_needle2                      ... bench:       5,845 ns/iter (+/- 363) = 17108 MB/s
test misc::match_class                       ... bench:         102 ns/iter (+/- 8) = 794 MB/s
test misc::match_class_in_range              ... bench:         101 ns/iter (+/- 21) = 801 MB/s
test misc::match_class_unicode               ... bench:       1,140 ns/iter (+/- 91) = 141 MB/s
test misc::medium_1K                         ... bench:         240 ns/iter (+/- 29) = 4383 MB/s
test misc::medium_1MB                        ... bench:      61,326 ns/iter (+/- 4,083) = 17098 MB/s
test misc::medium_32                         ... bench:         143 ns/iter (+/- 16) = 419 MB/s
test misc::medium_32K                        ... bench:       2,067 ns/iter (+/- 183) = 15866 MB/s
test misc::no_exponential                    ... bench:       1,198 ns/iter (+/- 104) = 83 MB/s
test misc::not_literal                       ... bench:         110 ns/iter (+/- 10) = 463 MB/s
test misc::one_pass_long_prefix              ... bench:         124 ns/iter (+/- 9) = 209 MB/s
test misc::one_pass_long_prefix_not          ... bench:         127 ns/iter (+/- 22) = 204 MB/s
test misc::one_pass_short                    ... bench:         110 ns/iter (+/- 17) = 154 MB/s
test misc::one_pass_short_not                ... bench:         113 ns/iter (+/- 10) = 150 MB/s
test misc::reallyhard2_1K                    ... bench:         246 ns/iter (+/- 43) = 4227 MB/s
test misc::reallyhard_1K                     ... bench:         251 ns/iter (+/- 41) = 4187 MB/s
test misc::reallyhard_1MB                    ... bench:      61,776 ns/iter (+/- 4,118) = 16974 MB/s
test misc::reallyhard_32                     ... bench:         179 ns/iter (+/- 24) = 329 MB/s
test misc::reallyhard_32K                    ... bench:       2,121 ns/iter (+/- 237) = 15462 MB/s
test misc::reverse_suffix_no_quadratic       ... bench:      35,152 ns/iter (+/- 2,335) = 227 MB/s
test regexdna::find_new_lines                ... bench:   2,889,153 ns/iter (+/- 267,871) = 1759 MB/s
test regexdna::subst1                        ... bench:     886,155 ns/iter (+/- 72,789) = 5736 MB/s
test regexdna::subst10                       ... bench:     912,789 ns/iter (+/- 107,843) = 5569 MB/s
test regexdna::subst11                       ... bench:     874,472 ns/iter (+/- 82,608) = 5813 MB/s
test regexdna::subst2                        ... bench:     856,053 ns/iter (+/- 115,684) = 5938 MB/s
test regexdna::subst3                        ... bench:     835,617 ns/iter (+/- 39,632) = 6083 MB/s
test regexdna::subst4                        ... bench:     871,321 ns/iter (+/- 252,972) = 5834 MB/s
test regexdna::subst5                        ... bench:     843,441 ns/iter (+/- 50,820) = 6026 MB/s
test regexdna::subst6                        ... bench:     840,535 ns/iter (+/- 71,618) = 6047 MB/s
test regexdna::subst7                        ... bench:     861,247 ns/iter (+/- 47,244) = 5902 MB/s
test regexdna::subst8                        ... bench:     850,337 ns/iter (+/- 46,820) = 5978 MB/s
test regexdna::subst9                        ... bench:     844,355 ns/iter (+/- 66,487) = 6020 MB/s
test regexdna::variant1                      ... bench:   2,693,982 ns/iter (+/- 95,142) = 1886 MB/s
test regexdna::variant2                      ... bench:   3,323,224 ns/iter (+/- 109,205) = 1529 MB/s
test regexdna::variant3                      ... bench:   3,730,761 ns/iter (+/- 164,207) = 1362 MB/s
test regexdna::variant4                      ... bench:   3,687,914 ns/iter (+/- 170,831) = 1378 MB/s
test regexdna::variant5                      ... bench:   2,791,626 ns/iter (+/- 170,090) = 1820 MB/s
test regexdna::variant6                      ... bench:   3,057,464 ns/iter (+/- 141,120) = 1662 MB/s
test regexdna::variant7                      ... bench:   3,722,301 ns/iter (+/- 154,763) = 1365 MB/s
test regexdna::variant8                      ... bench:   3,703,193 ns/iter (+/- 154,812) = 1372 MB/s
test regexdna::variant9                      ... bench:   3,629,001 ns/iter (+/- 151,072) = 1400 MB/s
test sherlock::before_after_holmes           ... FAILED
test sherlock::before_holmes                 ... bench:      67,114 ns/iter (+/- 4,457) = 8864 MB/s
test sherlock::everything_greedy             ... FAILED
test sherlock::everything_greedy_nl          ... FAILED
test sherlock::holmes_cochar_watson          ... bench:     128,796 ns/iter (+/- 65,276) = 4619 MB/s
test sherlock::holmes_coword_watson          ... FAILED
test sherlock::ing_suffix                    ... FAILED
test sherlock::ing_suffix_limited_space      ... FAILED
test sherlock::letters                       ... FAILED
test sherlock::letters_lower                 ... FAILED
test sherlock::letters_upper                 ... FAILED
test sherlock::line_boundary_sherlock_holmes ... bench:     109,405 ns/iter (+/- 18,879) = 5437 MB/s
test sherlock::name_alt1                     ... bench:     102,854 ns/iter (+/- 26,882) = 5784 MB/s
test sherlock::name_alt2                     ... bench:     114,794 ns/iter (+/- 10,208) = 5182 MB/s
test sherlock::name_alt3                     ... bench:     133,629 ns/iter (+/- 27,325) = 4452 MB/s
test sherlock::name_alt3_nocase              ... bench:     133,226 ns/iter (+/- 17,181) = 4465 MB/s
test sherlock::name_alt4                     ... FAILED
test sherlock::name_alt4_nocase              ... FAILED
test sherlock::name_alt5                     ... bench:     123,491 ns/iter (+/- 12,270) = 4817 MB/s
test sherlock::name_alt5_nocase              ... bench:     134,591 ns/iter (+/- 70,626) = 4420 MB/s
test sherlock::name_holmes                   ... bench:      48,857 ns/iter (+/- 14,570) = 12177 MB/s
test sherlock::name_holmes_nocase            ... bench:      76,927 ns/iter (+/- 11,307) = 7733 MB/s
test sherlock::name_sherlock                 ... bench:      39,700 ns/iter (+/- 4,377) = 14985 MB/s
test sherlock::name_sherlock_holmes          ... bench:      48,097 ns/iter (+/- 5,856) = 12369 MB/s
test sherlock::name_sherlock_holmes_nocase   ... bench:      50,787 ns/iter (+/- 4,627) = 11714 MB/s
test sherlock::name_sherlock_nocase          ... bench:      58,680 ns/iter (+/- 8,080) = 10138 MB/s
test sherlock::name_whitespace               ... bench:     120,073 ns/iter (+/- 17,443) = 4954 MB/s
test sherlock::no_match_common               ... bench:      35,147 ns/iter (+/- 4,386) = 16926 MB/s
test sherlock::no_match_really_common        ... bench:      37,740 ns/iter (+/- 5,557) = 15763 MB/s
test sherlock::no_match_uncommon             ... bench:      34,812 ns/iter (+/- 4,135) = 17089 MB/s
test sherlock::quotes                        ... FAILED
test sherlock::repeated_class_negation       ... bench:   1,866,506 ns/iter (+/- 220,589) = 318 MB/s
test sherlock::the_lower                     ... bench:     290,255 ns/iter (+/- 16,425) = 2049 MB/s
test sherlock::the_nocase                    ... bench:     332,620 ns/iter (+/- 34,718) = 1788 MB/s
test sherlock::the_upper                     ... bench:      62,563 ns/iter (+/- 50,150) = 9509 MB/s
test sherlock::the_whitespace                ... FAILED
test sherlock::word_ending_n                 ... bench:   1,405,705 ns/iter (+/- 229,212) = 423 MB/s
test sherlock::words                         ... FAILED

failures:

---- sherlock::before_after_holmes stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `137`,
 right: `661`', bench/src/sherlock.rs:165:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102ed8cd0 - test::ns_iter_inner::h65421b9e2859f157
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102eeb3a1 - test::Bencher::iter::h94e94ab330a6a9ce
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0bf4e - bench::sherlock::before_after_holmes::h0340c09a723e00aa
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::everything_greedy stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `13053`,
 right: `594934`', bench/src/sherlock.rs:111:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102ed9940 - test::ns_iter_inner::h981951c478a014d6
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102eecea1 - test::Bencher::iter::hb7a5f75074b3f034
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0b3ee - bench::sherlock::everything_greedy::h8acdeebc3b6b9270
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::everything_greedy_nl stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `594934`', bench/src/sherlock.rs:125:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102edbb7d - test::ns_iter_inner::hee0ecebd39d0b308
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102edfae1 - test::Bencher::iter::h1ed453ca0b63dcb8
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0b58e - bench::sherlock::everything_greedy_nl::he745035c7a4538f0
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::holmes_coword_watson stdout ----
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ParseError(ParseIntError { kind: InvalidDigit })', libcore/result.rs:945:5
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x10322c372 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:328
   7:        0x10326e895 - <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::hc90ce869b180db5d
                               at libcore/panicking.rs:71
   8:        0x102f0fa9d - core::result::unwrap_failed::h65a2f1e33779de1c
                               at /Users/travis/build/rust-lang/rust/src/libcore/macros.rs:26
   9:        0x102ef7c70 - std::sync::once::Once::call_once::{{closure}}::h41dd2ede8e633a45
                               at /Users/travis/build/rust-lang/rust/src/libcore/result.rs:782
                               at bench/src/sherlock.rs:183
                               at /Users/travis/build/rust-lang/rust/src/libcore/ops/function.rs:223
                               at /Users/flier/.cargo/registry/src/mirrors.ustc.edu.cn-61ef6e0cd06fb9b8/lazy_static-1.0.0/src/lazy.rs:24
                               at /Users/travis/build/rust-lang/rust/src/libstd/sync/once.rs:227
  10:        0x103238e5f - std::sync::once::Once::call_once::{{closure}}::hdf127557e05b632b
                               at libstd/sync/once.rs:340
  11:        0x102f0c2fe - bench::sherlock::holmes_coword_watson::h49292dc38ddb5a19
                               at /Users/travis/build/rust-lang/rust/src/libstd/sync/once.rs:227
                               at /Users/flier/.cargo/registry/src/mirrors.ustc.edu.cn-61ef6e0cd06fb9b8/lazy_static-1.0.0/src/lazy.rs:23
                               at /Users/flier/github/rust-regex/<__lazy_static_internal macros>:13
                               at /Users/flier/github/rust-regex/<__lazy_static_internal macros>:14
                               at bench/src/bench.rs:235
  12:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  13:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  14:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  15:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  16:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  17:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  18:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  19:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  20:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  21:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  22:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  23:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::ing_suffix stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `2824`,
 right: `2843`', bench/src/sherlock.rs:237:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102ed9f70 - test::ns_iter_inner::ha565116217fa05b4
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102ef0421 - test::Bencher::iter::hea79b315a6870dfc
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0caae - bench::sherlock::ing_suffix::hf3d5e444eff85eb0
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::ing_suffix_limited_space stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `2081`,
 right: `2100`', bench/src/sherlock.rs:245:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102edb220 - test::ns_iter_inner::hcf9cda6e26419bdc
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102ef0161 - test::Bencher::iter::he0ed14692015fa9c
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0cc4e - bench::sherlock::ing_suffix_limited_space::hcdd268757bf86909
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::letters stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `447160`,
 right: `447161`', bench/src/sherlock.rs:133:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102ed8820 - test::ns_iter_inner::h5de977f7f6bd1b6e
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102ef2961 - test::Bencher::iter::hfa161b87cdebe37b
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0b72e - bench::sherlock::letters::h688ad6c8c753599f
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::letters_lower stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `432980`,
 right: `432966`', bench/src/sherlock.rs:145:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102ed76f0 - test::ns_iter_inner::h23960180495961d4
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102eed9a1 - test::Bencher::iter::hc6e5be891c865942
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0ba6e - bench::sherlock::letters_lower::he153b4b0699dfd2a
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::letters_upper stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `14180`,
 right: `14195`', bench/src/sherlock.rs:139:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102ed7ba0 - test::ns_iter_inner::h379c858cd051dd96
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102ee8361 - test::Bencher::iter::h6f73b19261453f28
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0b8ce - bench::sherlock::letters_upper::hefb78695002ca393
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::name_alt4 stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `582`,
 right: `1843`', bench/src/sherlock.rs:72:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102ed81e0 - test::ns_iter_inner::h5336f574e5c991d4
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102ee3b61 - test::Bencher::iter::h460b5779cad1c014
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0a20e - bench::sherlock::name_alt4::hc1e58cf3a754c3e8
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::name_alt4_nocase stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `697`,
 right: `2055`', bench/src/sherlock.rs:75:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102ed6a70 - test::ns_iter_inner::h06415a06d1cc2282
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102ef2c21 - test::Bencher::iter::hfa9ad9eac9a1ef67
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0a3ae - bench::sherlock::name_alt4_nocase::h8903ab7381f02c02
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::quotes stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `767`,
 right: `768`', bench/src/sherlock.rs:191:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102ed8500 - test::ns_iter_inner::h5ab88b808eb1f590
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102ee7b61 - test::Bencher::iter::h6f11619504e1a1cc
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0c42e - bench::sherlock::quotes::h4a230362c6af4947
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::the_whitespace stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `5410`,
 right: `31313`', bench/src/sherlock.rs:101:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102edb9f0 - test::ns_iter_inner::hedcf7977d86faf4b
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102eded21 - test::Bencher::iter::h17198ec6958c5c0b
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0b24e - bench::sherlock::the_whitespace::haa29a86fa47b9120
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::words stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `109214`,
 right: `447639`', bench/src/sherlock.rs:151:1
stack backtrace:
   0:        0x10323807f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x103227f8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x10322c1b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10322be8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x10322c831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x10322c3b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x102edaa50 - test::ns_iter_inner::hc0d5517465529275
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x102edf561 - test::Bencher::iter::h19640c882e2c310e
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x102f0bc0e - bench::sherlock::words::h76fa58767cf05ff5
                               at bench/src/bench.rs:238
   9:        0x102f387a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x102f27189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x102f1a23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x102f16de8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x102f12541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x102f12870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x102f05075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x10322c2d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x103246d7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x10322f5e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x102f04d8b - bench::__test::main::hab4f97e114b20800


failures:
    sherlock::before_after_holmes
    sherlock::everything_greedy
    sherlock::everything_greedy_nl
    sherlock::holmes_coword_watson
    sherlock::ing_suffix
    sherlock::ing_suffix_limited_space
    sherlock::letters
    sherlock::letters_lower
    sherlock::letters_upper
    sherlock::name_alt4
    sherlock::name_alt4_nocase
    sherlock::quotes
    sherlock::the_whitespace
    sherlock::words

test result: FAILED. 0 passed; 14 failed; 0 ignored; 83 measured; 0 filtered out

error: bench failed
 flier@iMac  ~/github/rust-regex/bench   vs_hyperscan ✚ ● ⍟1  cargo +nightly bench --bench bench --features re-hyperscan
warning: An explicit [[test]] section is specified in Cargo.toml which currently
disables Cargo from automatically inferring other test targets.
This inference behavior will change in the Rust 2018 edition and the following
files will be included as a test target:

* /Users/flier/github/rust-regex/tests/searcher.rs
* /Users/flier/github/rust-regex/tests/word_boundary_unicode.rs
* /Users/flier/github/rust-regex/tests/flags.rs
* /Users/flier/github/rust-regex/tests/crazy.rs
* /Users/flier/github/rust-regex/tests/regression.rs
* /Users/flier/github/rust-regex/tests/unicode.rs
* /Users/flier/github/rust-regex/tests/word_boundary_ascii.rs
* /Users/flier/github/rust-regex/tests/word_boundary.rs
* /Users/flier/github/rust-regex/tests/misc.rs
* /Users/flier/github/rust-regex/tests/noparse.rs
* /Users/flier/github/rust-regex/tests/replace.rs
* /Users/flier/github/rust-regex/tests/api_str.rs
* /Users/flier/github/rust-regex/tests/fowler.rs
* /Users/flier/github/rust-regex/tests/set.rs
* /Users/flier/github/rust-regex/tests/bytes.rs
* /Users/flier/github/rust-regex/tests/macros.rs
* /Users/flier/github/rust-regex/tests/suffix_reverse.rs
* /Users/flier/github/rust-regex/tests/shortest_match.rs
* /Users/flier/github/rust-regex/tests/macros_str.rs
* /Users/flier/github/rust-regex/tests/api.rs
* /Users/flier/github/rust-regex/tests/multiline.rs
* /Users/flier/github/rust-regex/tests/macros_bytes.rs

This is likely to break cargo build or cargo test as these files may not be
ready to be compiled as a test target today. You can future-proof yourself
and disable this warning by adding `autotests = false` to your [package]
section. You may also move the files to a location where Cargo would not
automatically infer them to be a target, such as in subfolders.

For more information on this warning you can consult
https://github.com/rust-lang/cargo/issues/5330
   Compiling regex-benchmark v0.1.0 (file:///Users/flier/github/rust-regex/bench)
    Finished release [optimized + debuginfo] target(s) in 9.57s
     Running /Users/flier/github/rust-regex/target/release/deps/bench-814c4e1c233c34d2

running 97 tests
test misc::anchored_literal_long_match       ... bench:         284 ns/iter (+/- 34) = 1373 MB/s
test misc::anchored_literal_long_non_match   ... bench:          81 ns/iter (+/- 11) = 4814 MB/s
test misc::anchored_literal_short_match      ... bench:          95 ns/iter (+/- 14) = 273 MB/s
test misc::anchored_literal_short_non_match  ... bench:          41 ns/iter (+/- 3) = 634 MB/s
test misc::easy0_1K                          ... bench:         228 ns/iter (+/- 17) = 4609 MB/s
test misc::easy0_1MB                         ... bench:      60,018 ns/iter (+/- 2,886) = 17471 MB/s
test misc::easy0_32                          ... bench:         137 ns/iter (+/- 13) = 430 MB/s
test misc::easy0_32K                         ... bench:       2,036 ns/iter (+/- 112) = 16107 MB/s
test misc::easy1_1K                          ... bench:         251 ns/iter (+/- 37) = 4159 MB/s
test misc::easy1_1MB                         ... bench:      53,692 ns/iter (+/- 11,392) = 19529 MB/s
test misc::easy1_32                          ... bench:         141 ns/iter (+/- 106) = 368 MB/s
test misc::easy1_32K                         ... bench:       1,841 ns/iter (+/- 223) = 17809 MB/s
test misc::hard_1K                           ... bench:         238 ns/iter (+/- 29) = 4415 MB/s
test misc::hard_1MB                          ... bench:      60,544 ns/iter (+/- 4,481) = 17319 MB/s
test misc::hard_32                           ... bench:         137 ns/iter (+/- 11) = 430 MB/s
test misc::hard_32K                          ... bench:       2,067 ns/iter (+/- 390) = 15865 MB/s
test misc::literal                           ... bench:          76 ns/iter (+/- 5) = 671 MB/s
test misc::long_needle1                      ... bench:       5,834 ns/iter (+/- 697) = 17141 MB/s
test misc::long_needle2                      ... bench:       5,808 ns/iter (+/- 465) = 17217 MB/s
test misc::match_class                       ... bench:         100 ns/iter (+/- 6) = 810 MB/s
test misc::match_class_in_range              ... bench:         101 ns/iter (+/- 8) = 801 MB/s
test misc::match_class_unicode               ... bench:       1,136 ns/iter (+/- 74) = 141 MB/s
test misc::medium_1K                         ... bench:         240 ns/iter (+/- 36) = 4383 MB/s
test misc::medium_1MB                        ... bench:      60,154 ns/iter (+/- 2,539) = 17431 MB/s
test misc::medium_32                         ... bench:         143 ns/iter (+/- 25) = 419 MB/s
test misc::medium_32K                        ... bench:       2,060 ns/iter (+/- 153) = 15920 MB/s
test misc::no_exponential                    ... bench:       1,241 ns/iter (+/- 234) = 80 MB/s
test misc::not_literal                       ... bench:         111 ns/iter (+/- 7) = 459 MB/s
test misc::one_pass_long_prefix              ... bench:         125 ns/iter (+/- 18) = 208 MB/s
test misc::one_pass_long_prefix_not          ... bench:         128 ns/iter (+/- 27) = 203 MB/s
test misc::one_pass_short                    ... bench:         108 ns/iter (+/- 3) = 157 MB/s
test misc::one_pass_short_not                ... bench:         111 ns/iter (+/- 10) = 153 MB/s
test misc::reallyhard2_1K                    ... bench:         227 ns/iter (+/- 20) = 4581 MB/s
test misc::reallyhard_1K                     ... bench:         242 ns/iter (+/- 36) = 4342 MB/s
test misc::reallyhard_1MB                    ... bench:      60,136 ns/iter (+/- 3,788) = 17437 MB/s
test misc::reallyhard_32                     ... bench:         185 ns/iter (+/- 37) = 318 MB/s
test misc::reallyhard_32K                    ... bench:       2,075 ns/iter (+/- 88) = 15804 MB/s
test misc::reverse_suffix_no_quadratic       ... bench:      34,269 ns/iter (+/- 1,211) = 233 MB/s
test regexdna::find_new_lines                ... bench:   2,684,786 ns/iter (+/- 140,733) = 1893 MB/s
test regexdna::subst1                        ... bench:     842,428 ns/iter (+/- 78,350) = 6034 MB/s
test regexdna::subst10                       ... bench:     838,340 ns/iter (+/- 40,822) = 6063 MB/s
test regexdna::subst11                       ... bench:     854,228 ns/iter (+/- 80,452) = 5950 MB/s
test regexdna::subst2                        ... bench:     899,290 ns/iter (+/- 189,399) = 5652 MB/s
test regexdna::subst3                        ... bench:     847,387 ns/iter (+/- 90,354) = 5998 MB/s
test regexdna::subst4                        ... bench:     843,568 ns/iter (+/- 49,176) = 6026 MB/s
test regexdna::subst5                        ... bench:     843,977 ns/iter (+/- 76,801) = 6023 MB/s
test regexdna::subst6                        ... bench:     837,329 ns/iter (+/- 43,516) = 6070 MB/s
test regexdna::subst7                        ... bench:     849,430 ns/iter (+/- 74,025) = 5984 MB/s
test regexdna::subst8                        ... bench:     839,824 ns/iter (+/- 49,560) = 6052 MB/s
test regexdna::subst9                        ... bench:     850,139 ns/iter (+/- 91,575) = 5979 MB/s
test regexdna::variant1                      ... bench:   2,718,479 ns/iter (+/- 300,738) = 1869 MB/s
test regexdna::variant2                      ... bench:   3,319,738 ns/iter (+/- 119,956) = 1531 MB/s
test regexdna::variant3                      ... bench:   3,734,937 ns/iter (+/- 180,457) = 1361 MB/s
test regexdna::variant4                      ... bench:   3,694,889 ns/iter (+/- 150,309) = 1375 MB/s
test regexdna::variant5                      ... bench:   2,915,103 ns/iter (+/- 1,245,680) = 1743 MB/s
test regexdna::variant6                      ... bench:   3,176,650 ns/iter (+/- 397,150) = 1600 MB/s
test regexdna::variant7                      ... bench:   3,983,374 ns/iter (+/- 979,943) = 1276 MB/s
test regexdna::variant8                      ... bench:   3,929,608 ns/iter (+/- 799,205) = 1293 MB/s
test regexdna::variant9                      ... bench:   4,031,356 ns/iter (+/- 660,319) = 1260 MB/s
test sherlock::before_after_holmes           ... FAILED
test sherlock::before_holmes                 ... bench:      71,879 ns/iter (+/- 6,559) = 8276 MB/s
test sherlock::everything_greedy             ... FAILED
test sherlock::everything_greedy_nl          ... FAILED
test sherlock::holmes_cochar_watson          ... bench:     128,774 ns/iter (+/- 11,662) = 4619 MB/s
test sherlock::holmes_coword_watson          ... FAILED
test sherlock::ing_suffix                    ... FAILED
test sherlock::ing_suffix_limited_space      ... FAILED
test sherlock::letters                       ... FAILED
test sherlock::letters_lower                 ... FAILED
test sherlock::letters_upper                 ... FAILED
test sherlock::line_boundary_sherlock_holmes ... bench:     103,979 ns/iter (+/- 23,969) = 5721 MB/s
test sherlock::name_alt1                     ... bench:     103,346 ns/iter (+/- 6,207) = 5756 MB/s
test sherlock::name_alt2                     ... bench:     125,803 ns/iter (+/- 16,600) = 4729 MB/s
test sherlock::name_alt3                     ... bench:     134,874 ns/iter (+/- 8,688) = 4411 MB/s
test sherlock::name_alt3_nocase              ... bench:     133,322 ns/iter (+/- 8,766) = 4462 MB/s
test sherlock::name_alt4                     ... FAILED
test sherlock::name_alt4_nocase              ... FAILED
test sherlock::name_alt5                     ... bench:     123,791 ns/iter (+/- 7,777) = 4805 MB/s
test sherlock::name_alt5_nocase              ... bench:     127,589 ns/iter (+/- 11,340) = 4662 MB/s
test sherlock::name_holmes                   ... bench:      50,642 ns/iter (+/- 8,778) = 11747 MB/s
test sherlock::name_holmes_nocase            ... bench:      83,641 ns/iter (+/- 85,775) = 7112 MB/s
test sherlock::name_sherlock                 ... bench:      39,935 ns/iter (+/- 5,690) = 14897 MB/s
test sherlock::name_sherlock_holmes          ... bench:      53,747 ns/iter (+/- 37,905) = 11069 MB/s
test sherlock::name_sherlock_holmes_nocase   ... bench:      53,803 ns/iter (+/- 3,703) = 11057 MB/s
test sherlock::name_sherlock_nocase          ... bench:      60,486 ns/iter (+/- 11,189) = 9835 MB/s
test sherlock::name_whitespace               ... bench:     121,188 ns/iter (+/- 39,554) = 4909 MB/s
test sherlock::no_match_common               ... bench:      34,287 ns/iter (+/- 3,459) = 17351 MB/s
test sherlock::no_match_really_common        ... bench:      34,919 ns/iter (+/- 7,611) = 17037 MB/s
test sherlock::no_match_uncommon             ... bench:      34,585 ns/iter (+/- 1,993) = 17202 MB/s
test sherlock::quotes                        ... FAILED
test sherlock::repeated_class_negation       ... bench:   1,854,572 ns/iter (+/- 71,851) = 320 MB/s
test sherlock::the_lower                     ... bench:     292,491 ns/iter (+/- 29,402) = 2034 MB/s
test sherlock::the_nocase                    ... bench:     350,185 ns/iter (+/- 45,123) = 1698 MB/s
test sherlock::the_upper                     ... bench:      58,855 ns/iter (+/- 16,457) = 10108 MB/s
test sherlock::the_whitespace                ... FAILED
test sherlock::word_ending_n                 ... bench:   1,494,059 ns/iter (+/- 237,967) = 398 MB/s
test sherlock::words                         ... FAILED

failures:

---- sherlock::before_after_holmes stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `137`,
 right: `661`', bench/src/sherlock.rs:165:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055eccd0 - test::ns_iter_inner::h65421b9e2859f157
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x1055ff3a1 - test::Bencher::iter::h94e94ab330a6a9ce
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x10561ff4e - bench::sherlock::before_after_holmes::h0340c09a723e00aa
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::everything_greedy stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `13053`,
 right: `594934`', bench/src/sherlock.rs:111:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055ed940 - test::ns_iter_inner::h981951c478a014d6
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x105600ea1 - test::Bencher::iter::hb7a5f75074b3f034
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x10561f3ee - bench::sherlock::everything_greedy::h8acdeebc3b6b9270
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::everything_greedy_nl stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `594934`', bench/src/sherlock.rs:125:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055efb7d - test::ns_iter_inner::hee0ecebd39d0b308
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x1055f3ae1 - test::Bencher::iter::h1ed453ca0b63dcb8
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x10561f58e - bench::sherlock::everything_greedy_nl::he745035c7a4538f0
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::holmes_coword_watson stdout ----
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ParseError(ParseIntError { kind: InvalidDigit })', libcore/result.rs:945:5
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x105940372 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:328
   7:        0x105982895 - <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::hc90ce869b180db5d
                               at libcore/panicking.rs:71
   8:        0x105623a9d - core::result::unwrap_failed::h65a2f1e33779de1c
                               at /Users/travis/build/rust-lang/rust/src/libcore/macros.rs:26
   9:        0x10560bc70 - std::sync::once::Once::call_once::{{closure}}::h41dd2ede8e633a45
                               at /Users/travis/build/rust-lang/rust/src/libcore/result.rs:782
                               at bench/src/sherlock.rs:183
                               at /Users/travis/build/rust-lang/rust/src/libcore/ops/function.rs:223
                               at /Users/flier/.cargo/registry/src/mirrors.ustc.edu.cn-61ef6e0cd06fb9b8/lazy_static-1.0.0/src/lazy.rs:24
                               at /Users/travis/build/rust-lang/rust/src/libstd/sync/once.rs:227
  10:        0x10594ce5f - std::sync::once::Once::call_once::{{closure}}::hdf127557e05b632b
                               at libstd/sync/once.rs:340
  11:        0x1056202fe - bench::sherlock::holmes_coword_watson::h49292dc38ddb5a19
                               at /Users/travis/build/rust-lang/rust/src/libstd/sync/once.rs:227
                               at /Users/flier/.cargo/registry/src/mirrors.ustc.edu.cn-61ef6e0cd06fb9b8/lazy_static-1.0.0/src/lazy.rs:23
                               at /Users/flier/github/rust-regex/<__lazy_static_internal macros>:13
                               at /Users/flier/github/rust-regex/<__lazy_static_internal macros>:14
                               at bench/src/bench.rs:235
  12:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  13:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  14:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  15:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  16:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  17:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  18:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  19:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  20:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  21:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  22:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  23:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::ing_suffix stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `2824`,
 right: `2843`', bench/src/sherlock.rs:237:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055edf70 - test::ns_iter_inner::ha565116217fa05b4
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x105604421 - test::Bencher::iter::hea79b315a6870dfc
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x105620aae - bench::sherlock::ing_suffix::hf3d5e444eff85eb0
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::ing_suffix_limited_space stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `2081`,
 right: `2100`', bench/src/sherlock.rs:245:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055ef220 - test::ns_iter_inner::hcf9cda6e26419bdc
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x105604161 - test::Bencher::iter::he0ed14692015fa9c
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x105620c4e - bench::sherlock::ing_suffix_limited_space::hcdd268757bf86909
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::letters stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `447160`,
 right: `447161`', bench/src/sherlock.rs:133:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055ec820 - test::ns_iter_inner::h5de977f7f6bd1b6e
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x105606961 - test::Bencher::iter::hfa161b87cdebe37b
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x10561f72e - bench::sherlock::letters::h688ad6c8c753599f
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::letters_lower stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `432980`,
 right: `432966`', bench/src/sherlock.rs:145:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055eb6f0 - test::ns_iter_inner::h23960180495961d4
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x1056019a1 - test::Bencher::iter::hc6e5be891c865942
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x10561fa6e - bench::sherlock::letters_lower::he153b4b0699dfd2a
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::letters_upper stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `14180`,
 right: `14195`', bench/src/sherlock.rs:139:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055ebba0 - test::ns_iter_inner::h379c858cd051dd96
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x1055fc361 - test::Bencher::iter::h6f73b19261453f28
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x10561f8ce - bench::sherlock::letters_upper::hefb78695002ca393
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::name_alt4 stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `582`,
 right: `1843`', bench/src/sherlock.rs:72:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055ec1e0 - test::ns_iter_inner::h5336f574e5c991d4
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x1055f7b61 - test::Bencher::iter::h460b5779cad1c014
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x10561e20e - bench::sherlock::name_alt4::hc1e58cf3a754c3e8
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::name_alt4_nocase stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `697`,
 right: `2055`', bench/src/sherlock.rs:75:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055eaa70 - test::ns_iter_inner::h06415a06d1cc2282
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x105606c21 - test::Bencher::iter::hfa9ad9eac9a1ef67
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x10561e3ae - bench::sherlock::name_alt4_nocase::h8903ab7381f02c02
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::quotes stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `767`,
 right: `768`', bench/src/sherlock.rs:191:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055ec500 - test::ns_iter_inner::h5ab88b808eb1f590
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x1055fbb61 - test::Bencher::iter::h6f11619504e1a1cc
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x10562042e - bench::sherlock::quotes::h4a230362c6af4947
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::the_whitespace stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `5410`,
 right: `31313`', bench/src/sherlock.rs:101:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055ef9f0 - test::ns_iter_inner::hedcf7977d86faf4b
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x1055f2d21 - test::Bencher::iter::h17198ec6958c5c0b
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x10561f24e - bench::sherlock::the_whitespace::haa29a86fa47b9120
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800

---- sherlock::words stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `109214`,
 right: `447639`', bench/src/sherlock.rs:151:1
stack backtrace:
   0:        0x10594c07f - std::sys::unix::backtrace::tracing::imp::unwind_backtrace::he87cad97a036c64d
                               at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1:        0x10593bf8d - std::sys_common::backtrace::print::hefa8238944e278aa
                               at libstd/sys_common/backtrace.rs:71
                               at libstd/sys_common/backtrace.rs:59
   2:        0x1059401b1 - std::panicking::default_hook::{{closure}}::h685b29b05b0202fb
                               at libstd/panicking.rs:211
   3:        0x10593fe8b - std::panicking::default_hook::hc7e9600ac4967b32
                               at libstd/panicking.rs:221
   4:        0x105940831 - <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get::h764ea4b9d403b11f
                               at libstd/panicking.rs:463
   5:        0x1059403b0 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/panicking.rs:350
   6:        0x1055eea50 - test::ns_iter_inner::hc0d5517465529275
                               at bench/src/bench.rs:240
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1574
   7:        0x1055f3561 - test::Bencher::iter::h19640c882e2c310e
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1584
                               at /Users/travis/build/rust-lang/rust/src/libtest/lib.rs:1552
   8:        0x10561fc0e - bench::sherlock::words::h76fa58767cf05ff5
                               at bench/src/bench.rs:238
   9:        0x10564c7a5 - std::panicking::try::do_call::h15762d5ca2afa544
                               at libtest/lib.rs:1440
                               at libtest/lib.rs:1559
                               at libtest/lib.rs:1677
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:305
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:310
  10:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  11:        0x10563b189 - test::bench::benchmark::h0a852d58848e271b
                               at /Users/travis/build/rust-lang/rust/src/libstd/panicking.rs:289
                               at /Users/travis/build/rust-lang/rust/src/libstd/panic.rs:374
                               at libtest/lib.rs:1677
  12:        0x10562e23b - test::run_tests_console::{{closure}}::hcf4c6e8a4bb67709
                               at libtest/lib.rs:1439
  13:        0x10562ade8 - test::fmt_thousands_sep::hd0003a5ac433bc79
                               at libtest/lib.rs:1153
                               at libtest/lib.rs:923
  14:        0x105626541 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:285
  15:        0x105626870 - <alloc::string::String as core::fmt::Display>::fmt::hbf6d3b53704c5544
                               at libtest/lib.rs:319
  16:        0x105619075 - std::rt::lang_start::{{closure}}::hdbc08a163f242f53
                               at /Users/travis/build/rust-lang/rust/src/libstd/rt.rs:74
  17:        0x1059402d7 - std::panicking::try::do_call::hfd75cf9e05cc5943
                               at libstd/rt.rs:59
                               at libstd/panicking.rs:310
  18:        0x10595ad7e - panic_unwind::dwarf::eh::read_encoded_pointer::hfc4eff335740b497
                               at libpanic_unwind/lib.rs:105
  19:        0x1059435e1 - std::sys_common::cleanup::hb7ec9cd3edb2c988
                               at libstd/panicking.rs:289
                               at libstd/panic.rs:374
                               at libstd/rt.rs:58
  20:        0x105618d8b - bench::__test::main::hab4f97e114b20800


failures:
    sherlock::before_after_holmes
    sherlock::everything_greedy
    sherlock::everything_greedy_nl
    sherlock::holmes_coword_watson
    sherlock::ing_suffix
    sherlock::ing_suffix_limited_space
    sherlock::letters
    sherlock::letters_lower
    sherlock::letters_upper
    sherlock::name_alt4
    sherlock::name_alt4_nocase
    sherlock::quotes
    sherlock::the_whitespace
    sherlock::words

test result: FAILED. 0 passed; 14 failed; 0 ignored; 83 measured; 0 filtered out