### PR TITLE
Fix typo in comment ("ocassionally")

### DIFF
--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -9,7 +9,7 @@ use std::u8;
 // The primary invariant that interval sets guards is canonical ordering. That
 // is, every interval set contains an ordered sequence of intervals where
 // no two intervals are overlapping or adjacent. While this invariant is
-// ocassionally broken within the implementation, it should be impossible for
+// occasionally broken within the implementation, it should be impossible for
 // callers to observe it.
 //
 // Since case folding (as implemented below) breaks that invariant, we roll


### PR DESCRIPTION
Just fixing a misspelled word - "ocassionally". The correct spelling is with a double "c" and single "s", i.e. "occasionally".