### PR TITLE
Split `Inst` enum into `BytesInst` and `UnicodeInst` enums

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::iter;
+use std::mem;
 use std::result;
 use std::sync::Arc;
 
@@ -9,8 +10,8 @@ use syntax::is_word_byte;
 use syntax::utf8::{Utf8Range, Utf8Sequence, Utf8Sequences};
 
 use prog::{
-    EmptyLook, Inst, InstBytes, InstChar, InstEmptyLook, InstPtr, InstRanges,
-    InstSave, InstSplit, Program,
+    BytesInst, EmptyLook, InstBytes, InstChar, InstEmptyLook, InstPtr,
+    InstRanges, InstSave, InstSplit, InstTrait, Program, UnicodeInst,
 };
 
 use Error;
@@ -29,9 +30,9 @@ struct Patch {
 // `Compiler` is only public via the `internal` module, so avoid deriving
 // `Debug`.
 #[allow(missing_debug_implementations)]
-pub struct Compiler {
-    insts: Vec<MaybeInst>,
-    compiled: Program,
+pub struct Compiler<I: InstTrait> {
+    insts: Vec<MaybeInst<I>>,
+    compiled: Program<I>,
     capture_name_idx: HashMap<String, usize>,
     num_exprs: usize,
     size_limit: usize,
@@ -40,7 +41,7 @@ pub struct Compiler {
     byte_classes: ByteClassSet,
 }
 
-impl Compiler {
+impl<I: InstTrait> Compiler<I> {
     /// Create a new regular expression compiler.
     ///
     /// Various options can be set before calling `compile` on an expression.
@@ -62,22 +63,6 @@ impl Compiler {
     /// compilation will stop and return an error.
     pub fn size_limit(mut self, size_limit: usize) -> Self {
         self.size_limit = size_limit;
-        self
-    }
-
-    /// If bytes is true, then the program is compiled as a byte based
-    /// automaton, which incorporates UTF-8 decoding into the machine. If it's
-    /// false, then the automaton is Unicode scalar value based, e.g., an
-    /// engine utilizing such an automaton is responsible for UTF-8 decoding.
-    ///
-    /// The specific invariant is that when returning a byte based machine,
-    /// the neither the `Char` nor `Ranges` instructions are produced.
-    /// Conversely, when producing a Unicode scalar value machine, the `Bytes`
-    /// instruction is never produced.
-    ///
-    /// Note that `dfa(true)` implies `bytes(true)`.
-    pub fn bytes(mut self, yes: bool) -> Self {
-        self.compiled.is_bytes = yes;
         self
     }
 
@@ -108,13 +93,18 @@ impl Compiler {
         self.compiled.is_reverse = yes;
         self
     }
+}
 
+impl<I: InstTrait + From<(InstHole, usize)>> Compiler<I> {
     /// Compile a regular expression given its AST.
     ///
     /// The compiler is guaranteed to succeed unless the program exceeds the
     /// specified size limit. If the size limit is exceeded, then compilation
     /// stops and returns an error.
-    pub fn compile(mut self, exprs: &[Hir]) -> result::Result<Program, Error> {
+    pub fn compile(
+        mut self,
+        exprs: &[Hir],
+    ) -> result::Result<Program<I>, Error> {
         debug_assert!(!exprs.is_empty());
         self.num_exprs = exprs.len();
         if exprs.len() == 1 {
@@ -124,7 +114,7 @@ impl Compiler {
         }
     }
 
-    fn compile_one(mut self, expr: &Hir) -> result::Result<Program, Error> {
+    fn compile_one(mut self, expr: &Hir) -> result::Result<Program<I>, Error> {
         // If we're compiling a forward DFA and we aren't anchored, then
         // add a `.*?` before the first capture group.
         // Other matching engines handle this by baking the logic into the
@@ -145,14 +135,14 @@ impl Compiler {
         }
         self.fill_to_next(patch.hole);
         self.compiled.matches = vec![self.insts.len()];
-        self.push_compiled(Inst::Match(0));
+        self.push_compiled(I::new_match(0));
         self.compile_finish()
     }
 
     fn compile_many(
         mut self,
         exprs: &[Hir],
-    ) -> result::Result<Program, Error> {
+    ) -> result::Result<Program<I>, Error> {
         debug_assert!(exprs.len() > 1);
 
         self.compiled.is_anchored_start =
@@ -176,7 +166,7 @@ impl Compiler {
                 self.c_capture(0, expr)?.unwrap_or(self.next_inst());
             self.fill_to_next(hole);
             self.compiled.matches.push(self.insts.len());
-            self.push_compiled(Inst::Match(i));
+            self.push_compiled(I::new_match(i));
             prev_hole = self.fill_split(split, Some(entry), None);
         }
         let i = exprs.len() - 1;
@@ -185,11 +175,11 @@ impl Compiler {
         self.fill(prev_hole, entry);
         self.fill_to_next(hole);
         self.compiled.matches.push(self.insts.len());
-        self.push_compiled(Inst::Match(i));
+        self.push_compiled(I::new_match(i));
         self.compile_finish()
     }
 
-    fn compile_finish(mut self) -> result::Result<Program, Error> {
+    fn compile_finish(mut self) -> result::Result<Program<I>, Error> {
         self.compiled.insts =
             self.insts.into_iter().map(|inst| inst.unwrap()).collect();
         self.compiled.byte_classes = self.byte_classes.byte_classes();
@@ -474,9 +464,9 @@ impl Compiler {
         Ok(Some(Patch { hole: hole, entry: self.insts.len() - 1 }))
     }
 
-    fn c_concat<'a, I>(&mut self, exprs: I) -> ResultOrEmpty
+    fn c_concat<'a, E>(&mut self, exprs: E) -> ResultOrEmpty
     where
-        I: IntoIterator<Item = &'a Hir>,
+        E: IntoIterator<Item = &'a Hir>,
     {
         let mut exprs = exprs.into_iter();
         let Patch { mut hole, entry } = loop {
@@ -771,7 +761,7 @@ impl Compiler {
         }
     }
 
-    fn push_compiled(&mut self, inst: Inst) {
+    fn push_compiled(&mut self, inst: I) {
         self.insts.push(MaybeInst::Compiled(inst));
     }
 
@@ -795,7 +785,7 @@ impl Compiler {
     fn check_size(&self) -> result::Result<(), Error> {
         use std::mem::size_of;
 
-        if self.insts.len() * size_of::<Inst>() > self.size_limit {
+        if self.insts.len() * size_of::<I>() > self.size_limit {
             Err(Error::CompiledTooBig(self.size_limit))
         } else {
             Ok(())
@@ -822,29 +812,31 @@ impl Hole {
 }
 
 #[derive(Clone, Debug)]
-enum MaybeInst {
-    Compiled(Inst),
+enum MaybeInst<I> {
+    Compiled(I),
     Uncompiled(InstHole),
     Split,
     Split1(InstPtr),
     Split2(InstPtr),
 }
 
-impl MaybeInst {
+impl<I: InstTrait + From<(InstHole, usize)>> MaybeInst<I> {
     fn fill(&mut self, goto: InstPtr) {
         let maybeinst = match *self {
             MaybeInst::Split => MaybeInst::Split1(goto),
-            MaybeInst::Uncompiled(ref inst) => {
-                MaybeInst::Compiled(inst.fill(goto))
+            MaybeInst::Uncompiled(ref mut inst) => {
+                // Replace by dummy `InstHole`
+                let inst = mem::replace(inst, InstHole::Save { slot: 0 });
+                MaybeInst::Compiled((inst, goto).into())
             }
             MaybeInst::Split1(goto1) => {
-                MaybeInst::Compiled(Inst::Split(InstSplit {
+                MaybeInst::Compiled(I::new_split(InstSplit {
                     goto1: goto1,
                     goto2: goto,
                 }))
             }
             MaybeInst::Split2(goto2) => {
-                MaybeInst::Compiled(Inst::Split(InstSplit {
+                MaybeInst::Compiled(I::new_split(InstSplit {
                     goto1: goto,
                     goto2: goto2,
                 }))
@@ -861,7 +853,7 @@ impl MaybeInst {
     fn fill_split(&mut self, goto1: InstPtr, goto2: InstPtr) {
         let filled = match *self {
             MaybeInst::Split => {
-                Inst::Split(InstSplit { goto1: goto1, goto2: goto2 })
+                I::new_split(InstSplit { goto1: goto1, goto2: goto2 })
             }
             _ => unreachable!(
                 "must be called on Split instruction, \
@@ -896,7 +888,7 @@ impl MaybeInst {
         *self = MaybeInst::Split2(half_filled);
     }
 
-    fn unwrap(self) -> Inst {
+    fn unwrap(self) -> I {
         match self {
             MaybeInst::Compiled(inst) => inst,
             _ => unreachable!(
@@ -908,8 +900,10 @@ impl MaybeInst {
     }
 }
 
+// TODO: Specialize `compile` into `compile_bytes` and `compile_unicode`
+// to avoid making `InstHole` public?
 #[derive(Clone, Debug)]
-enum InstHole {
+pub enum InstHole {
     Save { slot: usize },
     EmptyLook { look: EmptyLook },
     Char { c: char },
@@ -917,32 +911,60 @@ enum InstHole {
     Bytes { start: u8, end: u8 },
 }
 
-impl InstHole {
-    fn fill(&self, goto: InstPtr) -> Inst {
-        match *self {
+impl From<(InstHole, InstPtr)> for UnicodeInst {
+    fn from(val: (InstHole, InstPtr)) -> UnicodeInst {
+        let (hole, goto) = val;
+        match hole {
             InstHole::Save { slot } => {
-                Inst::Save(InstSave { goto: goto, slot: slot })
+                UnicodeInst::Save(InstSave { goto: goto, slot: slot })
             }
             InstHole::EmptyLook { look } => {
-                Inst::EmptyLook(InstEmptyLook { goto: goto, look: look })
+                UnicodeInst::EmptyLook(InstEmptyLook {
+                    goto: goto,
+                    look: look,
+                })
             }
-            InstHole::Char { c } => Inst::Char(InstChar { goto: goto, c: c }),
+            InstHole::Char { c } => {
+                UnicodeInst::Char(InstChar { goto: goto, c: c })
+            }
             InstHole::Ranges { ref ranges } => {
-                Inst::Ranges(InstRanges { goto: goto, ranges: ranges.clone() })
+                UnicodeInst::Ranges(InstRanges {
+                    goto: goto,
+                    ranges: ranges.clone(),
+                })
             }
-            InstHole::Bytes { start, end } => {
-                Inst::Bytes(InstBytes { goto: goto, start: start, end: end })
-            }
+            InstHole::Bytes { .. } => unreachable!(),
         }
     }
 }
 
-struct CompileClass<'a, 'b> {
-    c: &'a mut Compiler,
+impl From<(InstHole, InstPtr)> for BytesInst {
+    fn from(val: (InstHole, InstPtr)) -> BytesInst {
+        let (hole, goto) = val;
+        match hole {
+            InstHole::Save { slot } => {
+                BytesInst::Save(InstSave { goto: goto, slot: slot })
+            }
+            InstHole::EmptyLook { look } => {
+                BytesInst::EmptyLook(InstEmptyLook { goto: goto, look: look })
+            }
+            InstHole::Char { .. } => unreachable!(),
+            InstHole::Ranges { .. } => unreachable!(),
+            InstHole::Bytes { start, end } => BytesInst::Bytes(InstBytes {
+                goto: goto,
+                start: start,
+                end: end,
+            }),
+        }
+    }
+}
+
+struct CompileClass<'a, 'b, I: InstTrait> {
+    c: &'a mut Compiler<I>,
     ranges: &'b [hir::ClassUnicodeRange],
 }
 
-impl<'a, 'b> CompileClass<'a, 'b> {
+impl<'a, 'b, I: InstTrait + From<(InstHole, usize)>> CompileClass<'a, 'b, I> {
     fn compile(mut self) -> Result {
         let mut holes = vec![];
         let mut initial_entry = None;
@@ -992,9 +1014,9 @@ impl<'a, 'b> CompileClass<'a, 'b> {
         }
     }
 
-    fn c_utf8_seq_<'r, I>(&mut self, seq: I) -> Result
+    fn c_utf8_seq_<'r, S>(&mut self, seq: S) -> Result
     where
-        I: IntoIterator<Item = &'r Utf8Range>,
+        S: IntoIterator<Item = &'r Utf8Range>,
     {
         // The initial instruction for each UTF-8 sequence should be the same.
         let mut from_inst = ::std::usize::MAX;
@@ -1013,17 +1035,14 @@ impl<'a, 'b> CompileClass<'a, 'b> {
                 }
             }
             self.c.byte_classes.set_range(byte_range.start, byte_range.end);
+            let inst_hole = InstHole::Bytes {
+                start: byte_range.start,
+                end: byte_range.end,
+            };
             if from_inst == ::std::usize::MAX {
-                last_hole = self.c.push_hole(InstHole::Bytes {
-                    start: byte_range.start,
-                    end: byte_range.end,
-                });
+                last_hole = self.c.push_hole(inst_hole);
             } else {
-                self.c.push_compiled(Inst::Bytes(InstBytes {
-                    goto: from_inst,
-                    start: byte_range.start,
-                    end: byte_range.end,
-                }));
+                self.c.push_compiled((inst_hole, from_inst).into());
             }
             from_inst = self.c.insts.len().checked_sub(1).unwrap();
             debug_assert!(from_inst < ::std::usize::MAX);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -781,5 +781,5 @@ pub mod internal {
     pub use exec::{Exec, ExecBuilder};
     pub use input::{Char, CharInput, Input, InputAt};
     pub use literal::LiteralSearcher;
-    pub use prog::{EmptyLook, Inst, InstRanges, Program};
+    pub use prog::{BytesInst, EmptyLook, InstRanges, Program, UnicodeInst};
 }

--- a/src/prog.rs
+++ b/src/prog.rs
@@ -15,9 +15,9 @@ pub type InstPtr = usize;
 /// Program is a sequence of instructions and various facts about thos
 /// instructions.
 #[derive(Clone)]
-pub struct Program {
+pub struct Program<I: InstTrait> {
     /// A sequence of instructions that represents an NFA.
-    pub insts: Vec<Inst>,
+    pub insts: Vec<I>,
     /// Pointers to each Match instruction in the sequence.
     ///
     /// This is always length 1 unless this program represents a regex set.
@@ -38,9 +38,6 @@ pub struct Program {
     pub byte_classes: Vec<u8>,
     /// When true, this program can only match valid UTF-8.
     pub only_utf8: bool,
-    /// When true, this program uses byte range instructions instead of Unicode
-    /// range instructions.
-    pub is_bytes: bool,
     /// When true, the program is compiled for DFA matching. For example, this
     /// implies `is_bytes` and also inserts a preceding `.*?` for unanchored
     /// regexes.
@@ -74,7 +71,7 @@ pub struct Program {
     pub dfa_size_limit: usize,
 }
 
-impl Program {
+impl<I: InstTrait> Program<I> {
     /// Creates an empty instruction sequence. Fields are given default
     /// values.
     pub fn new() -> Self {
@@ -86,7 +83,6 @@ impl Program {
             start: 0,
             byte_classes: vec![0; 256],
             only_utf8: true,
-            is_bytes: false,
             is_dfa: false,
             is_reverse: false,
             is_anchored_start: false,
@@ -101,9 +97,9 @@ impl Program {
     /// next pc that is not a no-op instruction.
     pub fn skip(&self, mut pc: usize) -> usize {
         loop {
-            match self[pc] {
-                Inst::Save(ref i) => pc = i.goto,
-                _ => return pc,
+            match self[pc].save_goto() {
+                Some(goto) => pc = goto,
+                None => return pc,
             }
         }
     }
@@ -117,10 +113,7 @@ impl Program {
             // meaningless.
             return false;
         }
-        match self[self.skip(pc)] {
-            Inst::Match(_) => true,
-            _ => false,
-        }
+        self[self.skip(pc)].is_match()
     }
 
     /// Returns true if the current configuration demands that an implicit
@@ -132,7 +125,7 @@ impl Program {
     /// Returns true if this program uses Byte instructions instead of
     /// Char/Range instructions.
     pub fn uses_bytes(&self) -> bool {
-        self.is_bytes || self.is_dfa
+        I::IS_BYTES || self.is_dfa
     }
 
     /// Returns true if this program exclusively matches valid UTF-8 bytes.
@@ -148,7 +141,7 @@ impl Program {
         // The only instruction that uses heap space is Ranges (for
         // Unicode codepoint programs) to store non-overlapping codepoint
         // ranges. To keep this operation constant time, we ignore them.
-        (self.len() * mem::size_of::<Inst>())
+        (self.len() * mem::size_of::<I>())
             + (self.matches.len() * mem::size_of::<InstPtr>())
             + (self.captures.len() * mem::size_of::<Option<String>>())
             + (self.capture_name_idx.len()
@@ -158,8 +151,8 @@ impl Program {
     }
 }
 
-impl Deref for Program {
-    type Target = [Inst];
+impl<I: InstTrait> Deref for Program<I> {
+    type Target = [I];
 
     #[cfg_attr(feature = "perf-inline", inline(always))]
     fn deref(&self) -> &Self::Target {
@@ -167,67 +160,13 @@ impl Deref for Program {
     }
 }
 
-impl fmt::Debug for Program {
+impl<I: InstTrait> fmt::Debug for Program<I> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Inst::*;
-
-        fn with_goto(cur: usize, goto: usize, fmtd: String) -> String {
-            if goto == cur + 1 {
-                fmtd
-            } else {
-                format!("{} (goto: {})", fmtd, goto)
-            }
-        }
-
-        fn visible_byte(b: u8) -> String {
-            use std::ascii::escape_default;
-            let escaped = escape_default(b).collect::<Vec<u8>>();
-            String::from_utf8_lossy(&escaped).into_owned()
-        }
-
         for (pc, inst) in self.iter().enumerate() {
-            match *inst {
-                Match(slot) => write!(f, "{:04} Match({:?})", pc, slot)?,
-                Save(ref inst) => {
-                    let s = format!("{:04} Save({})", pc, inst.slot);
-                    write!(f, "{}", with_goto(pc, inst.goto, s))?;
-                }
-                Split(ref inst) => {
-                    write!(
-                        f,
-                        "{:04} Split({}, {})",
-                        pc, inst.goto1, inst.goto2
-                    )?;
-                }
-                EmptyLook(ref inst) => {
-                    let s = format!("{:?}", inst.look);
-                    write!(f, "{:04} {}", pc, with_goto(pc, inst.goto, s))?;
-                }
-                Char(ref inst) => {
-                    let s = format!("{:?}", inst.c);
-                    write!(f, "{:04} {}", pc, with_goto(pc, inst.goto, s))?;
-                }
-                Ranges(ref inst) => {
-                    let ranges = inst
-                        .ranges
-                        .iter()
-                        .map(|r| format!("{:?}-{:?}", r.0, r.1))
-                        .collect::<Vec<String>>()
-                        .join(", ");
-                    write!(
-                        f,
-                        "{:04} {}",
-                        pc,
-                        with_goto(pc, inst.goto, ranges)
-                    )?;
-                }
-                Bytes(ref inst) => {
-                    let s = format!(
-                        "Bytes({}, {})",
-                        visible_byte(inst.start),
-                        visible_byte(inst.end)
-                    );
-                    write!(f, "{:04} {}", pc, with_goto(pc, inst.goto, s))?;
+            write!(f, "{:04} {:?}", pc, inst)?;
+            if let Some(goto) = inst.goto() {
+                if pc + 1 == goto {
+                    write!(f, " (goto: {})", goto)?;
                 }
             }
             if pc == self.start {
@@ -239,33 +178,34 @@ impl fmt::Debug for Program {
     }
 }
 
-impl<'a> IntoIterator for &'a Program {
-    type Item = &'a Inst;
-    type IntoIter = slice::Iter<'a, Inst>;
+impl<'a, I: InstTrait> IntoIterator for &'a Program<I> {
+    type Item = &'a I;
+    type IntoIter = slice::Iter<'a, I>;
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-/// Inst is an instruction code in a Regex program.
+/// `InstTrait` represents an instruction code in a Regex program.
 ///
 /// Regrettably, a regex program either contains Unicode codepoint
-/// instructions (Char and Ranges) or it contains byte instructions (Bytes).
+/// instructions (Char and Ranges: [`UnicodeInst`]) or it contains
+/// byte instructions (Bytes: [`BytesInst`]).
 /// A regex program can never contain both.
-///
-/// It would be worth investigating splitting this into two distinct types and
-/// then figuring out how to make the matching engines polymorphic over those
-/// types without sacrificing performance.
-///
-/// Other than the benefit of moving invariants into the type system, another
-/// benefit is the decreased size. If we remove the `Char` and `Ranges`
-/// instructions from the `Inst` enum, then its size shrinks from 40 bytes to
-/// 24 bytes. (This is because of the removal of a `Vec` in the `Ranges`
-/// variant.) Given that byte based machines are typically much bigger than
-/// their Unicode analogues (because they can decode UTF-8 directly), this ends
-/// up being a pretty significant savings.
-#[derive(Clone, Debug)]
-pub enum Inst {
+pub trait InstTrait: fmt::Debug {
+    const IS_BYTES: bool;
+
+    /// Returns true if and only if this is a match instruction.
+    fn is_match(&self) -> bool;
+    fn goto(&self) -> Option<usize>;
+    fn save_goto(&self) -> Option<usize>;
+    fn new_match(i: usize) -> Self;
+    fn new_split(split: InstSplit) -> Self;
+}
+
+/// A Unicode codepoint instruction.
+#[derive(Clone)]
+pub enum UnicodeInst {
     /// Match indicates that the program has reached a match state.
     ///
     /// The number in the match corresponds to the Nth logical regular
@@ -289,18 +229,171 @@ pub enum Inst {
     /// Ranges requires the regex program to match the character at the current
     /// position in the input with one of the ranges specified in InstRanges.
     Ranges(InstRanges),
+}
+
+impl InstTrait for UnicodeInst {
+    const IS_BYTES: bool = false;
+
+    #[inline]
+    fn is_match(&self) -> bool {
+        match *self {
+            Self::Match(_) => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    fn goto(&self) -> Option<usize> {
+        match self {
+            Self::Match(_) => None,
+            Self::Save(ref inst) => Some(inst.goto),
+            Self::Split(_) => None,
+            Self::EmptyLook(ref inst) => Some(inst.goto),
+            Self::Char(ref inst) => Some(inst.goto),
+            Self::Ranges(ref inst) => Some(inst.goto),
+        }
+    }
+
+    #[inline]
+    fn save_goto(&self) -> Option<usize> {
+        match self {
+            Self::Save(ref inst) => Some(inst.goto),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn new_match(i: usize) -> Self {
+        Self::Match(i)
+    }
+
+    #[inline]
+    fn new_split(split: InstSplit) -> Self {
+        Self::Split(split)
+    }
+}
+
+impl fmt::Debug for UnicodeInst {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Match(slot) => write!(f, "Match({:?})", slot),
+            Self::Save(ref inst) => write!(f, "Save({})", inst.slot),
+            Self::Split(ref inst) => {
+                write!(f, "Split({}, {})", inst.goto1, inst.goto2)
+            }
+            Self::EmptyLook(ref inst) => {
+                write!(f, "{:?}", inst.look)
+            }
+            Self::Char(ref inst) => {
+                write!(f, "{:?}", inst.c)
+            }
+            Self::Ranges(ref inst) => {
+                write!(
+                    f,
+                    "{}",
+                    inst.ranges
+                        .iter()
+                        .map(|r| format!("{:?}-{:?}", r.0, r.1))
+                        .collect::<Vec<String>>()
+                        .join(", ")
+                )
+            }
+        }
+    }
+}
+
+/// A byte instruction.
+#[derive(Clone)]
+pub enum BytesInst {
+    /// Match indicates that the program has reached a match state.
+    ///
+    /// The number in the match corresponds to the Nth logical regular
+    /// expression in this program. This index is always 0 for normal regex
+    /// programs. Values greater than 0 appear when compiling regex sets, and
+    /// each match instruction gets its own unique value. The value corresponds
+    /// to the Nth regex in the set.
+    Match(usize),
+    /// Save causes the program to save the current location of the input in
+    /// the slot indicated by InstSave.
+    Save(InstSave),
+    /// Split causes the program to diverge to one of two paths in the
+    /// program, preferring goto1 in InstSplit.
+    Split(InstSplit),
+    /// EmptyLook represents a zero-width assertion in a regex program. A
+    /// zero-width assertion does not consume any of the input text.
+    EmptyLook(InstEmptyLook),
     /// Bytes is like Ranges, except it expresses a single byte range. It is
     /// used in conjunction with Split instructions to implement multi-byte
     /// character classes.
     Bytes(InstBytes),
 }
 
-impl Inst {
-    /// Returns true if and only if this is a match instruction.
-    pub fn is_match(&self) -> bool {
+impl InstTrait for BytesInst {
+    const IS_BYTES: bool = true;
+
+    #[inline]
+    fn is_match(&self) -> bool {
         match *self {
-            Inst::Match(_) => true,
+            Self::Match(_) => true,
             _ => false,
+        }
+    }
+
+    #[inline]
+    fn goto(&self) -> Option<usize> {
+        match self {
+            Self::Match(_) => None,
+            Self::Save(ref inst) => Some(inst.goto),
+            Self::Split(_) => None,
+            Self::EmptyLook(ref inst) => Some(inst.goto),
+            Self::Bytes(ref inst) => Some(inst.goto),
+        }
+    }
+
+    #[inline]
+    fn save_goto(&self) -> Option<usize> {
+        match self {
+            Self::Save(ref inst) => Some(inst.goto),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn new_match(i: usize) -> Self {
+        Self::Match(i)
+    }
+
+    #[inline]
+    fn new_split(split: InstSplit) -> Self {
+        Self::Split(split)
+    }
+}
+
+impl fmt::Debug for BytesInst {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn visible_byte(b: u8) -> String {
+            use std::ascii::escape_default;
+            let escaped = escape_default(b).collect::<Vec<u8>>();
+            String::from_utf8_lossy(&escaped).into_owned()
+        }
+
+        match self {
+            Self::Match(slot) => write!(f, "Match({:?})", slot),
+            Self::Save(ref inst) => write!(f, "Save({})", inst.slot),
+            Self::Split(ref inst) => {
+                write!(f, "Split({}, {})", inst.goto1, inst.goto2)
+            }
+            Self::EmptyLook(ref inst) => {
+                write!(f, "{:?}", inst.look)
+            }
+            Self::Bytes(ref inst) => {
+                write!(
+                    f,
+                    "Bytes({}, {})",
+                    visible_byte(inst.start),
+                    visible_byte(inst.end)
+                )
+            }
         }
     }
 }
@@ -430,5 +523,19 @@ impl InstBytes {
     /// Returns true if and only if the given byte is in this range.
     pub fn matches(&self, byte: u8) -> bool {
         self.start <= byte && byte <= self.end
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn test_size_of_inst() {
+        use std::mem::size_of;
+
+        use super::{BytesInst, UnicodeInst};
+
+        assert_eq!(24, size_of::<BytesInst>());
+        assert_eq!(40, size_of::<UnicodeInst>());
     }
 }


### PR DESCRIPTION
While trying to understand better the internals of the crate, I stumbled upon this comment:
```Rust
/// Regrettably, a regex program either contains Unicode codepoint
/// instructions (Char and Ranges) or it contains byte instructions (Bytes).
/// A regex program can never contain both.
///
/// It would be worth investigating splitting this into two distinct types and
/// then figuring out how to make the matching engines polymorphic over those
/// types without sacrificing performance.
///
/// Other than the benefit of moving invariants into the type system, another
/// benefit is the decreased size. If we remove the `Char` and `Ranges`
/// instructions from the `Inst` enum, then its size shrinks from 40 bytes to
/// 24 bytes. (This is because of the removal of a `Vec` in the `Ranges`
/// variant.) Given that byte based machines are typically much bigger than
/// their Unicode analogues (because they can decode UTF-8 directly), this ends
/// up being a pretty significant savings.
```

This is what this PR proposes to implement by making `Program` generic over the instruction type: `Program<I>`.
All tests seem should pass but benchmarks have not been updated yet.

cc @BurntSushi, I hope this will be useful :+1: 