### PR TITLE
Fix numbered group binding

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -92,7 +92,7 @@ pub fn expand_bytes(
 /// `CaptureRef` represents a reference to a capture group inside some text.
 /// The reference is either a capture group name or a number.
 ///
-/// It is also tagged with the position in the text immediately proceeding the
+/// It is also tagged with the position in the text following the
 /// capture reference.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct CaptureRef<'a> {
@@ -204,6 +204,7 @@ mod tests {
     find!(find_cap_ref3, "$0", c!(0, 2));
     find!(find_cap_ref4, "$5", c!(5, 2));
     find!(find_cap_ref5, "$10", c!(10, 3));
+    // see https://github.com/rust-lang/regex/pull/585 for more on characters following numbers
     find!(find_cap_ref6, "$42a", c!("42a", 4));
     find!(find_cap_ref7, "${42}a", c!(42, 5));
     find!(find_cap_ref8, "${42");
@@ -212,4 +213,8 @@ mod tests {
     find!(find_cap_ref11, "$");
     find!(find_cap_ref12, " ");
     find!(find_cap_ref13, "");
+    find!(find_cap_ref16, "$x-$y", c!("x",2));
+    find!(find_cap_ref17, "$x_$y", c!("x_",3));
+    find!(find_cap_ref14, "$1-$2", c!(1,2));
+    find!(find_cap_ref15, "$1_$2", c!("1_",3));
 }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -213,8 +213,8 @@ mod tests {
     find!(find_cap_ref11, "$");
     find!(find_cap_ref12, " ");
     find!(find_cap_ref13, "");
-    find!(find_cap_ref16, "$x-$y", c!("x",2));
-    find!(find_cap_ref17, "$x_$y", c!("x_",3));
     find!(find_cap_ref14, "$1-$2", c!(1,2));
     find!(find_cap_ref15, "$1_$2", c!("1_",3));
+    find!(find_cap_ref16, "$x-$y", c!("x",2));
+    find!(find_cap_ref17, "$x_$y", c!("x_",3));
 }


### PR DESCRIPTION
Ref https://github.com/rust-lang/regex/issues/69 should `re.replace("ab","$1_$2")` equal `"a_b"` or `"ab"`? 

In [this test](https://github.com/rust-lang/regex/blob/89467a9325c09249772920cd1e21282442fc9798/src/expand.rs#L207) `$42a` binds as a single group reference; which would suggest `$1_` did the same (I think?)

[Here](https://regexr.com/4ff3e) it looks like any non-number character following the number does not bind, and so `$42a` would only bind the `42`. I'm no regex expert but a cursory look suggests there's are various approaches to valid number references: https://www.regular-expressions.info/replacebackref.html

As an initial attempt, I changed the test case referenced above. 

Let me know if this is reasonable