### PR TITLE
compile: Use std::convert::TryFrom to convert u32 to usize

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1160,13 +1160,8 @@ impl ByteClassSet {
 }
 
 fn u32_to_usize(n: u32) -> usize {
-    // In case usize is less than 32 bits, we need to guard against overflow.
-    // On most platforms this compiles to nothing.
-    // TODO Use `std::convert::TryFrom` once it's stable.
-    if (n as u64) > (::std::usize::MAX as u64) {
-        panic!("BUG: {} is too big to be pointer sized", n)
-    }
-    n as usize
+    std::convert::TryFrom::try_from(n)
+        .expect("BUG: {} is too big to be pointer sized")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The interface and behavior doesn't change because we're using expect to
panic when try_from fails.