### PR TITLE
Implement Clone for SubCaptureMatches

### DIFF
--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -1051,6 +1051,7 @@ impl<'t, 'i> Index<&'i str> for Captures<'t> {
 ///
 /// The lifetime `'c` corresponds to the lifetime of the `Captures` value, and
 /// the lifetime `'t` corresponds to the originally matched text.
+#[derive(Clone)]
 pub struct SubCaptureMatches<'c, 't: 'c> {
     caps: &'c Captures<'t>,
     it: SubCapturesPosIter<'c>,

--- a/src/re_trait.rs
+++ b/src/re_trait.rs
@@ -51,6 +51,7 @@ impl Locations {
 /// Positions are byte indices in terms of the original string matched.
 ///
 /// `'c` is the lifetime of the captures.
+#[derive(Clone)]
 pub struct SubCapturesPosIter<'c> {
     idx: usize,
     locs: &'c Locations,

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -1053,6 +1053,7 @@ impl<'t, 'i> Index<&'i str> for Captures<'t> {
 ///
 /// The lifetime `'c` corresponds to the lifetime of the `Captures` value, and
 /// the lifetime `'t` corresponds to the originally matched text.
+#[derive(Clone)]
 pub struct SubCaptureMatches<'c, 't: 'c> {
     caps: &'c Captures<'t>,
     it: SubCapturesPosIter<'c>,


### PR DESCRIPTION
Similar to BurntSushi/rust-csv#204, consider this a proposal more than anything else. Not sure if there are edge cases I haven't considered. I poked around but didn't see any former discussions/issues about this.

Clonable iterators are useful when writing code that is generic over
iterators that needs to be able to iterate twice.