### PR TITLE
Tweak features for regex-syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ doctest = false
 # Features are documented in the "Crate features" section of the crate docs:
 # https://docs.rs/regex/*/#crate-features
 [features]
-default = ["std", "perf", "unicode"]
+default = ["std", "perf", "unicode", "regex-syntax/default"]
 
 # ECOSYSTEM FEATURES
 
@@ -71,6 +71,7 @@ unicode = [
   "unicode-perl",
   "unicode-script",
   "unicode-segment",
+  "regex-syntax/unicode",
 ]
 # Enables use of the `Age` property, e.g., `\p{Age:3.0}`.
 unicode-age = ["regex-syntax/unicode-age"]


### PR DESCRIPTION
This commit tweaks the features enabled for the `regex-syntax` crate
from the `regex` crate itself. This isn't intended to actually have any
functional change, but should help feature unification for Cargo in some
projects.

One project I work on exhibits an issue where executing `cargo build`
followed by `cargo test` will rebuild `regex-syntax` and all of its
transitive dependencies. The cause for this issue is that the tests are
using the `proptest` crate. The `proptest` crate depends on
`regex-syntax` with normal features (e.g. the defaults). All other
crates depend on `regex` with normal default features too.

The problem happens where when *only* the `regex` crate depends on
`regex-syntax` then the `default` and `unicode` features of
`regex-syntax` are disabled. This is because the `regex` crate disables
default features and `regex`'s `unicode` feature delegates to all the
individual features of `regex-syntax`. When the `regex-syntax` crate is
depended on directly by `proptest` it then enables the `default` and
`unicode` features of `regex-syntax`.

Functionally these two builds of `regex-syntax` are exactly the same
since `default` is simply a proxy for `unicode` and `unicode` is simply
an umbrella including other features.

This PR updates the features enabled on `regex-syntax` by the `regex`
crate in two ways:

* The `default` feature for `regex` enables `regex-syntax/default`.
* The `unicode` feature for `regex` enables the `regex-syntax/unicode`
  feature.

This makes is so that if another crate in your crate graph depends on
`regex-syntax` then it'll have, by default, the same set of features
enabled than if you also depend on `regex`.