### PR TITLE
Automatically check if README.md examples are working when running "cargo test"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ lazy_static = "1"
 quickcheck = { version = "0.7", default-features = false }
 # For generating random test data.
 rand = "0.6.5"
+# To check README's example
+doc-comment = "0.3"
 
 [features]
 default = ["use_std"]

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ fn main() {
 
 This example outputs:
 
-```
+```text
 year: 2010, month: 03, day: 14
 year: 2014, month: 10, day: 14
 ```
@@ -107,7 +107,7 @@ regular expressions are compiled exactly once.
 
 For example:
 
-```rust
+```rust,ignore
 use regex::Regex;
 
 fn some_helper_function(text: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,6 +532,11 @@ extern crate thread_local;
 extern crate quickcheck;
 extern crate regex_syntax as syntax;
 extern crate utf8_ranges;
+#[cfg(test)]
+extern crate doc_comment;
+
+#[cfg(test)]
+doc_comment::doctest!("../README.md");
 
 #[cfg(feature = "use_std")]
 pub use error::Error;


### PR DESCRIPTION
Since rustdoc nightly now provides "cfg(test)" when running on test mode, we can now use this macro on test mode only to check if README.md examples are working as expected.