### PR TITLE
Fix a bug in capture with match

### DIFF
--- a/src/backtrack.rs
+++ b/src/backtrack.rs
@@ -98,6 +98,7 @@ impl<'a, 'm, 'r, 's, I: Input> Bounded<'a, 'm, 'r, 's, I> {
         slots: &'s mut [Slot],
         input: I,
         start: usize,
+        end: usize, 
     ) -> bool {
         let mut cache = cache.borrow_mut();
         let cache = &mut cache.backtrack;
@@ -109,7 +110,7 @@ impl<'a, 'm, 'r, 's, I: Input> Bounded<'a, 'm, 'r, 's, I> {
             slots: slots,
             m: cache,
         };
-        b.exec_(start)
+        b.exec_(start, end)
     }
 
     /// Clears the cache such that the backtracking engine can be executed
@@ -147,7 +148,7 @@ impl<'a, 'm, 'r, 's, I: Input> Bounded<'a, 'm, 'r, 's, I> {
 
     /// Start backtracking at the given position in the input, but also look
     /// for literal prefixes.
-    fn exec_(&mut self, mut at: InputAt) -> bool {
+    fn exec_(&mut self, mut at: InputAt, end: usize) -> bool {
         self.clear();
         // If this is an anchored regex at the beginning of the input, then
         // we're either already done or we only need to try backtracking once.
@@ -170,7 +171,7 @@ impl<'a, 'm, 'r, 's, I: Input> Bounded<'a, 'm, 'r, 's, I> {
             if matched && self.prog.matches.len() == 1 {
                 return true;
             }
-            if at.is_end() {
+            if at.pos() == end {
                 break;
             }
             at = self.input.at(at.next_pos());

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -556,7 +556,8 @@ impl<'c> RegularExpression for ExecNoSync<'c> {
         match self.ro.match_type {
             MatchType::Literal(ty) => {
                 self.find_literals(ty, text, start).and_then(|(s, e)| {
-                    self.captures_nfa_type(MatchNfaType::Auto, slots, text, s, e)
+                    self.captures_nfa_type(
+                        MatchNfaType::Auto, slots, text, s, e)
                 })
             }
             MatchType::Dfa => {
@@ -565,7 +566,8 @@ impl<'c> RegularExpression for ExecNoSync<'c> {
                 } else {
                     match self.find_dfa_forward(text, start) {
                         dfa::Result::Match((s, e)) => {
-                            self.captures_nfa_type(MatchNfaType::Auto, slots, text, s, e)
+                            self.captures_nfa_type(
+                                MatchNfaType::Auto, slots, text, s, e)
                         }
                         dfa::Result::NoMatch(_) => None,
                         dfa::Result::Quit => self.captures_nfa(slots, text, start),
@@ -575,7 +577,8 @@ impl<'c> RegularExpression for ExecNoSync<'c> {
             MatchType::DfaAnchoredReverse => {
                 match self.find_dfa_anchored_reverse(text, start) {
                     dfa::Result::Match((s, e)) => {
-                        self.captures_nfa_type(MatchNfaType::Auto, slots, text, s, e)
+                        self.captures_nfa_type(
+                            MatchNfaType::Auto, slots, text, s, e)
                     }
                     dfa::Result::NoMatch(_) => None,
                     dfa::Result::Quit => self.captures_nfa(slots, text, start),
@@ -584,7 +587,8 @@ impl<'c> RegularExpression for ExecNoSync<'c> {
             MatchType::DfaSuffix => {
                 match self.find_dfa_reverse_suffix(text, start) {
                     dfa::Result::Match((s, e)) => {
-                        self.captures_nfa_type(MatchNfaType::Auto, slots, text, s, e)
+                        self.captures_nfa_type(
+                            MatchNfaType::Auto, slots, text, s, e)
                     }
                     dfa::Result::NoMatch(_) => None,
                     dfa::Result::Quit => self.captures_nfa(slots, text, start),
@@ -845,7 +849,15 @@ impl<'c> ExecNoSync<'c> {
         start: usize,
     ) -> Option<usize> {
         let mut slots = [None, None];
-        if self.exec_nfa(ty, &mut [false], &mut slots, true, text, start, text.len()) {
+        if self.exec_nfa(
+            ty,
+            &mut [false],
+            &mut slots,
+            true,
+            text,
+            start,
+            text.len()
+        ) {
             slots[1]
         } else {
             None
@@ -860,7 +872,15 @@ impl<'c> ExecNoSync<'c> {
         start: usize,
     ) -> Option<(usize, usize)> {
         let mut slots = [None, None];
-        if self.exec_nfa(ty, &mut [false], &mut slots, false, text, start, text.len()) {
+        if self.exec_nfa(
+            ty,
+            &mut [false],
+            &mut slots,
+            false,
+            text,
+            start,
+            text.len()
+        ) {
             match (slots[0], slots[1]) {
                 (Some(s), Some(e)) => Some((s, e)),
                 _ => None,
@@ -879,7 +899,8 @@ impl<'c> ExecNoSync<'c> {
         text: &[u8],
         start: usize,
     ) -> Option<(usize, usize)> {
-        self.captures_nfa_type(MatchNfaType::Auto, slots, text, start, text.len())
+        self.captures_nfa_type(
+            MatchNfaType::Auto, slots, text, start, text.len())
     }
 
     /// Like captures_nfa, but allows specification of type of NFA engine.
@@ -1037,7 +1058,10 @@ impl<'c> ExecNoSync<'c> {
                     }
                 }
             }
-            Nfa(ty) => self.exec_nfa(ty, matches, &mut [], false, text, start, text.len()),
+            Nfa(ty) => {
+                self.exec_nfa(
+                    ty, matches, &mut [], false, text, start, text.len())
+            }
             Nothing => false,
         }
     }

--- a/src/pikevm.rs
+++ b/src/pikevm.rs
@@ -107,6 +107,7 @@ impl<'r, I: Input> Fsm<'r, I> {
         quit_after_match: bool,
         input: I,
         start: usize,
+        end: usize, 
     ) -> bool {
         let mut cache = cache.borrow_mut();
         let cache = &mut cache.pikevm;
@@ -124,6 +125,7 @@ impl<'r, I: Input> Fsm<'r, I> {
             slots,
             quit_after_match,
             at,
+            end, 
         )
     }
 
@@ -135,6 +137,7 @@ impl<'r, I: Input> Fsm<'r, I> {
         slots: &mut [Slot],
         quit_after_match: bool,
         mut at: InputAt,
+        end: usize, 
     ) -> bool {
         let mut matched = false;
         let mut all_matched = false;
@@ -212,7 +215,7 @@ impl<'r, I: Input> Fsm<'r, I> {
                     }
                 }
             }
-            if at.is_end() {
+            if at.pos() == end {
                 break;
             }
             at = at_next;

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -88,8 +88,13 @@ ismatch!(reverse_suffix2, r"\d\d\d000", "153.230000\n", true);
 matiter!(reverse_suffix3, r"\d\d\d000", "153.230000\n", (4, 10));
 
 // See: https://github.com/rust-lang/regex/issues/334
-mat!(captures_after_dfa_premature_end, r"a(b*(X|$))?", "abcbX",
+// See: https://github.com/rust-lang/regex/issues/557
+mat!(captures_after_dfa_premature_end1, r"a(b*(X|$))?", "abcbX",
      Some((0, 1)), None, None);
+mat!(captures_after_dfa_premature_end2, r"a(bc*(X|$))?", "abcbX",
+     Some((0, 1)), None, None);
+mat!(captures_after_dfa_premature_end3, r"(aa$)?", "aaz",
+     Some((0, 0)));
 
 // See: https://github.com/rust-lang/regex/issues/437
 ismatch!(


### PR DESCRIPTION
When performing "EndText" matching, it is necessary to check whether
the current position matches the input text length.However, when
capturing a submatch using the matching result of DFA, "EndText" matching
wasn't actually performed correctly because the input text is sliced.

By applying this patch we specify the match end position by the argument "end",
not using slice when performing capture with the matching result of DFA.

Fixes rust-lang#557