### PR TITLE
update some debs mostly for minimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ aho-corasick = "0.6.0"
 # For skipping along search text quickly when a leading byte is known.
 memchr = "2.0.0"
 # For managing regex caches quickly across multiple threads.
-thread_local = "0.3.2"
+thread_local = "0.3.6"
 # For parsing regular expressions.
 regex-syntax = { path = "regex-syntax", version = "0.6.0" }
 # For compiling UTF-8 decoding into automata.

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -12,12 +12,12 @@ build = "build.rs"
 workspace = ".."
 
 [dependencies]
-docopt = "0.8"
+docopt = "1"
 lazy_static = "1"
 libc = "0.2"
 onig = { version = "3", optional = true }
 libpcre-sys = { version = "0.2", optional = true }
-memmap = "0.6"
+memmap = "0.6.2"
 regex = { version = "1", path = ".." }
 regex-syntax = { version = "0.6.0", path = "../regex-syntax" }
 serde = "1"


### PR DESCRIPTION
This bumps the minimal acceptable versions in Cargo.toml to versions that are compatible with `-Z minimal-versions`. This is part of the process of seeing how hard this is for crates to use in preparation for getting it stabilized for use in CI, specifically upstreaming the changes required to get criterion working with it. It is easy to use if all of your dependencies support it, but much harder if trying to impose it on them.

I am not sure I have this exactly correct. There may be more things that need to be updated for the benchmarking code to work with minimal-versions. I was not able to test with all the feachers. But I have verified that `docopt` can be made to work with this change to `regex`. So it is a step in the correct direction.