### PR TITLE
Add missing implementations of core iterator traits

### DIFF
--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
+use std::iter::FusedIterator;
 use std::ops::{Index, Range};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -701,6 +702,8 @@ impl<'r, 't> Iterator for Matches<'r, 't> {
     }
 }
 
+impl<'r, 't> FusedIterator for Matches<'r, 't> {}
+
 /// An iterator that yields all non-overlapping capture groups matching a
 /// particular regular expression.
 ///
@@ -723,6 +726,8 @@ impl<'r, 't> Iterator for CaptureMatches<'r, 't> {
         })
     }
 }
+
+impl<'r, 't> FusedIterator for CaptureMatches<'r, 't> {}
 
 /// Yields all substrings delimited by a regular expression match.
 ///
@@ -757,6 +762,8 @@ impl<'r, 't> Iterator for Split<'r, 't> {
     }
 }
 
+impl<'r, 't> FusedIterator for Split<'r, 't> {}
+
 /// Yields at most `N` substrings delimited by a regular expression match.
 ///
 /// The last substring will be whatever remains after splitting.
@@ -790,7 +797,13 @@ impl<'r, 't> Iterator for SplitN<'r, 't> {
             Some(&text[self.splits.last..])
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.n))
+    }
 }
+
+impl<'r, 't> FusedIterator for SplitN<'r, 't> {}
 
 /// An iterator over the names of all possible captures.
 ///
@@ -813,7 +826,15 @@ impl<'r> Iterator for CaptureNames<'r> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
 }
+
+impl<'r> ExactSizeIterator for CaptureNames<'r> {}
+
+impl<'r> FusedIterator for CaptureNames<'r> {}
 
 /// CaptureLocations is a low level representation of the raw offsets of each
 /// submatch.
@@ -1072,6 +1093,8 @@ impl<'c, 't> Iterator for SubCaptureMatches<'c, 't> {
             .map(|cap| cap.map(|(s, e)| Match::new(self.caps.text, s, e)))
     }
 }
+
+impl<'c, 't> FusedIterator for SubCaptureMatches<'c, 't> {}
 
 /// Replacer describes types that can be used to replace matches in a byte
 /// string.

--- a/src/re_set.rs
+++ b/src/re_set.rs
@@ -352,6 +352,8 @@ impl DoubleEndedIterator for SetMatchesIntoIter {
     }
 }
 
+impl iter::FusedIterator for SetMatchesIntoIter {}
+
 /// A borrowed iterator over the set of matches from a regex set.
 ///
 /// The lifetime `'a` refers to the lifetime of a `SetMatches` value.
@@ -391,6 +393,8 @@ impl<'a> DoubleEndedIterator for SetMatchesIter<'a> {
         }
     }
 }
+
+impl<'a> iter::FusedIterator for SetMatchesIter<'a> {}
 
 #[doc(hidden)]
 impl From<Exec> for RegexSet {

--- a/src/re_trait.rs
+++ b/src/re_trait.rs
@@ -1,3 +1,5 @@
+use std::iter::FusedIterator;
+
 /// Slot is a single saved capture location. Note that there are two slots for
 /// every capture in a regular expression (one slot each for the start and end
 /// of the capture).
@@ -72,6 +74,8 @@ impl<'c> Iterator for SubCapturesPosIter<'c> {
         x
     }
 }
+
+impl<'c> FusedIterator for SubCapturesPosIter<'c> {}
 
 /// `RegularExpression` describes types that can implement regex searching.
 ///
@@ -205,6 +209,13 @@ where
     }
 }
 
+impl<'t, R> FusedIterator for Matches<'t, R>
+where
+    R: RegularExpression,
+    R::Text: 't + AsRef<[u8]>,
+{
+}
+
 /// An iterator over all non-overlapping successive leftmost-first matches with
 /// captures.
 pub struct CaptureMatches<'t, R>(Matches<'t, R>)
@@ -259,4 +270,11 @@ where
         self.0.last_match = Some(e);
         Some(locs)
     }
+}
+
+impl<'t, R> FusedIterator for CaptureMatches<'t, R>
+where
+    R: RegularExpression,
+    R::Text: 't + AsRef<[u8]>,
+{
 }

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
+use std::iter::FusedIterator;
 use std::ops::{Index, Range};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -762,7 +763,15 @@ impl<'r> Iterator for CaptureNames<'r> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
 }
+
+impl<'r> ExactSizeIterator for CaptureNames<'r> {}
+
+impl<'r> FusedIterator for CaptureNames<'r> {}
 
 /// Yields all substrings delimited by a regular expression match.
 ///
@@ -797,6 +806,8 @@ impl<'r, 't> Iterator for Split<'r, 't> {
     }
 }
 
+impl<'r, 't> FusedIterator for Split<'r, 't> {}
+
 /// Yields at most `N` substrings delimited by a regular expression match.
 ///
 /// The last substring will be whatever remains after splitting.
@@ -830,7 +841,13 @@ impl<'r, 't> Iterator for SplitN<'r, 't> {
             Some(&text[self.splits.last..])
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.n))
+    }
 }
+
+impl<'r, 't> FusedIterator for SplitN<'r, 't> {}
 
 /// CaptureLocations is a low level representation of the raw offsets of each
 /// submatch.
@@ -1075,6 +1092,8 @@ impl<'c, 't> Iterator for SubCaptureMatches<'c, 't> {
     }
 }
 
+impl<'c, 't> FusedIterator for SubCaptureMatches<'c, 't> {}
+
 /// An iterator that yields all non-overlapping capture groups matching a
 /// particular regular expression.
 ///
@@ -1098,6 +1117,8 @@ impl<'r, 't> Iterator for CaptureMatches<'r, 't> {
     }
 }
 
+impl<'r, 't> FusedIterator for CaptureMatches<'r, 't> {}
+
 /// An iterator over all non-overlapping matches for a particular string.
 ///
 /// The iterator yields a `Match` value. The iterator stops when no more
@@ -1115,6 +1136,8 @@ impl<'r, 't> Iterator for Matches<'r, 't> {
         self.0.next().map(|(s, e)| Match::new(text, s, e))
     }
 }
+
+impl<'r, 't> FusedIterator for Matches<'r, 't> {}
 
 /// Replacer describes types that can be used to replace matches in a string.
 ///


### PR DESCRIPTION
- Add missing implementations of FusedIterator.
- Add missing implementations of ExactSizeIterator.
- Add missing overrides of `Iterator::count` when wrapping a slice iterator.
- Add missing overrides of `Iterator::size_hint` when size hint is known.

Context: I'm building an implementation of Ruby `Regexp` on top of the `regex` crate, and having guarantees around whether iterators are fused will allow me to implement these traits on my wrapping `Iterator`s as well.