### PR TITLE
regex: implement size_hint for set match iterators

### DIFF
--- a/src/re_set.rs
+++ b/src/re_set.rs
@@ -295,6 +295,10 @@ impl Iterator for SetMatchesIntoIter {
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint() 
+    }
 }
 
 impl DoubleEndedIterator for SetMatchesIntoIter {
@@ -330,6 +334,10 @@ impl<'a> Iterator for SetMatchesIter<'a> {
                 Some((i, &true)) => return Some(i),
             }
         }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint() 
     }
 }
 


### PR DESCRIPTION
Implementing `size_hint` for `SetMatchesIntoIter` and `SetMatchesIter` by just passing through the hint from the underlying iterators.

I've refrained from implementing `ExactSizeIterator` for these two types because I wasn't sure whether you'd be okay committing to this API.