### PR TITLE
Rust 2018 README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ If you have lots of dates in text that you'd like to iterate over, then it's
 easy to adapt the above example with an iterator:
 
 ```rust
-extern crate regex;
-
 use regex::Regex;
 
 const TO_SEARCH: &'static str = "
@@ -104,8 +102,7 @@ regular expressions are compiled exactly once.
 For example:
 
 ```rust
-#[macro_use] extern crate lazy_static;
-extern crate regex;
+use lazy_static::lazy_static;
 
 use regex::Regex;
 

--- a/README.md
+++ b/README.md
@@ -32,18 +32,10 @@ Add this to your `Cargo.toml`:
 regex = "1"
 ```
 
-and this to your crate root:
-
-```rust
-extern crate regex;
-```
-
 Here's a simple example that matches a date in YYYY-MM-DD format and prints the
 year, month and day:
 
 ```rust
-extern crate regex;
-
 use regex::Regex;
 
 fn main() {


### PR DESCRIPTION
Making the example use 2018 behaviour the default. 

Here are the changes working in the playground (note 2018 selected):

https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=931cef3284f7178eb62554da4a2c035b

https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=aaf7f7a741bae6f15de710a16a7340ed

https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=619ddc6c95a9a02bd94fd9e19d22c445

Other top 20 crates are updating as well so this is to fall in line. Didn't mention 2015 compatibility as this has largely been ignored elsewhere (except in log crate), with the assumption that anyone on older versions of Rust will know the extern crate syntax.

Having the default 2018 changes in means less friction for new Rustaceans, a lot of whom will only have adopted it post 2018 introduction.

FYI, I can update to include some sort of nod to 2015 if there is a need from the maintainers 👍

Lastly, I noticed docs.rs will still use older syntax. Not sure whether this should be addressed as well. Let me know on merge and I can look into it.