### PR TITLE
upgrade to aho-corasick 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [dependencies]
 # For very fast prefix literal matching.
-aho-corasick = "0.6.7"
+aho-corasick = "0.7.1"
 # For skipping along search text quickly when a leading byte is known.
 memchr = "2.0.2"
 # For managing regex caches quickly across multiple threads.

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -46,9 +46,7 @@ ci/test-regex-capi
 # very long time. Also, check that we can build the regex-debug tool.
 if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
   cargo build --verbose --manifest-path regex-debug/Cargo.toml
-  for x in rust rust-bytes pcre1 onig; do
-    (cd bench && ./run $x --no-run --verbose)
-  done
+  (cd bench && ./run rust --no-run --verbose)
 
   # Test minimal versions.
   cargo +nightly generate-lockfile -Z minimal-versions

--- a/regex-syntax/src/hir/translate.rs
+++ b/regex-syntax/src/hir/translate.rs
@@ -2589,4 +2589,49 @@ mod tests {
         assert!(!t(r"\b").is_match_empty());
         assert!(!t(r"(?-u)\b").is_match_empty());
     }
+
+    #[test]
+    fn analysis_is_literal() {
+        // Positive examples.
+        assert!(t(r"").is_literal());
+        assert!(t(r"a").is_literal());
+        assert!(t(r"ab").is_literal());
+        assert!(t(r"abc").is_literal());
+        assert!(t(r"(?m)abc").is_literal());
+
+        // Negative examples.
+        assert!(!t(r"^").is_literal());
+        assert!(!t(r"a|b").is_literal());
+        assert!(!t(r"(a)").is_literal());
+        assert!(!t(r"a+").is_literal());
+        assert!(!t(r"foo(a)").is_literal());
+        assert!(!t(r"(a)foo").is_literal());
+        assert!(!t(r"[a]").is_literal());
+    }
+
+    #[test]
+    fn analysis_is_alternation_literal() {
+        // Positive examples.
+        assert!(t(r"").is_alternation_literal());
+        assert!(t(r"a").is_alternation_literal());
+        assert!(t(r"ab").is_alternation_literal());
+        assert!(t(r"abc").is_alternation_literal());
+        assert!(t(r"(?m)abc").is_alternation_literal());
+        assert!(t(r"a|b").is_alternation_literal());
+        assert!(t(r"a|b|c").is_alternation_literal());
+        assert!(t(r"foo|bar").is_alternation_literal());
+        assert!(t(r"foo|bar|baz").is_alternation_literal());
+
+        // Negative examples.
+        assert!(!t(r"^").is_alternation_literal());
+        assert!(!t(r"(a)").is_alternation_literal());
+        assert!(!t(r"a+").is_alternation_literal());
+        assert!(!t(r"foo(a)").is_alternation_literal());
+        assert!(!t(r"(a)foo").is_alternation_literal());
+        assert!(!t(r"[a]").is_alternation_literal());
+        assert!(!t(r"[a]|b").is_alternation_literal());
+        assert!(!t(r"a|[b]").is_alternation_literal());
+        assert!(!t(r"(a)|b").is_alternation_literal());
+        assert!(!t(r"a|(b)").is_alternation_literal());
+    }
 }

--- a/src/literal/mod.rs
+++ b/src/literal/mod.rs
@@ -11,7 +11,7 @@
 use std::cmp;
 use std::mem;
 
-use aho_corasick::{Automaton, AcAutomaton, FullAcAutomaton};
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
 use memchr::{memchr, memchr2, memchr3};
 use syntax::hir::literal::{Literal, Literals};
 
@@ -46,7 +46,7 @@ enum Matcher {
     /// A single substring, find using Boyer-Moore.
     BoyerMoore(BoyerMooreSearch),
     /// An Aho-Corasick automaton.
-    AC(FullAcAutomaton<Literal>),
+    AC { ac: AhoCorasick<u32>, lits: Vec<Literal> },
     /// A simd accelerated multiple string matcher. Used only for a small
     /// number of small literals.
     TeddySSSE3(TeddySSSE3),
@@ -102,7 +102,9 @@ impl LiteralSearcher {
             Bytes(ref sset) => sset.find(haystack).map(|i| (i, i + 1)),
             FreqyPacked(ref s) => s.find(haystack).map(|i| (i, i + s.len())),
             BoyerMoore(ref s) => s.find(haystack).map(|i| (i, i + s.len())),
-            AC(ref aut) => aut.find(haystack).next().map(|m| (m.start, m.end)),
+            AC { ref ac, .. } => {
+                ac.find(haystack).map(|m| (m.start(), m.end()))
+            }
             TeddySSSE3(ref t) => t.find(haystack).map(|m| (m.start, m.end)),
             TeddyAVX2(ref t) => t.find(haystack).map(|m| (m.start, m.end)),
         }
@@ -141,7 +143,7 @@ impl LiteralSearcher {
             Matcher::Bytes(ref sset) => LiteralIter::Bytes(&sset.dense),
             Matcher::FreqyPacked(ref s) => LiteralIter::Single(&s.pat),
             Matcher::BoyerMoore(ref s) => LiteralIter::Single(&s.pattern),
-            Matcher::AC(ref ac) => LiteralIter::AC(ac.patterns()),
+            Matcher::AC { ref lits, .. } => LiteralIter::AC(lits),
             Matcher::TeddySSSE3(ref ted) => {
                 LiteralIter::TeddySSSE3(ted.patterns())
             }
@@ -174,7 +176,7 @@ impl LiteralSearcher {
             Bytes(ref sset) => sset.dense.len(),
             FreqyPacked(_) => 1,
             BoyerMoore(_) => 1,
-            AC(ref aut) => aut.len(),
+            AC { ref ac, .. } => ac.pattern_count(),
             TeddySSSE3(ref ted) => ted.len(),
             TeddyAVX2(ref ted) => ted.len(),
         }
@@ -188,7 +190,7 @@ impl LiteralSearcher {
             Bytes(ref sset) => sset.approximate_size(),
             FreqyPacked(ref single) => single.approximate_size(),
             BoyerMoore(ref single) => single.approximate_size(),
-            AC(ref aut) => aut.heap_bytes(),
+            AC { ref ac, .. } => ac.heap_bytes(),
             TeddySSSE3(ref ted) => ted.approximate_size(),
             TeddyAVX2(ref ted) => ted.approximate_size(),
         }
@@ -258,7 +260,11 @@ impl Matcher {
             // Fallthrough to ol' reliable Aho-Corasick...
         }
         let pats = lits.literals().to_owned();
-        Matcher::AC(AcAutomaton::new(pats).into_full())
+        let ac = AhoCorasickBuilder::new()
+            .dfa(true)
+            .build_with_size::<u32, _, _>(&pats)
+            .unwrap();
+        Matcher::AC { ac, lits: pats }
     }
 }
 

--- a/src/literal/teddy_ssse3/imp.rs
+++ b/src/literal/teddy_ssse3/imp.rs
@@ -320,7 +320,7 @@ References
 
 use std::cmp;
 
-use aho_corasick::{Automaton, AcAutomaton, FullAcAutomaton};
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
 use syntax::hir::literal::Literals;
 
 use vector::ssse3::{SSSE3VectorBuilder, u8x16};
@@ -349,7 +349,7 @@ pub struct Teddy {
     pats: Vec<Vec<u8>>,
     /// An Aho-Corasick automaton of the patterns. We use this when we need to
     /// search pieces smaller than the Teddy block size.
-    ac: FullAcAutomaton<Vec<u8>>,
+    ac: AhoCorasick,
     /// A set of 8 buckets. Each bucket corresponds to a single member of a
     /// bitset. A bucket contains zero or more substrings. This is useful
     /// when the number of substrings exceeds 8, since our bitsets cannot have
@@ -399,10 +399,14 @@ impl Teddy {
             buckets[bucket].push(pati);
             masks.add(bucket as u8, pat);
         }
+        let ac = AhoCorasickBuilder::new()
+            .dfa(true)
+            .prefilter(false)
+            .build(&pats);
         Some(Teddy {
             vb: vb,
             pats: pats.to_vec(),
-            ac: AcAutomaton::new(pats.to_vec()).into_full(),
+            ac: ac,
             buckets: buckets,
             masks: masks,
         })
@@ -651,11 +655,11 @@ impl Teddy {
     /// block based approach.
     #[inline(never)]
     fn slow(&self, haystack: &[u8], pos: usize) -> Option<Match> {
-        self.ac.find(&haystack[pos..]).next().map(|m| {
+        self.ac.find(&haystack[pos..]).map(|m| {
             Match {
-                pat: m.pati,
-                start: pos + m.start,
-                end: pos + m.end,
+                pat: m.pattern(),
+                start: pos + m.start(),
+                end: pos + m.end(),
             }
         })
     }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -114,3 +114,13 @@ ismatch!(
     \u{10}\u{11}\u{12}\u{13}\u{14}\u{15}\u{16}\u{17}\
     \u{18}\u{19}\u{1a}\u{1b}\u{1c}\u{1d}\u{1e}\u{1f}",
     true);
+
+// Tests that our Aho-Corasick optimization works correctly. It only
+// kicks in when we have >32 literals.
+mat!(
+    ahocorasick1,
+    "samwise|sam|a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z|\
+     A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z",
+    "samwise",
+    Some((0, 7))
+);


### PR DESCRIPTION
We also take this opportunity to add an optimization I've long wanted to add: cause regexes like `foo|bar|baz|...|quux` to just dispatch to Aho-Corasick instead of using the lazy DFA, which can be quite a bit slower for a large dictionary (such as `/usr/share/dict/words`). The optimization is fairly brittle, but it's a somewhat common case. We couldn't do this before because Aho-Corasick didn't support leftmost-first match semantics, so it couldn't serve as a drop-in replacement for a regex alternation.