### PR TITLE
Make u8x16 and u8x32 have Vector call ABI

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -303,13 +303,13 @@ library benchmarks (especially RE2).
 If you're hacking on one of the matching engines and just want to see
 benchmarks, then all you need to run is:
 
-    $ ./bench/run rust
+    $ (cd bench && ./run rust)
 
 If you want to compare your results with older benchmarks, then try:
 
-    $ ./bench/run rust | tee old
+    $ (cd bench && ./run rust | tee old)
     $ ... make it faster
-    $ ./bench/run rust | tee new
+    $ (cd bench && ./run rust | tee new)
     $ cargo benchcmp old new --improvements
 
 The `cargo-benchcmp` utility is available here:

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -22,6 +22,7 @@ regex = { version = "1", path = ".." }
 regex-syntax = { version = "0.6", path = "../regex-syntax" }
 serde = "1"
 serde_derive = "1"
+cfg-if = "0.1"
 
 [build-dependencies]
 cc = "1"

--- a/src/literal/teddy_avx2/imp.rs
+++ b/src/literal/teddy_avx2/imp.rs
@@ -285,6 +285,7 @@ impl Teddy {
         res: u8x32,
         mut bitfield: u32,
     ) -> Option<Match> {
+        let patterns = res.bytes();
         while bitfield != 0 {
             // The next offset, relative to pos, where some fingerprint
             // matched.
@@ -296,7 +297,7 @@ impl Teddy {
 
             // The bitfield telling us which patterns had fingerprints that
             // match at this starting position.
-            let mut patterns = res.extract(byte_pos);
+            let mut patterns = patterns[byte_pos];
             while patterns != 0 {
                 let bucket = patterns.trailing_zeros() as usize;
                 patterns &= !(1 << bucket);
@@ -461,12 +462,20 @@ impl Mask {
         let byte_lo = (byte & 0xF) as usize;
         let byte_hi = (byte >> 4) as usize;
 
-        let lo = self.lo.extract(byte_lo) | ((1 << bucket) as u8);
-        self.lo.replace(byte_lo, lo);
-        self.lo.replace(byte_lo + 16, lo);
+        {
+            let mut lo_bytes = self.lo.bytes();
+            let lo = lo_bytes[byte_lo] | ((1 << bucket) as u8);
+            lo_bytes[byte_lo] = lo;
+            lo_bytes[byte_lo + 16] = lo;
+            self.lo.replace_bytes(lo_bytes);
+        }
 
-        let hi = self.hi.extract(byte_hi) | ((1 << bucket) as u8);
-        self.hi.replace(byte_hi, hi);
-        self.hi.replace(byte_hi + 16, hi);
+        {
+            let mut hi_bytes = self.hi.bytes();
+            let hi = hi_bytes[byte_hi] | ((1 << bucket) as u8);
+            hi_bytes[byte_hi] = hi;
+            hi_bytes[byte_hi + 16] = hi;
+            self.hi.replace_bytes(hi_bytes);
+        }
     }
 }

--- a/src/literal/teddy_ssse3/imp.rs
+++ b/src/literal/teddy_ssse3/imp.rs
@@ -595,6 +595,7 @@ impl Teddy {
         res: u8x16,
         mut bitfield: u32,
     ) -> Option<Match> {
+        let patterns = res.bytes();
         while bitfield != 0 {
             // The next offset, relative to pos, where some fingerprint
             // matched.
@@ -606,7 +607,7 @@ impl Teddy {
 
             // The bitfield telling us which patterns had fingerprints that
             // match at this starting position.
-            let mut patterns = res.extract(byte_pos);
+            let mut patterns = patterns[byte_pos];
             while patterns != 0 {
                 let bucket = patterns.trailing_zeros() as usize;
                 patterns &= !(1 << bucket);
@@ -771,10 +772,17 @@ impl Mask {
         let byte_lo = (byte & 0xF) as usize;
         let byte_hi = (byte >> 4) as usize;
 
-        let lo = self.lo.extract(byte_lo);
-        self.lo.replace(byte_lo, ((1 << bucket) as u8) | lo);
-
-        let hi = self.hi.extract(byte_hi);
-        self.hi.replace(byte_hi, ((1 << bucket) as u8) | hi);
+        {
+            let mut lo_bytes = self.lo.bytes();
+            let lo = lo_bytes[byte_lo];
+            lo_bytes[byte_lo] = ((1 << bucket) as u8) | lo;
+            self.lo.replace_bytes(lo_bytes);
+        }
+        {
+            let mut hi_bytes = self.hi.bytes();
+            let hi = hi_bytes[byte_hi];
+            hi_bytes[byte_hi] = ((1 << bucket) as u8) | hi;
+            self.hi.replace_bytes(hi_bytes);
+        }
     }
 }

--- a/src/vector/ssse3.rs
+++ b/src/vector/ssse3.rs
@@ -79,12 +79,14 @@ impl SSSE3VectorBuilder {
 #[derive(Clone, Copy)]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
-pub struct u8x16(__m128i);
+pub struct u8x16 {
+    vector: __m128i
+}
 
 impl u8x16 {
     #[inline]
     unsafe fn splat(n: u8) -> u8x16 {
-        u8x16(_mm_set1_epi8(n as i8))
+        u8x16 { vector: _mm_set1_epi8(n as i8) }
     }
 
     #[inline]
@@ -96,7 +98,7 @@ impl u8x16 {
     #[inline]
     unsafe fn load_unchecked_unaligned(slice: &[u8]) -> u8x16 {
         let v = _mm_loadu_si128(slice.as_ptr() as *const u8 as *const __m128i);
-        u8x16(v)
+        u8x16 { vector: v }
     }
 
     #[inline]
@@ -109,14 +111,14 @@ impl u8x16 {
     #[inline]
     unsafe fn load_unchecked(slice: &[u8]) -> u8x16 {
         let v = _mm_load_si128(slice.as_ptr() as *const u8 as *const __m128i);
-        u8x16(v)
+        u8x16 { vector: v }
     }
 
     #[inline]
     pub fn shuffle(self, indices: u8x16) -> u8x16 {
         // Safe because we know SSSE3 is enabled.
         unsafe {
-            u8x16(_mm_shuffle_epi8(self.0, indices.0))
+            u8x16 { vector: _mm_shuffle_epi8(self.vector, indices.vector) }
         }
     }
 
@@ -124,9 +126,9 @@ impl u8x16 {
     pub fn ne(self, other: u8x16) -> u8x16 {
         // Safe because we know SSSE3 is enabled.
         unsafe {
-            let boolv = _mm_cmpeq_epi8(self.0, other.0);
+            let boolv = _mm_cmpeq_epi8(self.vector, other.vector);
             let ones = _mm_set1_epi8(0xFF as u8 as i8);
-            u8x16(_mm_andnot_si128(boolv, ones))
+            u8x16 { vector: _mm_andnot_si128(boolv, ones) }
         }
     }
 
@@ -134,7 +136,7 @@ impl u8x16 {
     pub fn and(self, other: u8x16) -> u8x16 {
         // Safe because we know SSSE3 is enabled.
         unsafe {
-            u8x16(_mm_and_si128(self.0, other.0))
+            u8x16 { vector: _mm_and_si128(self.vector, other.vector) }
         }
     }
 
@@ -142,7 +144,7 @@ impl u8x16 {
     pub fn movemask(self) -> u32 {
         // Safe because we know SSSE3 is enabled.
         unsafe {
-            _mm_movemask_epi8(self.0) as u32
+            _mm_movemask_epi8(self.vector) as u32
         }
     }
 
@@ -150,7 +152,7 @@ impl u8x16 {
     pub fn alignr_14(self, other: u8x16) -> u8x16 {
         // Safe because we know SSSE3 is enabled.
         unsafe {
-            u8x16(_mm_alignr_epi8(self.0, other.0, 14))
+            u8x16 { vector: _mm_alignr_epi8(self.vector, other.vector, 14) }
         }
     }
 
@@ -158,7 +160,7 @@ impl u8x16 {
     pub fn alignr_15(self, other: u8x16) -> u8x16 {
         // Safe because we know SSSE3 is enabled.
         unsafe {
-            u8x16(_mm_alignr_epi8(self.0, other.0, 15))
+            u8x16 { vector: _mm_alignr_epi8(self.vector, other.vector, 15) }
         }
     }
 
@@ -166,7 +168,7 @@ impl u8x16 {
     pub fn bit_shift_right_4(self) -> u8x16 {
         // Safe because we know SSSE3 is enabled.
         unsafe {
-            u8x16(_mm_srli_epi16(self.0, 4))
+            u8x16 { vector: _mm_srli_epi16(self.vector, 4) }
         }
     }
 
@@ -179,7 +181,7 @@ impl u8x16 {
     #[inline]
     pub fn replace_bytes(&mut self, value: [u8; 16]) {
         // Safe because __m128i and [u8; 16] are layout compatible
-        self.0 = unsafe { mem::transmute(value) };
+        self.vector = unsafe { mem::transmute(value) };
     }
 }
 


### PR DESCRIPTION
Before this commit, u8x16 and u8x32 were repr(Rust) unions. This introduced
unspecified behavior because the field offsets of repr(Rust) unions are not
guaranteed to be at offset 0, so that field access was potentially UB.

This commit fixes that, and closes #588 .

The unions were also generating a lot of unnecessary memory operations. This
commit fixes that as well.

The issue is that unions have an Aggregate call ABI, which is the same as the
call ABI of arrays. That is, they are passed around by memory, and not in Vector
registers.

This is good, if most of the time one operates on them as arrays. This was,
however, not the case. Most of the operations on these unions are using SIMD
instructions. This means that the union needs to be copied into a SIMD register,
operated on, and then spilled back to the stack, on every single operation.
That's unnecessary, although apparently LLVM was able to optimize all the
unnecessary memory operations away and leave these always in registers.

This commit fixes this issue as well, by making the u8x16 and u8x32
repr(transparent) newtypes over the architecture specific vector types, giving
them the Vector ABI.

The vectors are then copied to the stack only when necessary, and as little as
possible. This is done using mem::transmute, removing the need for unions
altogether (fixing #588 by not having to worry about union layout at all).

To make it clear when the vectors are spilled into the stack, the
vector::replace(index, value) and vector::extract(index) APIs have been removed,
and instead, only a vector::bytes(self) and a vector::from_bytes(&mut self, [u8;
N]) APIs are provided instead. This prevents spilling the vectors back and forth
onto the stack every time an index needs to be modified, by using vector::bytes
to spill the vector to the stack once, making all the random-access
modifications in memory, and then using vector::from_bytes only once to move the
memory back into a SIMD register.

---

I haven't run any benchmarks, so please do benchmark that this does not introduce any performance regressions before merging this