### PR TITLE
syntax: fix flag scoping issue

### DIFF
--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -199,3 +199,14 @@ fn regression_nfa_stops1() {
     let re = ::regex::bytes::Regex::new(r"\bs(?:[ab])").unwrap();
     assert_eq!(0, re.find_iter(b"s\xE4").count());
 }
+
+// See: https://github.com/rust-lang/regex/issues/640
+#[cfg(feature = "unicode-case")]
+matiter!(
+    flags_are_unset,
+    r"((?i)foo)|Bar",
+    "foo Foo bar Bar",
+    (0, 3),
+    (4, 7),
+    (12, 15)
+);


### PR DESCRIPTION
This fixes a rather nasty bug where flags set inside a group were being
applies to expressions outside the group. e.g., In the simplest case,
`((?i)a)b)` would match `aB`, even though the case insensitive flag
_shouldn't_ be applied to `b`.

The issue here was that we were actually going out of our way to reset
the flags when a group is popped only _some_ of the time. Namely, when
flags were set via `(?i:a)b` syntax. Instead, flags should be reset to
their previous state _every_ time a group is popped in the translator.

The fix here is pretty simple. When we open a group, if the group itself
does not have any flags, then we simply record the current state of the
flags instead of trying to replace the current flags. Then, when we pop
the group, we are guaranteed to obtain the old flags, at which point, we
reset them.

Fixes #640