### PR TITLE
Use more correct license specification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "regex"
 version = "1.3.1"  #:version
 authors = ["The Rust Project Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang/regex"
 documentation = "https://docs.rs/regex"


### PR DESCRIPTION
Historically, the `/` was used throughout the ecosystem, but the actual SPDX standard requires this to be an OR. The said standard also has AND, and for this reason `/` is ambiguous. https://github.com/rust-lang/cargo/pull/4898 contains some more details about this.