### PR TITLE
Disambiguate the documentation of is_match

### DIFF
--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -119,7 +119,7 @@ impl Regex {
         RegexBuilder::new(re).build()
     }
 
-    /// Returns true if and only if the regex matches the string given.
+    /// Returns true if and only if there is a match for the regex in the string given.
     ///
     /// It is recommended to use this method if all you need to do is test
     /// a match, since the underlying matching engine may be able to do less

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -175,7 +175,7 @@ impl Regex {
         RegexBuilder::new(re).build()
     }
 
-    /// Returns true if and only if the regex matches the string given.
+    /// Returns true if and only if there is a match for the regex in the string given.
     ///
     /// It is recommended to use this method if all you need to do is test
     /// a match, since the underlying matching engine may be able to do less


### PR DESCRIPTION
This may be subjective, and due to the fact that I am not a native speaker, but I initially understood

> the regex matches the string given.

as meaning that the match for the regex should span the entire given string.

I changed it to
> there is a match for the regex in the string given.

which in unambiguous.