### PR TITLE
Replace "cfg(test)" with "cfg(doctest)" for readme testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,7 +622,7 @@ compile_error!("`std` feature is currently required to build this crate");
 
 #[cfg(feature = "perf-literal")]
 extern crate aho_corasick;
-#[cfg(test)]
+#[cfg(doctest)]
 extern crate doc_comment;
 #[cfg(feature = "perf-literal")]
 extern crate memchr;
@@ -633,7 +633,7 @@ extern crate regex_syntax as syntax;
 #[cfg(feature = "perf-cache")]
 extern crate thread_local;
 
-#[cfg(test)]
+#[cfg(doctest)]
 doc_comment::doctest!("../README.md");
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
Rustdoc now passes "doctest" when running in test mode.