### PR TITLE
syntax: better error message for missing repetition quantifier

### DIFF
--- a/regex-syntax/src/ast/mod.rs
+++ b/regex-syntax/src/ast/mod.rs
@@ -153,6 +153,9 @@ pub enum ErrorKind {
     /// The range provided in a counted repetition operator is invalid. The
     /// range is invalid if the start is greater than the end.
     RepetitionCountInvalid,
+    /// An opening `{` was not followed by a valid decimal value.
+    /// For example, `x{}` or `x{]}` would fail.
+    RepetitionQuantifierDecimalMissing,
     /// An opening `{` was found with no corresponding closing `}`.
     RepetitionCountUnclosed,
     /// A repetition operator was applied to a missing sub-expression. This
@@ -306,6 +309,9 @@ impl fmt::Display for ErrorKind {
             RepetitionCountInvalid => {
                 write!(f, "invalid repetition count range, \
                            the start must be <= the end")
+            }
+            RepetitionQuantifierDecimalMissing => {
+                write!(f, "Repetition quantifier expects a valid decimal")
             }
             RepetitionCountUnclosed => {
                 write!(f, "unclosed counted repetition")

--- a/regex-syntax/src/ast/mod.rs
+++ b/regex-syntax/src/ast/mod.rs
@@ -95,7 +95,10 @@ pub enum ErrorKind {
     ClassRangeLiteral,
     /// An opening `[` was found with no corresponding closing `]`.
     ClassUnclosed,
-    /// An empty decimal number was given where one was expected.
+    /// Note that this error variant is no longer used. Namely, a decimal
+    /// number can only appear as a repetition quantifier. When the number
+    /// in a repetition quantifier is empty, then it gets its own specialized
+    /// error, `RepetitionCountDecimalEmpty`.
     DecimalEmpty,
     /// An invalid decimal number was given where one was expected.
     DecimalInvalid,
@@ -155,7 +158,7 @@ pub enum ErrorKind {
     RepetitionCountInvalid,
     /// An opening `{` was not followed by a valid decimal value.
     /// For example, `x{}` or `x{]}` would fail.
-    RepetitionQuantifierDecimalMissing,
+    RepetitionCountDecimalEmpty,
     /// An opening `{` was found with no corresponding closing `}`.
     RepetitionCountUnclosed,
     /// A repetition operator was applied to a missing sub-expression. This
@@ -310,8 +313,8 @@ impl fmt::Display for ErrorKind {
                 write!(f, "invalid repetition count range, \
                            the start must be <= the end")
             }
-            RepetitionQuantifierDecimalMissing => {
-                write!(f, "Repetition quantifier expects a valid decimal")
+            RepetitionCountDecimalEmpty => {
+                write!(f, "repetition quantifier expects a valid decimal")
             }
             RepetitionCountUnclosed => {
                 write!(f, "unclosed counted repetition")

--- a/regex-syntax/src/ast/parse.rs
+++ b/regex-syntax/src/ast/parse.rs
@@ -1113,15 +1113,11 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
                 ast::ErrorKind::RepetitionCountUnclosed,
             ));
         }
-        let count_start = match self.parse_decimal() {
-            Err(ast::Error {kind: ast::ErrorKind::DecimalEmpty, span, pattern}) => return Err(ast::Error {
-                kind: ast::ErrorKind::RepetitionQuantifierDecimalMissing,
-                pattern,
-                span,
-            }),
-            Err(e) => return Err(e),
-            Ok(value) => value,
-        };
+        let count_start = specialize_err(
+            self.parse_decimal(),
+            ast::ErrorKind::DecimalEmpty,
+            ast::ErrorKind::RepetitionCountDecimalEmpty,
+        )?;
         let mut range = ast::RepetitionRange::Exactly(count_start);
         if self.is_eof() {
             return Err(self.error(
@@ -1137,15 +1133,11 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
                 ));
             }
             if self.char() != '}' {
-                let count_end = match self.parse_decimal() {
-                    Err(ast::Error {kind: ast::ErrorKind::DecimalEmpty, span, pattern}) => return Err(ast::Error {
-                        kind: ast::ErrorKind::RepetitionQuantifierDecimalMissing,
-                        pattern,
-                        span,
-                    }),
-                    Err(e) => return Err(e),
-                    Ok(value) => value,
-                };
+                let count_end = specialize_err(
+                    self.parse_decimal(),
+                    ast::ErrorKind::DecimalEmpty,
+                    ast::ErrorKind::RepetitionCountDecimalEmpty,
+                )?;
                 range = ast::RepetitionRange::Bounded(count_start, count_end);
             } else {
                 range = ast::RepetitionRange::AtLeast(count_start);
@@ -2276,6 +2268,29 @@ impl<'p, 's, P: Borrow<Parser>> ast::Visitor for NestLimiter<'p, 's, P> {
     }
 }
 
+/// When the result is an error, transforms the ast::ErrorKind from the source
+/// Result into another one. This function is used to return clearer error
+/// messages when possible.
+fn specialize_err<T>(
+    result: Result<T>,
+    from: ast::ErrorKind,
+    to: ast::ErrorKind,
+) -> Result<T> {
+    if let Err(e) = result {
+        if e.kind == from {
+            Err(ast::Error {
+                kind: to,
+                pattern: e.pattern,
+                span: e.span,
+            })
+        } else {
+            Err(e)
+        }
+    } else {
+        result
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::ops::Range;
@@ -3163,13 +3178,13 @@ bar
             parser(r"a{]}").parse().unwrap_err(),
             TestError {
                 span: span(2..2),
-                kind: ast::ErrorKind::RepetitionQuantifierDecimalMissing,
+                kind: ast::ErrorKind::RepetitionCountDecimalEmpty,
             });
         assert_eq!(
             parser(r"a{1,]}").parse().unwrap_err(),
             TestError {
                 span: span(4..4),
-                kind: ast::ErrorKind::RepetitionQuantifierDecimalMissing,
+                kind: ast::ErrorKind::RepetitionCountDecimalEmpty,
             });
         assert_eq!(
             parser(r"a{").parse().unwrap_err(),
@@ -3181,13 +3196,13 @@ bar
             parser(r"a{}").parse().unwrap_err(),
             TestError {
                 span: span(2..2),
-                kind: ast::ErrorKind::RepetitionQuantifierDecimalMissing,
+                kind: ast::ErrorKind::RepetitionCountDecimalEmpty,
             });
         assert_eq!(
             parser(r"a{a").parse().unwrap_err(),
             TestError {
                 span: span(2..2),
-                kind: ast::ErrorKind::RepetitionQuantifierDecimalMissing,
+                kind: ast::ErrorKind::RepetitionCountDecimalEmpty,
             });
         assert_eq!(
             parser(r"a{9999999999}").parse().unwrap_err(),
@@ -3205,7 +3220,7 @@ bar
             parser(r"a{9,a").parse().unwrap_err(),
             TestError {
                 span: span(4..4),
-                kind: ast::ErrorKind::RepetitionQuantifierDecimalMissing,
+                kind: ast::ErrorKind::RepetitionCountDecimalEmpty,
             });
         assert_eq!(
             parser(r"a{9,9999999999}").parse().unwrap_err(),

--- a/tests/error_messages.rs
+++ b/tests/error_messages.rs
@@ -1,0 +1,19 @@
+// See: https://github.com/rust-lang/regex/issues/545
+#[test]
+fn repetition_quantifier_expects_a_valid_decimal() {
+    assert_panic_message(r"\\u{[^}]*}", r#"
+regex parse error:
+    \\u{[^}]*}
+        ^
+error: repetition quantifier expects a valid decimal
+"#);
+}
+
+fn assert_panic_message(regex: &str, expected_msg: &str) -> () {
+    let result = regex_new!(regex);
+    match result {
+        Ok(_) => panic!("Regular expression should have panicked"),
+        Err(regex::Error::Syntax(msg)) => assert_eq!(msg, expected_msg.trim()),
+        _ => panic!("Unexpected error received")
+    }
+}

--- a/tests/test_default.rs
+++ b/tests/test_default.rs
@@ -67,6 +67,7 @@ mod suffix_reverse;
 mod unicode;
 mod word_boundary;
 mod word_boundary_unicode;
+mod error_messages;
 
 #[test]
 fn disallow_non_utf8() {


### PR DESCRIPTION
Hi, first contribution to the Rust ecosystem, hopefully I'll get it right.

This is to solve @CAD97 issue https://github.com/rust-lang/regex/issues/545 which raised an uncleared error message when repetition quantifiers were not followed by a valid decimal (other languages would treat the `{}` as characters and this implementation would fail, but the message was "decimal literal empty" which was confusing)

The change is fairly simple, my main objective is to be able to contribute by starting small.

A few notes:
- To reuse the Span and pattern instances, I match and return the same error values but with a different kind. This way we can keep current and future errors in parse_decimal untouched.
- I also didn't extract a method for the `match` block since the code was small, but if you believe it makes sense, I could also make a `change_error_kind(From, To, self.parse_decimal())` method or pass the desired error kind to `parse_decimal(ErrorKindWhenMissing)`, but I felt the small duplication made it more obvious to read.
- I used `RepetitionQuantifierDecimalMissing` even though it also throws when the decimal is _invalid_, because the current implementation doesn't differentiate missing and invalid decimals, and I didn't want to change the behavior. It is also valid to have a missing decimal in cases like `x{1,}` or `x{,2}`, so I'm sure there's a better name for it.

I also noticed there was no integration tests for error messages. I excluded it from this PR but if you believe it can be valuable (it helped me make sure that my change actually worked) I can include it in this PR as a separate commit (or a different PR if you prefer). The test looks like this:

```rust
fn repetition_quantifier_decimal_error() {
    assert_panic_message(r"\\u{[^}]*}", r#"
regex parse error:
    \\u{[^}]*}
        ^
error: decimal literal empty
"#);
```

I'm ready to do my homework if I missed something, so just let me know!