### PR TITLE
fix rustc version in badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ by [RE2](https://github.com/google/re2).
 
 [![Build status](https://github.com/rust-lang/regex/workflows/ci/badge.svg)](https://github.com/rust-lang/regex/actions)
 [![](https://meritbadge.herokuapp.com/regex)](https://crates.io/crates/regex)
-[![Rust](https://img.shields.io/badge/rust-1.28.0%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/regex)
+[![Rust](https://img.shields.io/badge/rust-1.41.1%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/regex)
 
 ### Documentation
 


### PR DESCRIPTION
MSRV has been bumped to 1.41.1 in regex 1.5.0 / commit 832ba73, so this should be reflected in the readme, too.