### PR TITLE
Update fuzzer cargo.toml

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ['named-profiles']
+
 [package]
 name = "regex-fuzz"
 version = "0.0.0"
@@ -22,14 +24,12 @@ members = ["."]
 name = "fuzz_regex_match"
 path = "fuzz_targets/fuzz_regex_match.rs"
 
-[profile.debug]
-opt-level = 3
-debug = true
-
 [profile.release]
 opt-level = 3
 debug = true
 
+[profile.debug]
+inherits = "release"
+
 [profile.test]
-opt-level = 3
-debug = true
+inherits = "release"


### PR DESCRIPTION
I had to apply these changes for OSS-Fuzz to continue working. Specifically I needed to add `cargo-features = ['named-profiles']` and `inherits` for any profile other than `release`. However, I have also confirmed now that the building is done with optimized + debuginfo in OSS-Fuzz (`Finished release [optimized + debuginfo] target(s) in 37.59s`).