### PR TITLE
Add ability get receive pattern from a RegexSet

### DIFF
--- a/src/re_set.rs
+++ b/src/re_set.rs
@@ -219,9 +219,10 @@ impl RegexSet {
 
     /// Returns the patterns that this set will match on.
     ///
-    /// This function can be used to determine the match without storing it
-    /// in a seperate `Slice`. This is useful when you want to know the pattern
-    /// that matched.
+    /// This function can be used to determine the pattern for a match. The 
+    /// slice returned has exactly as many patterns givens to this regex set, 
+    /// and the order of the slice is the same as the order of the patterns 
+    /// provided to the set.
     ///
     /// # Example
     ///

--- a/src/re_set.rs
+++ b/src/re_set.rs
@@ -216,6 +216,36 @@ impl RegexSet {
     pub fn len(&self) -> usize {
         self.0.regex_strings().len()
     }
+
+    /// Returns the patterns that this set will match on.
+    ///
+    /// This function can be used to determine the match without storing it
+    /// in a seperate `Slice`. This is useful when you want to know the pattern
+    /// that matched.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use regex::RegexSet;
+    /// let set = RegexSet::new(&[
+    ///     r"\w+",
+    ///     r"\d+",
+    ///     r"\pL+",
+    ///     r"foo",
+    ///     r"bar",
+    ///     r"barfoo",
+    ///     r"foobar",
+    /// ]).unwrap();
+    /// let matches: Vec<_> = set
+    ///     .matches("foobar")
+    ///     .into_iter()
+    ///     .map(|match_idx| &set.patterns()[match_idx])
+    ///     .collect();
+    /// assert_eq!(matches, vec![r"\w+", r"\pL+", r"foo", r"bar", r"foobar"]);
+    /// ```
+    pub fn patterns(&self) -> &[String] {
+        self.0.regex_strings()
+    }
 }
 
 /// A set of matches returned by a regex set.

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -30,3 +30,9 @@ fn regression_subsequent_matches() {
     assert!(set.matches(text).matched(1));
     assert!(set.matches(text).matched(1));
 }
+
+#[test]
+fn get_set_patterns() {
+    let set = regex_set!(&["a", "b"]);
+    assert_eq!(vec!["a", "b"], set.patterns());
+}


### PR DESCRIPTION
It is useful to access the regex one provided once to the regexset(-builder).
Instead to let the user store the regex in a seperate list to index them later, one can now receive the patterns from regexset directly.

This is a followup to https://github.com/rust-lang/regex/pull/528#issuecomment-431342324 which not uses the index-trait but instead provides a seperate function `patterns` for receiving the stored patterns.