### PR TITLE
Add missing closing parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,4 +235,4 @@ at your option.
 
 The data in `regex-syntax/src/unicode_tables/` is licensed under the Unicode
 License Agreement
-([LICENSE-UNICODE](http://www.unicode.org/copyright.html#License).
+([LICENSE-UNICODE](http://www.unicode.org/copyright.html#License)).


### PR DESCRIPTION
Following the style to the nearby links to LICENSE-APACHE and LICENSE_MIT, the link to LICENSE-UNICODE was placed after an opening parenthesis, but the closing parenthesis was missing.

Ref: #535