### PR TITLE
Shrink size of `Inst`

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -927,9 +927,10 @@ impl InstHole {
                 Inst::EmptyLook(InstEmptyLook { goto: goto, look: look })
             }
             InstHole::Char { c } => Inst::Char(InstChar { goto: goto, c: c }),
-            InstHole::Ranges { ref ranges } => {
-                Inst::Ranges(InstRanges { goto: goto, ranges: ranges.clone() })
-            }
+            InstHole::Ranges { ref ranges } => Inst::Ranges(InstRanges {
+                goto: goto,
+                ranges: ranges.clone().into_boxed_slice(),
+            }),
             InstHole::Bytes { start, end } => {
                 Inst::Bytes(InstBytes { goto: goto, start: start, end: end })
             }

--- a/src/prog.rs
+++ b/src/prog.rs
@@ -259,8 +259,8 @@ impl<'a> IntoIterator for &'a Program {
 ///
 /// Other than the benefit of moving invariants into the type system, another
 /// benefit is the decreased size. If we remove the `Char` and `Ranges`
-/// instructions from the `Inst` enum, then its size shrinks from 40 bytes to
-/// 24 bytes. (This is because of the removal of a `Vec` in the `Ranges`
+/// instructions from the `Inst` enum, then its size shrinks from 32 bytes to
+/// 24 bytes. (This is because of the removal of a `Box<[]>` in the `Ranges`
 /// variant.) Given that byte based machines are typically much bigger than
 /// their Unicode analogues (because they can decode UTF-8 directly), this ends
 /// up being a pretty significant savings.
@@ -374,7 +374,7 @@ pub struct InstRanges {
     /// succeeds.
     pub goto: InstPtr,
     /// The set of Unicode scalar value ranges to test.
-    pub ranges: Vec<(char, char)>,
+    pub ranges: Box<[(char, char)]>,
 }
 
 impl InstRanges {
@@ -430,5 +430,18 @@ impl InstBytes {
     /// Returns true if and only if the given byte is in this range.
     pub fn matches(&self, byte: u8) -> bool {
         self.start <= byte && byte <= self.end
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn test_size_of_inst() {
+        use std::mem::size_of;
+
+        use super::Inst;
+
+        assert_eq!(32, size_of::<Inst>());
     }
 }


### PR DESCRIPTION
By using a boxed slice instead of a vector, we can shrink the size
of the `Inst` structure by 8 bytes going from 40 to 32 bytes.
