### PR TITLE
Improve allocation of escape_into

### DIFF
--- a/regex-syntax/src/lib.rs
+++ b/regex-syntax/src/lib.rs
@@ -175,7 +175,7 @@ pub mod utf8;
 /// The string returned may be safely used as a literal in a regular
 /// expression.
 pub fn escape(text: &str) -> String {
-    let mut quoted = String::with_capacity(text.len());
+    let mut quoted = String::new();
     escape_into(text, &mut quoted);
     quoted
 }
@@ -185,6 +185,7 @@ pub fn escape(text: &str) -> String {
 /// This will append escape characters into the given buffer. The characters
 /// that are appended are safe to use as a literal in a regular expression.
 pub fn escape_into(text: &str, buf: &mut String) {
+    buf.reserve(text.len());
     for c in text.chars() {
         if is_meta_character(c) {
             buf.push('\\');


### PR DESCRIPTION
In regex-syntax,
Make escape_into allocate at most twice (all characters are escaped)
instead of more if used on an unallocated String.  This way, escape
doesn't have to allocate.