### PR TITLE
Add `Range` conversions for `Match` types

### DIFF
--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
-use std::ops::Index;
+use std::ops::{Index, Range};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -36,10 +36,17 @@ impl<'t> Match<'t> {
         self.end
     }
 
+    /// Returns the range over the starting and ending byte offsets of the match
+    /// in the haystack.
+    #[inline]
+    pub fn range(&self) -> Range<usize> {
+        self.start..self.end
+    }
+
     /// Returns the matched text.
     #[inline]
     pub fn as_bytes(&self) -> &'t [u8] {
-        &self.text[self.start..self.end]
+        &self.text[self.range()]
     }
 
     /// Creates a new match from the given haystack and byte offsets.

--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -56,6 +56,12 @@ impl<'t> Match<'t> {
     }
 }
 
+impl<'t> From<Match<'t>> for Range<usize> {
+    fn from(m: Match<'t>) -> Range<usize> {
+        m.range()
+    }
+}
+
 /// A compiled regular expression for matching arbitrary bytes.
 ///
 /// It can be used to search, split or replace text. All searching is done with

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -71,6 +71,12 @@ impl<'t> From<Match<'t>> for &'t str {
     }
 }
 
+impl<'t> From<Match<'t>> for Range<usize> {
+    fn from(m: Match<'t>) -> Range<usize> {
+        m.range()
+    }
+}
+
 /// A compiled regular expression for matching Unicode strings.
 ///
 /// It is represented as either a sequence of bytecode instructions (dynamic)

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
-use std::ops::Index;
+use std::ops::{Index, Range};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -45,10 +45,17 @@ impl<'t> Match<'t> {
         self.end
     }
 
+    /// Returns the range over the starting and ending byte offsets of the match
+    /// in the haystack.
+    #[inline]
+    pub fn range(&self) -> Range<usize> {
+        self.start..self.end
+    }
+
     /// Returns the matched text.
     #[inline]
     pub fn as_str(&self) -> &'t str {
-        &self.text[self.start..self.end]
+        &self.text[self.range()]
     }
 
     /// Creates a new match from the given haystack and byte offsets.


### PR DESCRIPTION
The `range` method is for convenience to slightly reduce the amount of code needed to be written by users. In my opinion, it also feels like a natural extension of the `Match` API. I've also added `From<Match>` conversions for `Range<usize>`.