### PR TITLE
[RFC] regex-capi: expose regex::escape

### DIFF
--- a/regex-capi/ctest/test.c
+++ b/regex-capi/ctest/test.c
@@ -531,6 +531,33 @@ bool test_regex_set_options() {
     return passed;
 }
 
+bool test_escape() {
+
+    bool passed = true;
+
+    const char *pattern = "^[a-z]+.*$";
+    const char *expected_escaped = "\\^\\[a\\-z\\]\\+\\.\\*\\$";
+
+    const char *escaped = rure_escape_must(pattern);
+    if (!escaped) {
+        if (DEBUG) {
+            fprintf(stderr,
+                    "[test_captures] expected escaped, but got no escaped\n");
+        }
+        passed = false;
+    } else if(strcmp(escaped, expected_escaped) != 0) {
+        if (DEBUG) {
+            fprintf(stderr,
+                    "[test_captures] expected \"%s\", but got \"%s\"\n",
+                    expected_escaped, escaped);
+        }
+        passed = false;
+    }
+    rure_string_free((char *)escaped);
+    return passed;
+
+}
+
 void run_test(bool (test)(), const char *name, bool *passed) {
     if (!test()) {
         *passed = false;
@@ -557,6 +584,7 @@ int main() {
     run_test(test_regex_set_options, "test_regex_set_options", &passed);
     run_test(test_regex_set_match_start, "test_regex_set_match_start",
              &passed);
+    run_test(test_escape, "test_escape", &passed);
 
     if (!passed) {
         exit(1);

--- a/regex-capi/include/rure.h
+++ b/regex-capi/include/rure.h
@@ -567,6 +567,38 @@ void rure_error_free(rure_error *err);
  */
 const char *rure_error_message(rure_error *err);
 
+/*
+ * rure_escape_must returns a NULL terminated string where all meta characters
+ * have been escaped. If escaping fails for any reason, an error message is
+ * printed to stderr and the process is aborted.
+ *
+ * The pattern given should be in UTF-8. For convenience, this accepts a C
+ * string, which means the pattern cannot contain NULL byte.
+ */
+const char *rure_escape_must(const char *pattern);
+
+/*
+ * rure_escape returns a NULL terminated string where all meta characters have
+ * been escaped. The pattern must be valid UTF-8 and the length corresponds to
+ * the number of bytes in the pattern.
+ *
+ * error is set if there was a problem compiling the pattern (including if the
+ * pattern is not valid UTF-8). If error is NULL, then no error information
+ * is returned. In all cases, if an error occurs, NULL is returned.
+ *
+ * The pointer returned must not be freed directly. Instead, it should be freed
+ * by calling rure_string_free.
+ */
+const char *rure_escape(const uint8_t *pattern, size_t length,
+                        rure_error *error);
+
+/*
+ * rure_string_free frees the string given.
+ *
+ * This must be called at most once per string.
+ */
+void rure_string_free(char *s);
+
 #ifdef __cplusplus
 }
 #endif

--- a/regex-capi/src/error.rs
+++ b/regex-capi/src/error.rs
@@ -1,3 +1,4 @@
+use ::std::ffi;
 use ::std::ffi::CString;
 use ::std::fmt;
 use ::std::str;
@@ -16,6 +17,7 @@ pub enum ErrorKind {
     None,
     Str(str::Utf8Error),
     Regex(regex::Error),
+    Nul(ffi::NulError),
 }
 
 impl Error {
@@ -29,7 +31,7 @@ impl Error {
     pub fn is_err(&self) -> bool {
         match self.kind {
             ErrorKind::None => false,
-            ErrorKind::Str(_) | ErrorKind::Regex(_) => true,
+            ErrorKind::Str(_) | ErrorKind::Regex(_) | ErrorKind::Nul(_) => true,
         }
     }
 }
@@ -40,6 +42,7 @@ impl fmt::Display for Error {
             ErrorKind::None => write!(f, "no error"),
             ErrorKind::Str(ref e) => e.fmt(f),
             ErrorKind::Regex(ref e) => e.fmt(f),
+            ErrorKind::Nul(ref e) => e.fmt(f),
         }
     }
 }


### PR DESCRIPTION
I needed regex::escape available in the C API so i added it, but i have only done a few hours of rust in my life so this patch might be totally wrong. I have successfully been able to rust-regex-escape some strings from Python using ctypes to load the library though.

I followed this guide to handle String as returned type: http://jakegoulding.com/rust-ffi-omnibus/string_return/