### PR TITLE
Library type required for compiling using armv7

### DIFF
--- a/regex-syntax/Cargo.toml
+++ b/regex-syntax/Cargo.toml
@@ -30,3 +30,7 @@ unicode-gencat = []
 unicode-perl = []
 unicode-script = []
 unicode-segment = []
+
+[lib]
+crate-type = ["rlib"]
+


### PR DESCRIPTION
I was trying to compile a program that uses regex as dependency on a Raspberry Pi, but it wasn't possible as regex-search wasn't provided as "rlib". Adding this setting to Cargo.toml makes it work, and also it works and compiles on desktop.