### PR TITLE
Update travis-ci link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ linear time with respect to the size of the regular expression and search text.
 Much of the syntax and implementation is inspired
 by [RE2](https://github.com/google/re2).
 
-[![Build Status](https://travis-ci.org/rust-lang/regex.svg?branch=master)](https://travis-ci.org/rust-lang/regex)
+[![Build Status](https://travis-ci.com/rust-lang/regex.svg?branch=master)](https://travis-ci.com/rust-lang/regex)
 [![Build status](https://ci.appveyor.com/api/projects/status/github/rust-lang/regex?svg=true)](https://ci.appveyor.com/project/rust-lang-libs/regex)
 [![Coverage Status](https://coveralls.io/repos/github/rust-lang/regex/badge.svg?branch=master)](https://coveralls.io/github/rust-lang/regex?branch=master)
 [![](https://meritbadge.herokuapp.com/regex)](https://crates.io/crates/regex)


### PR DESCRIPTION
Seems like only old builds are hosted on travis-ci.org, so update the CI info to point at travis-ci.com