### PR TITLE
Add `is_empty()` to `RegexSet`.

### DIFF
--- a/src/re_set.rs
+++ b/src/re_set.rs
@@ -207,6 +207,11 @@ impl RegexSet {
         self.0.regex_strings().len()
     }
 
+    /// Returns `true` if this set contains no regular expressions.
+    pub fn is_empty(&self) -> bool {
+        self.0.regex_strings().is_empty()
+    }
+
     /// Returns the patterns that this set will match on.
     ///
     /// This function can be used to determine the pattern for a match. The

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -54,3 +54,14 @@ fn get_set_patterns() {
     let set = regex_set!(&["a", "b"]);
     assert_eq!(vec!["a", "b"], set.patterns());
 }
+
+#[test]
+fn len_and_empty() {
+    let empty = regex_set!(&[""; 0]);
+    assert_eq!(empty.len(), 0);
+    assert!(empty.is_empty());
+
+    let not_empty = regex_set!(&["ab", "b"]);
+    assert_eq!(not_empty.len(), 2);
+    assert!(!not_empty.is_empty());
+}


### PR DESCRIPTION
Implementing `is_empty()` on RegexSet makes the API similar to standard
library collections like `Vec` and `BTreeSet`. The clippy lint
`len_without_is_empty` recommends that items which implement `len()`
should implement `is_empty()`.