### PR TITLE
perf: Improve dfa matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: required
 language: rust
 rust:
-  - 1.20.0
+  - 1.21.0
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ recommended for general use.
 
 ### Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.20.0`.
+This crate's minimum supported `rustc` version is `1.21.0`.
 
 The current **tentative** policy is that the minimum Rust version required
 to use this crate can be increased in minor version updates. For example, if

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -44,9 +44,9 @@ pub use ffi::re2::Regex;
 #[cfg(feature = "re-dphobos")]
 pub use ffi::d_phobos::Regex;
 #[cfg(feature = "re-rust")]
-pub use regex::Regex;
+pub use regex::{Regex, RegexSet};
 #[cfg(feature = "re-rust-bytes")]
-pub use regex::bytes::Regex;
+pub use regex::bytes::{Regex, RegexSet};
 #[cfg(feature = "re-tcl")]
 pub use ffi::tcl::Regex;
 
@@ -266,6 +266,56 @@ macro_rules! bench_captures {
                 match re.captures(&text) {
                     None => assert!(false, "no captures"),
                     Some(caps) => assert_eq!($count + 1, caps.len()),
+                }
+            });
+        }
+    }
+}
+
+macro_rules! bench_is_match_set {
+    ($name:ident, $is_match:expr, $re:expr, $haystack:expr) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            use std::sync::Mutex;
+            lazy_static! {
+                static ref RE: Mutex<RegexSet> = Mutex::new($re);
+                static ref TEXT: Mutex<Text> = Mutex::new(text!($haystack));
+            };
+            let re = RE.lock().unwrap();
+            let text = TEXT.lock().unwrap();
+            b.bytes = text.len() as u64;
+            b.iter(|| {
+                if re.is_match(&text) != $is_match {
+                    if $is_match {
+                        panic!("expected match, got not match");
+                    } else {
+                        panic!("expected no match, got match");
+                    }
+                }
+            });
+        }
+    }
+}
+
+macro_rules! bench_matches_set {
+    ($name:ident, $is_match:expr, $re:expr, $haystack:expr) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            use std::sync::Mutex;
+            lazy_static! {
+                static ref RE: Mutex<RegexSet> = Mutex::new($re);
+                static ref TEXT: Mutex<Text> = Mutex::new(text!($haystack));
+            };
+            let re = RE.lock().unwrap();
+            let text = TEXT.lock().unwrap();
+            b.bytes = text.len() as u64;
+            b.iter(|| {
+                if re.matches(&text).matched_any() != $is_match {
+                    if $is_match {
+                        panic!("expected match, got not match");
+                    } else {
+                        panic!("expected no match, got match");
+                    }
                 }
             });
         }

--- a/bench/src/misc.rs
+++ b/bench/src/misc.rs
@@ -14,7 +14,7 @@ use std::iter::repeat;
 
 use test::Bencher;
 
-use {Regex, Text};
+use {Regex, RegexSet, Text};
 
 #[cfg(not(feature = "re-onig"))]
 #[cfg(not(feature = "re-pcre1"))]
@@ -278,3 +278,21 @@ bench_captures!(short_haystack_1000000x,
             repeat("aaaa").take(1000000).collect::<String>(),
             repeat("dddd").take(1000000).collect::<String>(),
             ));
+
+#[cfg(any(feature = "re-rust", feature = "re-rust-bytes"))]
+bench_is_match_set!(is_match_set,
+    true,
+    RegexSet::new(vec!["aaaaaaaaaaaaaaaaaaa", "abc579", "def.+", "e24fg", "a.*2c", "23."]).unwrap(),
+    format!("{}a482c{}",
+            repeat('a').take(10).collect::<String>(),
+            repeat('b').take(10).collect::<String>())
+    );
+
+#[cfg(any(feature = "re-rust", feature = "re-rust-bytes"))]
+bench_matches_set!(matches_set,
+    true,
+    RegexSet::new(vec!["aaaaaaaaaaaaaaaaaaa", "abc579", "def.+", "e24fg", "a.*2c", "23."]).unwrap(),
+    format!("{}a482c{}",
+            repeat('a').take(10).collect::<String>(),
+            repeat('b').take(10).collect::<String>())
+    );

--- a/bench/src/misc.rs
+++ b/bench/src/misc.rs
@@ -14,7 +14,9 @@ use std::iter::repeat;
 
 use test::Bencher;
 
-use {Regex, RegexSet, Text};
+#[cfg(any(feature = "re-rust", feature = "re-rust-bytes"))]
+use RegexSet;
+use {Regex, Text};
 
 #[cfg(not(feature = "re-onig"))]
 #[cfg(not(feature = "re-pcre1"))]

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,7 +3,7 @@
 # This is the main CI script for testing the regex crate and its sub-crates.
 
 set -ex
-MSRV="1.20.0"
+MSRV="1.21.0"
 
 # If we're building on 1.20, then lazy_static 1.2 will fail to build since it
 # updated its MSRV to 1.24.1. In this case, we force the use of lazy_static 1.1

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -47,14 +47,16 @@ implementation.)
 */
 
 use std::borrow::Borrow;
-use std::collections::HashMap;
 use std::fmt;
 use std::iter::repeat;
 use std::mem;
+use std::sync::Arc;
 
 use exec::ProgramCache;
 use prog::{Inst, Program};
 use sparse::SparseSet;
+
+use self::state_map::StateMap;
 
 /// Return true if and only if the given program can be executed by a DFA.
 ///
@@ -118,7 +120,7 @@ struct CacheInner {
     /// things, we just pass indexes around manually. The performance impact of
     /// this is probably an instruction or two in the inner loop. However, on
     /// 64 bit, each StatePtr is half the size of a *State.
-    compiled: HashMap<State, StatePtr>,
+    compiled: StateMap,
     /// The transition table.
     ///
     /// The transition table is laid out in row-major order, where states are
@@ -135,9 +137,6 @@ struct CacheInner {
     /// bytes that never discriminate a distinct path through the DFA from each
     /// other.
     trans: Transitions,
-    /// Our set of states. Note that `StatePtr / num_byte_classes` indexes
-    /// this Vec rather than just a `StatePtr`.
-    states: Vec<State>,
     /// A set of cached start states, which are limited to the number of
     /// permutations of flags set just before the initial byte of input. (The
     /// index into this vec is a `EmptyFlags`.)
@@ -270,13 +269,20 @@ impl<T> Result<T> {
 /// it is packed into a single byte; Otherwise the byte 128 (-128 as an i8)
 /// is coded as a flag, followed by 4 bytes encoding the delta.
 #[derive(Clone, Eq, Hash, PartialEq)]
-struct State {
-    data: Box<[u8]>,
+pub struct State {
+    data: Arc<[u8]>,
 }
 
 impl Borrow<[u8]> for State {
     fn borrow(&self) -> &[u8] {
         &self.data
+    }
+}
+
+impl State {
+    fn heap_size(&self) -> usize {
+        // 2 * Reference counters
+        2 * mem::size_of::<usize>() + self.data.len()
     }
 }
 
@@ -437,9 +443,8 @@ impl Cache {
         let starts = vec![STATE_UNKNOWN; 256];
         let mut cache = Cache {
             inner: CacheInner {
-                compiled: HashMap::new(),
+                compiled: StateMap::new(),
                 trans: Transitions::new(num_byte_classes),
-                states: vec![],
                 start_states: starts,
                 stack: vec![],
                 flush_count: 0,
@@ -1157,7 +1162,11 @@ impl<'a> Fsm<'a> {
             Some(v) => v,
         }
         // In the cache? Cool. Done.
-        if let Some(&si) = self.cache.compiled.get(&self.cache.insts_scratch_space[..]) {
+        if let Some(si) = self
+            .cache
+            .compiled
+            .get_ptr(&self.cache.insts_scratch_space[..])
+        {
             return Some(si);
         }
 
@@ -1170,7 +1179,7 @@ impl<'a> Fsm<'a> {
         }
 
         let key = State {
-            data: self.cache.insts_scratch_space.clone().into_boxed_slice(),
+            data: Arc::from(&self.cache.insts_scratch_space[..]),
         };
         // Allocate room for our state and add it.
         self.add_state(key)
@@ -1246,7 +1255,7 @@ impl<'a> Fsm<'a> {
     /// This returns false if the cache is not cleared and the DFA should
     /// give up.
     fn clear_cache_and_save(&mut self, current_state: Option<&mut StatePtr>) -> bool {
-        if self.cache.states.is_empty() {
+        if self.cache.compiled.is_empty() {
             // Nothing to clear...
             return true;
         }
@@ -1276,7 +1285,7 @@ impl<'a> Fsm<'a> {
         // 10 or fewer bytes per state.
         // Additionally, we permit the cache to be flushed a few times before
         // caling it quits.
-        let nstates = self.cache.states.len();
+        let nstates = self.cache.compiled.len();
         if self.cache.flush_count >= 3
             && self.at >= self.last_cache_flush
             && (self.at - self.last_cache_flush) <= 10 * nstates
@@ -1296,7 +1305,6 @@ impl<'a> Fsm<'a> {
         };
         self.cache.reset_size();
         self.cache.trans.clear();
-        self.cache.states.clear();
         self.cache.compiled.clear();
         for s in &mut self.cache.start_states {
             *s = STATE_UNKNOWN;
@@ -1316,7 +1324,7 @@ impl<'a> Fsm<'a> {
     fn restore_state(&mut self, state: State) -> Option<StatePtr> {
         // If we've already stored this state, just return a pointer to it.
         // None will be the wiser.
-        if let Some(&si) = self.cache.compiled.get(&state) {
+        if let Some(si) = self.cache.compiled.get_ptr(&state.data) {
             return Some(si);
         }
         self.add_state(state)
@@ -1451,7 +1459,10 @@ impl<'a> Fsm<'a> {
 
     /// Returns a reference to a State given a pointer to it.
     fn state(&self, si: StatePtr) -> &State {
-        &self.cache.states[si as usize / self.num_byte_classes()]
+        self.cache
+            .compiled
+            .get_state(si as usize / self.num_byte_classes())
+            .unwrap()
     }
 
     /// Adds the given state to the DFA.
@@ -1483,14 +1494,12 @@ impl<'a> Fsm<'a> {
         // Finally, put our actual state on to our heap of states and index it
         // so we can find it later.
         self.cache.size += self.cache.trans.state_heap_size()
-            + (2 * state.data.len())
+            + state.heap_size()
             + (2 * mem::size_of::<State>())
             + mem::size_of::<StatePtr>();
-        self.cache.states.push(state.clone());
         self.cache.compiled.insert(state, si);
         // Transition table and set of states and map should all be in sync.
-        debug_assert!(self.cache.states.len() == self.cache.trans.num_states());
-        debug_assert!(self.cache.states.len() == self.cache.compiled.len());
+        debug_assert!(self.cache.compiled.len() == self.cache.trans.num_states());
         Some(si)
     }
 
@@ -1818,9 +1827,63 @@ fn read_varu32(data: &[u8]) -> (u32, usize) {
     (0, 0)
 }
 
+mod state_map {
+    use std::collections::HashMap;
+
+    use super::{State, StatePtr};
+
+    #[derive(Debug)]
+    pub struct StateMap {
+        /// The keys are not actually static but rely on always pointing to a buffer in `states`
+        /// which will never be moved except when clearing the map or on drop, in which case the
+        /// keys of this map will be removed before
+        map: HashMap<State, StatePtr>,
+        /// Our set of states. Note that `StatePtr / num_byte_classes` indexes
+        /// this Vec rather than just a `StatePtr`.
+        states: Vec<State>,
+    }
+
+    impl StateMap {
+        pub fn new() -> StateMap {
+            StateMap {
+                map: HashMap::new(),
+                states: Vec::new(),
+            }
+        }
+
+        pub fn len(&self) -> usize {
+            self.states.len()
+        }
+
+        pub fn is_empty(&self) -> bool {
+            self.states.is_empty()
+        }
+
+        pub fn get_ptr(&self, index: &[u8]) -> Option<StatePtr> {
+            self.map.get(index).cloned()
+        }
+
+        pub fn get_state(&self, index: usize) -> Option<&State> {
+            self.states.get(index)
+        }
+
+        pub fn insert(&mut self, state: State, si: StatePtr) {
+            self.map.insert(state.clone(), si);
+            self.states.push(state);
+        }
+
+        pub fn clear(&mut self) {
+            self.map.clear();
+            self.states.clear();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     extern crate rand;
+
+    use std::sync::Arc;
 
     use super::{
         push_inst_ptr, read_vari32, read_varu32, write_vari32, write_varu32, State, StateFlags,
@@ -1836,7 +1899,7 @@ mod tests {
                 push_inst_ptr(&mut data, &mut prev, ip);
             }
             let state = State {
-                data: data.into_boxed_slice(),
+                data: Arc::from(&data[..]),
             };
 
             let expected: Vec<usize> = ips.into_iter().map(|ip| ip as usize).collect();

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -88,7 +88,7 @@ pub fn can_exec(insts: &Program) -> bool {
 /// This cache is reused between multiple invocations of the same regex
 /// program. (It is not shared simultaneously between threads. If there is
 /// contention, then new caches are created.)
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Cache {
     /// Group persistent DFA related cache state together. The sparse sets
     /// listed below are used as scratch space while computing uncached states.
@@ -107,7 +107,7 @@ pub struct Cache {
 /// `CacheInner` is logically just a part of Cache, but groups together fields
 /// that aren't passed as function parameters throughout search. (This split
 /// is mostly an artifact of the borrow checker. It is happily paid.)
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct CacheInner {
     /// A cache of pre-compiled DFA states, keyed by the set of NFA states
     /// and the set of empty-width flags set at the byte in the input when the

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -155,6 +155,8 @@ struct CacheInner {
     /// The total heap size of the DFA's cache. We use this to determine when
     /// we should flush the cache.
     size: usize,
+
+    insts_scratch_space: Vec<u8>,   
 }
 
 /// The transition table.
@@ -435,6 +437,7 @@ impl Cache {
                 stack: vec![],
                 flush_count: 0,
                 size: 0,
+                insts_scratch_space: vec![],
             },
             qcur: SparseSet::new(prog.insts.len()),
             qnext: SparseSet::new(prog.insts.len()),
@@ -1220,7 +1223,10 @@ impl<'a> Fsm<'a> {
         // cache.
 
         // Reserve 1 byte for flags.
-        let mut insts = vec![0];
+        let mut insts = mem::replace(&mut self.cache.insts_scratch_space, Vec::new());
+        insts.clear();
+        insts.push(0);
+
         let mut prev = 0;
         for &ip in q {
             let ip = usize_to_u32(ip);
@@ -1244,13 +1250,15 @@ impl<'a> Fsm<'a> {
         // see a match when expanding NFA states previously, then this is a
         // dead state and no amount of additional input can transition out
         // of this state.
-        if insts.len() == 1 && !state_flags.is_match() {
+        let opt_state = if insts.len() == 1 && !state_flags.is_match() {
             None
         } else {
             let StateFlags(f) = *state_flags;
             insts[0] = f;
-            Some(State { data: insts.into_boxed_slice() })
-        }
+            Some(State { data: insts.clone().into_boxed_slice() })
+        };
+        self.cache.insts_scratch_space = insts;
+        opt_state
     }
 
     /// Clears the cache, but saves and restores current_state if it is not

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1271,7 +1271,7 @@ enum MatchNfaType {
 /// available to a particular program.
 pub type ProgramCache = RefCell<ProgramCacheInner>;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ProgramCacheInner {
     pub pikevm: pikevm::Cache,
     pub backtrack: backtrack::Cache,

--- a/src/prog.rs
+++ b/src/prog.rs
@@ -161,6 +161,7 @@ impl Program {
 impl Deref for Program {
     type Target = [Inst];
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         &*self.insts
     }

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -14,52 +14,49 @@ use std::slice;
 #[derive(Clone, Debug)]
 pub struct SparseSet {
     /// Dense contains the instruction pointers in the order in which they
-    /// were inserted. Accessing elements >= self.size is illegal.
+    /// were inserted.
     dense: Vec<usize>,
     /// Sparse maps instruction pointers to their location in dense.
     ///
     /// An instruction pointer is in the set if and only if
-    /// sparse[ip] < size && ip == dense[sparse[ip]].
-    sparse: Vec<usize>,
-    /// The number of elements in the set.
-    size: usize,
+    /// sparse[ip] < dense.len() && ip == dense[sparse[ip]].
+    sparse: Box<[usize]>,
 }
 
 impl SparseSet {
     pub fn new(size: usize) -> SparseSet {
         SparseSet {
-            dense: vec![0; size],
-            sparse: vec![0; size],
-            size: 0,
+            dense: Vec::with_capacity(size),
+            sparse: vec![0; size].into_boxed_slice(),
         }
     }
 
     pub fn len(&self) -> usize {
-        self.size
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.size == 0
-    }
-
-    pub fn capacity(&self) -> usize {
         self.dense.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.dense.is_empty()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.dense.capacity()
+    }
+
     pub fn insert(&mut self, value: usize) {
-        let i = self.size;
-        self.dense[i] = value;
+        let i = self.len();
+        assert!(i < self.capacity());
+        self.dense.push(value);
         self.sparse[value] = i;
-        self.size += 1;
     }
 
     pub fn contains(&self, value: usize) -> bool {
         let i = self.sparse[value];
-        i < self.size && self.dense[i] == value
+        self.dense.get(i) == Some(&value)
     }
 
     pub fn clear(&mut self) {
-        self.size = 0;
+        self.dense.clear();
     }
 }
 
@@ -67,7 +64,7 @@ impl Deref for SparseSet {
     type Target = [usize];
 
     fn deref(&self) -> &Self::Target {
-        &self.dense[0..self.size]
+        &self.dense
     }
 }
 


### PR DESCRIPTION
Various improvements from profiling `RegexSet::matches` usage.

```
 name                old ns/iter    new ns/iter    diff ns/iter   diff %  speedup 
 misc::is_match_set  73 (342 MB/s)  76 (328 MB/s)             3    4.11%   x 0.96 
 misc::matches_set   857 (29 MB/s)  604 (41 MB/s)          -253  -29.52%   x 1.42 
```