### PR TITLE
re_builder: add throwaway_on_parse_error flag

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -246,8 +246,13 @@ impl ExecBuilder {
                 .allow_invalid_utf8(!self.only_utf8)
                 .nest_limit(self.options.nest_limit)
                 .build();
-            let expr =
-                parser.parse(pat).map_err(|e| Error::Syntax(e.to_string()))?;
+            let parse_res = parser.parse(pat);
+            if parse_res.is_err() && self.options.throwaway_on_parse_error {
+                // The user opted to drop regex parse errors from the set
+                // instead of erroring out.
+                continue;
+            }
+            let expr = parse_res.map_err(|e| Error::Syntax(e.to_string()))?;
             bytes = bytes || !expr.is_always_utf8();
 
             if cfg!(feature = "perf-literal") {

--- a/src/re_builder.rs
+++ b/src/re_builder.rs
@@ -11,6 +11,7 @@ pub struct RegexOptions {
     pub dot_matches_new_line: bool,
     pub swap_greed: bool,
     pub ignore_whitespace: bool,
+    pub throwaway_on_parse_error: bool,
     pub unicode: bool,
     pub octal: bool,
 }
@@ -27,6 +28,7 @@ impl Default for RegexOptions {
             dot_matches_new_line: false,
             swap_greed: false,
             ignore_whitespace: false,
+            throwaway_on_parse_error: false,
             unicode: true,
             octal: false,
         }
@@ -321,6 +323,19 @@ macro_rules! define_set_builder {
                     yes: bool,
                 ) -> &mut RegexSetBuilder {
                     self.0.ignore_whitespace = yes;
+                    self
+                }
+
+                /// Set the value for the throwaway on parse error (`x`) flag.
+                ///
+                /// When enabled, regexes that don't compile will be excluded
+                /// from the set, and RegexSetBuilder.build() will not return
+                /// an error if a bad regex is provided.
+                pub fn throwaway_on_parse_error(
+                    &mut self,
+                    yes: bool,
+                ) -> &mut RegexSetBuilder {
+                    self.0.throwaway_on_parse_error = yes;
                     self
                 }
 


### PR DESCRIPTION
This flag is exposed to the RegexSetBuilder when the caller wants
malformed regexes thrown out. It is useful for dealing with user
provided regexes. Disabled by default because in most cases people want
this to fail loudly.

An example use case is:

```
   let set = RegexSetBuilder::new(&[
        String::from(r"foo"),
        String::from(r"bar"),
        String::from(r#"/^\=/"#), // this regex doesn't compile!
    ]).throwaway_on_parse_error(true).build().unwrap();
    assert!(set.is_match("foobar"));
```