### PR TITLE
Add `empty()` constructor to `RegexSet`

### DIFF
--- a/src/re_set.rs
+++ b/src/re_set.rs
@@ -96,6 +96,19 @@ impl RegexSet {
         RegexSetBuilder::new(exprs).build()
     }
 
+    /// Create a new empty regex set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use regex::RegexSet;
+    /// let set = RegexSet::empty();
+    /// assert!(set.is_empty());
+    /// ```
+    pub fn empty() -> RegexSet {
+        RegexSetBuilder::new(&[""; 0]).build().unwrap()
+    }
+
     /// Returns true if and only if one of the regexes in this set matches
     /// the text given.
     ///


### PR DESCRIPTION
A slightly nicer constructor for ergonomics. Useful when used as part of a larger builder.

Doctested with `is_empty` from https://github.com/rust-lang/regex/pull/687.