### PR TITLE
Update README with 2018 edition default in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,10 @@ Add this to your `Cargo.toml`:
 regex = "1"
 ```
 
-and this to your crate root:
-
-```rust
-extern crate regex;
-```
-
 Here's a simple example that matches a date in YYYY-MM-DD format and prints the
 year, month and day:
 
 ```rust
-extern crate regex;
-
 use regex::Regex;
 
 fn main() {


### PR DESCRIPTION
Making the example use 2018 behaviour the default. Other top 20 crates are updating as well so this is to fall in line. Didn't mention 2015 compatibility as this has largely been ignored elsewhere (except in log crate), with the assumption that anyone on older versions of Rust will know the extern crate syntax. 

Having the default 2018 changes in means less friction for new Rustaceans, a lot of whom will only have adopted it post 2018 introduction. 

FYI, I can update to include some sort of nod to 2015 if there is a need from the maintainers 👍 