### PR TITLE
Use https (not http) URL for meritbadge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by [RE2](https://github.com/google/re2).
 [![Build Status](https://travis-ci.org/rust-lang/regex.svg?branch=master)](https://travis-ci.org/rust-lang/regex)
 [![Build status](https://ci.appveyor.com/api/projects/status/github/rust-lang/regex?svg=true)](https://ci.appveyor.com/project/rust-lang-libs/regex)
 [![Coverage Status](https://coveralls.io/repos/github/rust-lang/regex/badge.svg?branch=master)](https://coveralls.io/github/rust-lang/regex?branch=master)
-[![](http://meritbadge.herokuapp.com/regex)](https://crates.io/crates/regex)
+[![](https://meritbadge.herokuapp.com/regex)](https://crates.io/crates/regex)
 [![Rust](https://img.shields.io/badge/rust-1.20%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/regex)
 
 ### Documentation


### PR DESCRIPTION
Right now this readme file uses an insecure http URL to reference a meritbadge image, which ends up producing "broken https" UI on the now-only-"mostly-secure" https crates.io page https://crates.io/crates/regex .  This patch just upgrades this to an HTTPS url (which still works), to avoid that problem. (Literally a 1-character change, changing "http" to "https".)