### PR TITLE
Fix some clippy lints up to rust 1.41.1

### DIFF
--- a/regex-syntax/src/ast/mod.rs
+++ b/regex-syntax/src/ast/mod.rs
@@ -385,7 +385,7 @@ impl PartialOrd for Position {
 impl Span {
     /// Create a new span with the given positions.
     pub fn new(start: Position, end: Position) -> Span {
-        Span { start: start, end: end }
+        Span { start, end }
     }
 
     /// Create a new span using the given position as the start and end.
@@ -427,7 +427,7 @@ impl Position {
     ///
     /// `column` is the approximate column number, starting at `1`.
     pub fn new(offset: usize, line: usize, column: usize) -> Position {
-        Position { offset: offset, line: line, column: column }
+        Position { offset, line, column }
     }
 }
 

--- a/regex-syntax/src/ast/parse.rs
+++ b/regex-syntax/src/ast/parse.rs
@@ -366,7 +366,7 @@ impl Parser {
 impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
     /// Build an internal parser from a parser configuration and a pattern.
     fn new(parser: P, pattern: &'s str) -> ParserI<'s, P> {
-        ParserI { parser: parser, pattern: pattern }
+        ParserI { parser, pattern }
     }
 
     /// Return a reference to the parser state.
@@ -381,11 +381,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
 
     /// Create a new error with the given span and error type.
     fn error(&self, span: Span, kind: ast::ErrorKind) -> ast::Error {
-        ast::Error {
-            kind: kind,
-            pattern: self.pattern().to_string(),
-            span: span,
-        }
+        ast::Error { kind, pattern: self.pattern().to_string(), span }
     }
 
     /// Return the current offset of the parser.
@@ -481,11 +477,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
             column = column.checked_add(1).unwrap();
         }
         offset += self.char().len_utf8();
-        self.parser().pos.set(Position {
-            offset: offset,
-            line: line,
-            column: column,
-        });
+        self.parser().pos.set(Position { offset, line, column });
         self.pattern()[self.offset()..].chars().next().is_some()
     }
 
@@ -703,8 +695,8 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
                     .unwrap_or(old_ignore_whitespace);
                 self.parser().stack_group.borrow_mut().push(
                     GroupState::Group {
-                        concat: concat,
-                        group: group,
+                        concat,
+                        group,
                         ignore_whitespace: old_ignore_whitespace,
                     },
                 );
@@ -899,12 +891,8 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
     #[inline(never)]
     fn unclosed_class_error(&self) -> ast::Error {
         for state in self.parser().stack_class.borrow().iter().rev() {
-            match *state {
-                ClassState::Open { ref set, .. } => {
-                    return self
-                        .error(set.span, ast::ErrorKind::ClassUnclosed);
-                }
-                _ => {}
+            if let ClassState::Open { ref set, .. } = *state {
+                return self.error(set.span, ast::ErrorKind::ClassUnclosed);
             }
         }
         // We are guaranteed to have a non-empty stack with at least
@@ -950,8 +938,8 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
         };
         let span = Span::new(lhs.span().start, rhs.span().end);
         ast::ClassSet::BinaryOp(ast::ClassSetBinaryOp {
-            span: span,
-            kind: kind,
+            span,
+            kind,
             lhs: Box::new(lhs),
             rhs: Box::new(rhs),
         })
@@ -1010,7 +998,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
         let ast = self.pop_group_end(concat)?;
         NestLimiter::new(self).check(&ast)?;
         Ok(ast::WithComments {
-            ast: ast,
+            ast,
             comments: mem::replace(
                 &mut *self.parser().comments.borrow_mut(),
                 vec![],
@@ -1066,9 +1054,9 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
             span: ast.span().with_end(self.pos()),
             op: ast::RepetitionOp {
                 span: Span::new(op_start, self.pos()),
-                kind: kind,
+                kind,
             },
-            greedy: greedy,
+            greedy,
             ast: Box::new(ast),
         }));
         Ok(concat)
@@ -1170,7 +1158,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
                 span: op_span,
                 kind: ast::RepetitionKind::Range(range),
             },
-            greedy: greedy,
+            greedy,
             ast: Box::new(ast),
         }));
         Ok(concat)
@@ -1235,7 +1223,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
                 }
                 Ok(Either::Left(ast::SetFlags {
                     span: Span { end: self.pos(), ..open_span },
-                    flags: flags,
+                    flags,
                 }))
             } else {
                 assert_eq!(char_end, ':');
@@ -1428,7 +1416,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
                 let ast = Primitive::Literal(ast::Literal {
                     span: self.span_char(),
                     kind: ast::LiteralKind::Verbatim,
-                    c: c,
+                    c,
                 });
                 self.bump();
                 Ok(ast)
@@ -1494,16 +1482,16 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
         let span = Span::new(start, self.pos());
         if is_meta_character(c) {
             return Ok(Primitive::Literal(ast::Literal {
-                span: span,
+                span,
                 kind: ast::LiteralKind::Punctuation,
-                c: c,
+                c,
             }));
         }
         let special = |kind, c| {
             Ok(Primitive::Literal(ast::Literal {
-                span: span,
+                span,
                 kind: ast::LiteralKind::Special(kind),
-                c: c,
+                c,
             }))
         };
         match c {
@@ -1517,19 +1505,19 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
                 special(ast::SpecialLiteralKind::Space, ' ')
             }
             'A' => Ok(Primitive::Assertion(ast::Assertion {
-                span: span,
+                span,
                 kind: ast::AssertionKind::StartText,
             })),
             'z' => Ok(Primitive::Assertion(ast::Assertion {
-                span: span,
+                span,
                 kind: ast::AssertionKind::EndText,
             })),
             'b' => Ok(Primitive::Assertion(ast::Assertion {
-                span: span,
+                span,
                 kind: ast::AssertionKind::WordBoundary,
             })),
             'B' => Ok(Primitive::Assertion(ast::Assertion {
-                span: span,
+                span,
                 kind: ast::AssertionKind::NotWordBoundary,
             })),
             _ => Err(self.error(span, ast::ErrorKind::EscapeUnrecognized)),
@@ -1569,7 +1557,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
         ast::Literal {
             span: Span::new(start, end),
             kind: ast::LiteralKind::Octal,
-            c: c,
+            c,
         }
     }
 
@@ -1645,7 +1633,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
             Some(c) => Ok(ast::Literal {
                 span: Span::new(start, end),
                 kind: ast::LiteralKind::HexFixed(kind),
-                c: c,
+                c,
             }),
         }
     }
@@ -1700,7 +1688,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
             Some(c) => Ok(ast::Literal {
                 span: Span::new(start, self.pos()),
                 kind: ast::LiteralKind::HexBrace(kind),
-                c: c,
+                c,
             }),
         }
     }
@@ -1949,7 +1937,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
         }
         let set = ast::ClassBracketed {
             span: Span::new(start, self.pos()),
-            negated: negated,
+            negated,
             kind: ast::ClassSet::union(ast::ClassSetUnion {
                 span: Span::new(union.span.start, union.span.start),
                 items: vec![],
@@ -2026,8 +2014,8 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
         };
         Some(ast::ClassAscii {
             span: Span::new(start, self.pos()),
-            kind: kind,
-            negated: negated,
+            kind,
+            negated,
         })
     }
 
@@ -2108,8 +2096,8 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
         };
         Ok(ast::ClassUnicode {
             span: Span::new(start, self.pos()),
-            negated: negated,
-            kind: kind,
+            negated,
+            kind,
         })
     }
 
@@ -2130,7 +2118,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
             'W' => (true, ast::ClassPerlKind::Word),
             c => panic!("expected valid Perl class but got '{}'", c),
         };
-        ast::ClassPerl { span: span, kind: kind, negated: negated }
+        ast::ClassPerl { span, kind, negated }
     }
 }
 
@@ -2146,7 +2134,7 @@ struct NestLimiter<'p, 's, P> {
 
 impl<'p, 's, P: Borrow<Parser>> NestLimiter<'p, 's, P> {
     fn new(p: &'p ParserI<'s, P>) -> NestLimiter<'p, 's, P> {
-        NestLimiter { p: p, depth: 0 }
+        NestLimiter { p, depth: 0 }
     }
 
     #[inline(never)]
@@ -2429,18 +2417,18 @@ mod tests {
     /// Create a punctuation literal starting at the given position.
     fn punct_lit(c: char, span: Span) -> Ast {
         Ast::Literal(ast::Literal {
-            span: span,
+            span,
             kind: ast::LiteralKind::Punctuation,
-            c: c,
+            c,
         })
     }
 
     /// Create a verbatim literal with the given span.
     fn lit_with(c: char, span: Span) -> Ast {
         Ast::Literal(ast::Literal {
-            span: span,
+            span,
             kind: ast::LiteralKind::Verbatim,
-            c: c,
+            c,
         })
     }
 
@@ -2451,12 +2439,12 @@ mod tests {
 
     /// Create a concatenation with the given span.
     fn concat_with(span: Span, asts: Vec<Ast>) -> Ast {
-        Ast::Concat(ast::Concat { span: span, asts: asts })
+        Ast::Concat(ast::Concat { span, asts })
     }
 
     /// Create an alternation with the given span.
     fn alt(range: Range<usize>, asts: Vec<Ast>) -> Ast {
-        Ast::Alternation(ast::Alternation { span: span(range), asts: asts })
+        Ast::Alternation(ast::Alternation { span: span(range), asts })
     }
 
     /// Create a capturing group with the given span.
@@ -2498,7 +2486,7 @@ mod tests {
             span: span_range(pat, range.clone()),
             flags: ast::Flags {
                 span: span_range(pat, (range.start + 2)..(range.end - 1)),
-                items: items,
+                items,
             },
         })
     }
@@ -4208,7 +4196,7 @@ bar
                 Ok(Primitive::Literal(ast::Literal {
                     span: span(0..2),
                     kind: ast::LiteralKind::Special(kind.clone()),
-                    c: c,
+                    c,
                 }))
             );
         }
@@ -4402,7 +4390,7 @@ bar
                     kind: ast::LiteralKind::HexFixed(
                         ast::HexLiteralKind::UnicodeShort
                     ),
-                    c: c,
+                    c,
                 }))
             );
         }
@@ -4466,7 +4454,7 @@ bar
                     kind: ast::LiteralKind::HexFixed(
                         ast::HexLiteralKind::UnicodeLong
                     ),
-                    c: c,
+                    c,
                 }))
             );
         }
@@ -4667,10 +4655,7 @@ bar
     #[test]
     fn parse_set_class() {
         fn union(span: Span, items: Vec<ast::ClassSetItem>) -> ast::ClassSet {
-            ast::ClassSet::union(ast::ClassSetUnion {
-                span: span,
-                items: items,
-            })
+            ast::ClassSet::union(ast::ClassSetUnion { span, items })
         }
 
         fn intersection(
@@ -4679,7 +4664,7 @@ bar
             rhs: ast::ClassSet,
         ) -> ast::ClassSet {
             ast::ClassSet::BinaryOp(ast::ClassSetBinaryOp {
-                span: span,
+                span,
                 kind: ast::ClassSetBinaryOpKind::Intersection,
                 lhs: Box::new(lhs),
                 rhs: Box::new(rhs),
@@ -4692,7 +4677,7 @@ bar
             rhs: ast::ClassSet,
         ) -> ast::ClassSet {
             ast::ClassSet::BinaryOp(ast::ClassSetBinaryOp {
-                span: span,
+                span,
                 kind: ast::ClassSetBinaryOpKind::Difference,
                 lhs: Box::new(lhs),
                 rhs: Box::new(rhs),
@@ -4705,7 +4690,7 @@ bar
             rhs: ast::ClassSet,
         ) -> ast::ClassSet {
             ast::ClassSet::BinaryOp(ast::ClassSetBinaryOp {
-                span: span,
+                span,
                 kind: ast::ClassSetBinaryOpKind::SymmetricDifference,
                 lhs: Box::new(lhs),
                 rhs: Box::new(rhs),
@@ -4734,9 +4719,9 @@ bar
 
         fn lit(span: Span, c: char) -> ast::ClassSetItem {
             ast::ClassSetItem::Literal(ast::Literal {
-                span: span,
+                span,
                 kind: ast::LiteralKind::Verbatim,
-                c: c,
+                c,
             })
         }
 
@@ -4756,7 +4741,7 @@ bar
                 ..span.end
             };
             ast::ClassSetItem::Range(ast::ClassSetRange {
-                span: span,
+                span,
                 start: ast::Literal {
                     span: Span { end: pos1, ..span },
                     kind: ast::LiteralKind::Verbatim,
@@ -4771,19 +4756,11 @@ bar
         }
 
         fn alnum(span: Span, negated: bool) -> ast::ClassAscii {
-            ast::ClassAscii {
-                span: span,
-                kind: ast::ClassAsciiKind::Alnum,
-                negated: negated,
-            }
+            ast::ClassAscii { span, kind: ast::ClassAsciiKind::Alnum, negated }
         }
 
         fn lower(span: Span, negated: bool) -> ast::ClassAscii {
-            ast::ClassAscii {
-                span: span,
-                kind: ast::ClassAsciiKind::Lower,
-                negated: negated,
-            }
+            ast::ClassAscii { span, kind: ast::ClassAsciiKind::Lower, negated }
         }
 
         assert_eq!(

--- a/regex-syntax/src/ast/print.rs
+++ b/regex-syntax/src/ast/print.rs
@@ -57,7 +57,7 @@ impl Printer {
     /// here are a `fmt::Formatter` (which is available in `fmt::Display`
     /// implementations) or a `&mut String`.
     pub fn print<W: fmt::Write>(&mut self, ast: &Ast, wtr: W) -> fmt::Result {
-        visitor::visit(ast, Writer { printer: self, wtr: wtr })
+        visitor::visit(ast, Writer { printer: self, wtr })
     }
 }
 

--- a/regex-syntax/src/ast/visitor.rs
+++ b/regex-syntax/src/ast/visitor.rs
@@ -388,7 +388,7 @@ impl<'a> HeapVisitor<'a> {
                         Some(ClassFrame::Union { head: item, tail: &[] })
                     }
                     ast::ClassSet::BinaryOp(ref op) => {
-                        Some(ClassFrame::Binary { op: op })
+                        Some(ClassFrame::Binary { op })
                     }
                 }
             }
@@ -402,11 +402,9 @@ impl<'a> HeapVisitor<'a> {
                     })
                 }
             }
-            ClassInduct::BinaryOp(op) => Some(ClassFrame::BinaryLHS {
-                op: op,
-                lhs: &op.lhs,
-                rhs: &op.rhs,
-            }),
+            ClassInduct::BinaryOp(op) => {
+                Some(ClassFrame::BinaryLHS { op, lhs: &op.lhs, rhs: &op.rhs })
+            }
             _ => None,
         }
     }
@@ -427,7 +425,7 @@ impl<'a> HeapVisitor<'a> {
             }
             ClassFrame::Binary { .. } => None,
             ClassFrame::BinaryLHS { op, rhs, .. } => {
-                Some(ClassFrame::BinaryRHS { op: op, rhs: rhs })
+                Some(ClassFrame::BinaryRHS { op, rhs })
             }
             ClassFrame::BinaryRHS { .. } => None,
         }

--- a/regex-syntax/src/error.rs
+++ b/regex-syntax/src/error.rs
@@ -182,7 +182,7 @@ impl<'p> Spans<'p> {
             if line_count <= 1 { 0 } else { line_count.to_string().len() };
         let mut spans = Spans {
             pattern: &fmter.pattern,
-            line_number_width: line_number_width,
+            line_number_width,
             by_line: vec![vec![]; line_count],
             multi_line: vec![],
         };
@@ -288,7 +288,7 @@ fn repeat_char(c: char, count: usize) -> String {
 mod tests {
     use crate::ast::parse::Parser;
 
-    fn assert_panic_message(pattern: &str, expected_msg: &str) -> () {
+    fn assert_panic_message(pattern: &str, expected_msg: &str) {
         let result = Parser::new().parse(pattern);
         match result {
             Ok(_) => {

--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -114,8 +114,8 @@ impl<I: Interval> IntervalSet<I> {
         // we're done.
         let drain_end = self.ranges.len();
 
-        let mut ita = (0..drain_end).into_iter();
-        let mut itb = (0..other.ranges.len()).into_iter();
+        let mut ita = 0..drain_end;
+        let mut itb = 0..other.ranges.len();
         let mut a = ita.next().unwrap();
         let mut b = itb.next().unwrap();
         loop {

--- a/regex-syntax/src/hir/mod.rs
+++ b/regex-syntax/src/hir/mod.rs
@@ -243,7 +243,7 @@ impl Hir {
         info.set_match_empty(true);
         info.set_literal(false);
         info.set_alternation_literal(false);
-        Hir { kind: HirKind::Empty, info: info }
+        Hir { kind: HirKind::Empty, info }
     }
 
     /// Creates a literal HIR expression.
@@ -268,7 +268,7 @@ impl Hir {
         info.set_match_empty(false);
         info.set_literal(true);
         info.set_alternation_literal(true);
-        Hir { kind: HirKind::Literal(lit), info: info }
+        Hir { kind: HirKind::Literal(lit), info }
     }
 
     /// Creates a class HIR expression.
@@ -285,7 +285,7 @@ impl Hir {
         info.set_match_empty(false);
         info.set_literal(false);
         info.set_alternation_literal(false);
-        Hir { kind: HirKind::Class(class), info: info }
+        Hir { kind: HirKind::Class(class), info }
     }
 
     /// Creates an anchor assertion HIR expression.
@@ -318,7 +318,7 @@ impl Hir {
         if let Anchor::EndLine = anchor {
             info.set_line_anchored_end(true);
         }
-        Hir { kind: HirKind::Anchor(anchor), info: info }
+        Hir { kind: HirKind::Anchor(anchor), info }
     }
 
     /// Creates a word boundary assertion HIR expression.
@@ -341,7 +341,7 @@ impl Hir {
         if let WordBoundary::AsciiNegate = word_boundary {
             info.set_always_utf8(false);
         }
-        Hir { kind: HirKind::WordBoundary(word_boundary), info: info }
+        Hir { kind: HirKind::WordBoundary(word_boundary), info }
     }
 
     /// Creates a repetition HIR expression.
@@ -368,7 +368,7 @@ impl Hir {
         info.set_match_empty(rep.is_match_empty() || rep.hir.is_match_empty());
         info.set_literal(false);
         info.set_alternation_literal(false);
-        Hir { kind: HirKind::Repetition(rep), info: info }
+        Hir { kind: HirKind::Repetition(rep), info }
     }
 
     /// Creates a group HIR expression.
@@ -385,7 +385,7 @@ impl Hir {
         info.set_match_empty(group.hir.is_match_empty());
         info.set_literal(false);
         info.set_alternation_literal(false);
-        Hir { kind: HirKind::Group(group), info: info }
+        Hir { kind: HirKind::Group(group), info }
     }
 
     /// Returns the concatenation of the given expressions.
@@ -476,7 +476,7 @@ impl Hir {
                         })
                         .any(|e| e.is_line_anchored_end()),
                 );
-                Hir { kind: HirKind::Concat(exprs), info: info }
+                Hir { kind: HirKind::Concat(exprs), info }
             }
         }
     }
@@ -538,7 +538,7 @@ impl Hir {
                     let x = info.is_alternation_literal() && e.is_literal();
                     info.set_alternation_literal(x);
                 }
-                Hir { kind: HirKind::Alternation(exprs), info: info }
+                Hir { kind: HirKind::Alternation(exprs), info }
             }
         }
     }

--- a/regex-syntax/src/hir/print.rs
+++ b/regex-syntax/src/hir/print.rs
@@ -65,7 +65,7 @@ impl Printer {
     /// here are a `fmt::Formatter` (which is available in `fmt::Display`
     /// implementations) or a `&mut String`.
     pub fn print<W: fmt::Write>(&mut self, hir: &Hir, wtr: W) -> fmt::Result {
-        visitor::visit(hir, Writer { printer: self, wtr: wtr })
+        visitor::visit(hir, Writer { printer: self, wtr })
     }
 }
 

--- a/regex-syntax/src/hir/translate.rs
+++ b/regex-syntax/src/hir/translate.rs
@@ -595,7 +595,7 @@ struct TranslatorI<'t, 'p> {
 impl<'t, 'p> TranslatorI<'t, 'p> {
     /// Build a new internal translator.
     fn new(trans: &'t Translator, pattern: &'p str) -> TranslatorI<'t, 'p> {
-        TranslatorI { trans: trans, pattern: pattern }
+        TranslatorI { trans, pattern }
     }
 
     /// Return a reference to the underlying translator.
@@ -615,7 +615,7 @@ impl<'t, 'p> TranslatorI<'t, 'p> {
 
     /// Create a new error with the given span and error type.
     fn error(&self, span: Span, kind: ErrorKind) -> Error {
-        Error { kind: kind, pattern: self.pattern.to_string(), span: span }
+        Error { kind, pattern: self.pattern.to_string(), span }
     }
 
     /// Return a copy of the active flags.
@@ -785,7 +785,7 @@ impl<'t, 'p> TranslatorI<'t, 'p> {
             }
             ast::GroupKind::NonCapturing(_) => hir::GroupKind::NonCapturing,
         };
-        Hir::group(hir::Group { kind: kind, hir: Box::new(expr) })
+        Hir::group(hir::Group { kind, hir: Box::new(expr) })
     }
 
     fn hir_repetition(&self, rep: &ast::Repetition, expr: Hir) -> Hir {
@@ -808,11 +808,7 @@ impl<'t, 'p> TranslatorI<'t, 'p> {
         };
         let greedy =
             if self.flags().swap_greed() { !rep.greedy } else { rep.greedy };
-        Hir::repetition(hir::Repetition {
-            kind: kind,
-            greedy: greedy,
-            hir: Box::new(expr),
-        })
+        Hir::repetition(hir::Repetition { kind, greedy, hir: Box::new(expr) })
     }
 
     fn hir_unicode_class(
@@ -1218,7 +1214,7 @@ mod tests {
     fn hir_quest(greedy: bool, expr: Hir) -> Hir {
         Hir::repetition(hir::Repetition {
             kind: hir::RepetitionKind::ZeroOrOne,
-            greedy: greedy,
+            greedy,
             hir: Box::new(expr),
         })
     }
@@ -1226,7 +1222,7 @@ mod tests {
     fn hir_star(greedy: bool, expr: Hir) -> Hir {
         Hir::repetition(hir::Repetition {
             kind: hir::RepetitionKind::ZeroOrMore,
-            greedy: greedy,
+            greedy,
             hir: Box::new(expr),
         })
     }
@@ -1234,7 +1230,7 @@ mod tests {
     fn hir_plus(greedy: bool, expr: Hir) -> Hir {
         Hir::repetition(hir::Repetition {
             kind: hir::RepetitionKind::OneOrMore,
-            greedy: greedy,
+            greedy,
             hir: Box::new(expr),
         })
     }
@@ -1242,7 +1238,7 @@ mod tests {
     fn hir_range(greedy: bool, range: hir::RepetitionRange, expr: Hir) -> Hir {
         Hir::repetition(hir::Repetition {
             kind: hir::RepetitionKind::Range(range),
-            greedy: greedy,
+            greedy,
             hir: Box::new(expr),
         })
     }

--- a/regex-syntax/src/unicode.rs
+++ b/regex-syntax/src/unicode.rs
@@ -99,7 +99,7 @@ pub fn simple_fold(
 
         Ok(CASE_FOLDING_SIMPLE
             .binary_search_by_key(&c, |&(c1, _)| c1)
-            .map(|i| CASE_FOLDING_SIMPLE[i].1.iter().map(|&c| c))
+            .map(|i| CASE_FOLDING_SIMPLE[i].1.iter().copied())
             .map_err(|i| {
                 if i >= CASE_FOLDING_SIMPLE.len() {
                     None
@@ -580,7 +580,7 @@ fn ages(canonical_age: &str) -> Result<impl Iterator<Item = Range>> {
     fn imp(canonical_age: &str) -> Result<impl Iterator<Item = Range>> {
         use crate::unicode_tables::age;
 
-        const AGES: &'static [(&'static str, Range)] = &[
+        const AGES: &[(&str, Range)] = &[
             ("V1_1", age::V1_1),
             ("V2_0", age::V2_0),
             ("V2_1", age::V2_1),
@@ -610,7 +610,7 @@ fn ages(canonical_age: &str) -> Result<impl Iterator<Item = Range>> {
         let pos = AGES.iter().position(|&(age, _)| canonical_age == age);
         match pos {
             None => Err(Error::PropertyValueNotFound),
-            Some(i) => Ok(AGES[..i + 1].iter().map(|&(_, classes)| classes)),
+            Some(i) => Ok(AGES[..=i].iter().map(|&(_, classes)| classes)),
         }
     }
 

--- a/regex-syntax/src/utf8.rs
+++ b/regex-syntax/src/utf8.rs
@@ -198,7 +198,7 @@ impl<'a> IntoIterator for &'a Utf8Sequence {
     type Item = &'a Utf8Range;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.as_slice().into_iter()
+        self.as_slice().iter()
     }
 }
 
@@ -448,7 +448,7 @@ fn max_scalar_value(nbytes: usize) -> u32 {
         1 => 0x007F,
         2 => 0x07FF,
         3 => 0xFFFF,
-        4 => 0x10FFFF,
+        4 => 0x0010_FFFF,
         _ => unreachable!("invalid UTF-8 byte sequence size"),
     }
 }
@@ -492,7 +492,7 @@ mod tests {
     fn single_codepoint_one_sequence() {
         // Tests that every range of scalar values that contains a single
         // scalar value is recognized by one sequence of byte ranges.
-        for i in 0x0..(0x10FFFF + 1) {
+        for i in 0x0..=0x0010_FFFF {
             let c = match char::from_u32(i) {
                 None => continue,
                 Some(c) => c,

--- a/src/backtrack.rs
+++ b/src/backtrack.rs
@@ -93,13 +93,7 @@ impl<'a, 'm, 'r, 's, I: Input> Bounded<'a, 'm, 'r, 's, I> {
         let mut cache = cache.borrow_mut();
         let cache = &mut cache.backtrack;
         let start = input.at(start);
-        let mut b = Bounded {
-            prog: prog,
-            input: input,
-            matches: matches,
-            slots: slots,
-            m: cache,
-        };
+        let mut b = Bounded { prog, input, matches, slots, m: cache };
         b.exec_(start, end)
     }
 
@@ -220,14 +214,14 @@ impl<'a, 'm, 'r, 's, I: Input> Bounded<'a, 'm, 'r, 's, I> {
                         // job is popped and the old capture index is restored.
                         self.m.jobs.push(Job::SaveRestore {
                             slot: inst.slot,
-                            old_pos: old_pos,
+                            old_pos,
                         });
                         self.slots[inst.slot] = Some(at.pos());
                     }
                     ip = inst.goto;
                 }
                 Split(ref inst) => {
-                    self.m.jobs.push(Job::Inst { ip: inst.goto2, at: at });
+                    self.m.jobs.push(Job::Inst { ip: inst.goto2, at });
                     ip = inst.goto1;
                 }
                 EmptyLook(ref inst) => {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -139,7 +139,8 @@ impl Compiler {
             self.compiled.start = dotstar_patch.entry;
         }
         self.compiled.captures = vec![None];
-        let patch = self.c_capture(0, expr)?.unwrap_or(self.next_inst());
+        let patch =
+            self.c_capture(0, expr)?.unwrap_or_else(|| self.next_inst());
         if self.compiled.needs_dotstar() {
             self.fill(dotstar_patch.hole, patch.entry);
         } else {
@@ -175,7 +176,7 @@ impl Compiler {
             self.fill_to_next(prev_hole);
             let split = self.push_split_hole();
             let Patch { hole, entry } =
-                self.c_capture(0, expr)?.unwrap_or(self.next_inst());
+                self.c_capture(0, expr)?.unwrap_or_else(|| self.next_inst());
             self.fill_to_next(hole);
             self.compiled.matches.push(self.insts.len());
             self.push_compiled(Inst::Match(i));
@@ -183,7 +184,7 @@ impl Compiler {
         }
         let i = exprs.len() - 1;
         let Patch { hole, entry } =
-            self.c_capture(0, &exprs[i])?.unwrap_or(self.next_inst());
+            self.c_capture(0, &exprs[i])?.unwrap_or_else(|| self.next_inst());
         self.fill(prev_hole, entry);
         self.fill_to_next(hole);
         self.compiled.matches.push(self.insts.len());
@@ -387,11 +388,11 @@ impl Compiler {
         } else {
             let entry = self.insts.len();
             let hole = self.push_hole(InstHole::Save { slot: first_slot });
-            let patch = self.c(expr)?.unwrap_or(self.next_inst());
+            let patch = self.c(expr)?.unwrap_or_else(|| self.next_inst());
             self.fill(hole, patch.entry);
             self.fill_to_next(patch.hole);
             let hole = self.push_hole(InstHole::Save { slot: first_slot + 1 });
-            Ok(Some(Patch { hole: hole, entry: entry }))
+            Ok(Some(Patch { hole, entry }))
         }
     }
 
@@ -425,7 +426,7 @@ impl Compiler {
                 self.c_class(&[hir::ClassUnicodeRange::new(c, c)])
             }
         } else {
-            let hole = self.push_hole(InstHole::Char { c: c });
+            let hole = self.push_hole(InstHole::Char { c });
             Ok(Some(Patch { hole, entry: self.insts.len() - 1 }))
         }
     }
@@ -435,7 +436,7 @@ impl Compiler {
 
         assert!(!ranges.is_empty());
         if self.compiled.uses_bytes() {
-            Ok(Some(CompileClass { c: self, ranges: ranges }.compile()?))
+            Ok(Some(CompileClass { c: self, ranges }.compile()?))
         } else {
             let ranges: Vec<(char, char)> =
                 ranges.iter().map(|r| (r.start(), r.end())).collect();
@@ -444,9 +445,9 @@ impl Compiler {
             } else {
                 self.extra_inst_bytes +=
                     ranges.len() * (size_of::<char>() * 2);
-                self.push_hole(InstHole::Ranges { ranges: ranges })
+                self.push_hole(InstHole::Ranges { ranges })
             };
-            Ok(Some(Patch { hole: hole, entry: self.insts.len() - 1 }))
+            Ok(Some(Patch { hole, entry: self.insts.len() - 1 }))
         }
     }
 
@@ -485,8 +486,8 @@ impl Compiler {
     }
 
     fn c_empty_look(&mut self, look: EmptyLook) -> ResultOrEmpty {
-        let hole = self.push_hole(InstHole::EmptyLook { look: look });
-        Ok(Some(Patch { hole: hole, entry: self.insts.len() - 1 }))
+        let hole = self.push_hole(InstHole::EmptyLook { look });
+        Ok(Some(Patch { hole, entry: self.insts.len() - 1 }))
     }
 
     fn c_concat<'a, I>(&mut self, exprs: I) -> ResultOrEmpty
@@ -510,7 +511,7 @@ impl Compiler {
                 hole = p.hole;
             }
         }
-        Ok(Some(Patch { hole: hole, entry: entry }))
+        Ok(Some(Patch { hole, entry }))
     }
 
     fn c_alternate(&mut self, exprs: &[Hir]) -> ResultOrEmpty {
@@ -653,7 +654,7 @@ impl Compiler {
         // None).
         let patch_concat = self
             .c_concat(iter::repeat(expr).take(min))?
-            .unwrap_or(self.next_inst());
+            .unwrap_or_else(|| self.next_inst());
         if let Some(patch_rep) = self.c_repeat_zero_or_more(expr, greedy)? {
             self.fill(patch_concat.hole, patch_rep.entry);
             Ok(Some(Patch { hole: patch_rep.hole, entry: patch_concat.entry }))
@@ -677,7 +678,7 @@ impl Compiler {
         }
         // Same reasoning as in c_repeat_range_min_or_more (we know that min <
         // max at this point).
-        let patch_concat = patch_concat.unwrap_or(self.next_inst());
+        let patch_concat = patch_concat.unwrap_or_else(|| self.next_inst());
         let initial_entry = patch_concat.entry;
         // It is much simpler to compile, e.g., `a{2,5}` as:
         //
@@ -856,14 +857,14 @@ impl MaybeInst {
             }
             MaybeInst::Split1(goto1) => {
                 MaybeInst::Compiled(Inst::Split(InstSplit {
-                    goto1: goto1,
+                    goto1,
                     goto2: goto,
                 }))
             }
             MaybeInst::Split2(goto2) => {
                 MaybeInst::Compiled(Inst::Split(InstSplit {
                     goto1: goto,
-                    goto2: goto2,
+                    goto2,
                 }))
             }
             _ => unreachable!(
@@ -877,9 +878,7 @@ impl MaybeInst {
 
     fn fill_split(&mut self, goto1: InstPtr, goto2: InstPtr) {
         let filled = match *self {
-            MaybeInst::Split => {
-                Inst::Split(InstSplit { goto1: goto1, goto2: goto2 })
-            }
+            MaybeInst::Split => Inst::Split(InstSplit { goto1, goto2 }),
             _ => unreachable!(
                 "must be called on Split instruction, \
                  instead it was called on: {:?}",
@@ -937,19 +936,17 @@ enum InstHole {
 impl InstHole {
     fn fill(&self, goto: InstPtr) -> Inst {
         match *self {
-            InstHole::Save { slot } => {
-                Inst::Save(InstSave { goto: goto, slot: slot })
-            }
+            InstHole::Save { slot } => Inst::Save(InstSave { goto, slot }),
             InstHole::EmptyLook { look } => {
-                Inst::EmptyLook(InstEmptyLook { goto: goto, look: look })
+                Inst::EmptyLook(InstEmptyLook { goto, look })
             }
-            InstHole::Char { c } => Inst::Char(InstChar { goto: goto, c: c }),
+            InstHole::Char { c } => Inst::Char(InstChar { goto, c }),
             InstHole::Ranges { ref ranges } => Inst::Ranges(InstRanges {
-                goto: goto,
+                goto,
                 ranges: ranges.clone().into_boxed_slice(),
             }),
             InstHole::Bytes { start, end } => {
-                Inst::Bytes(InstBytes { goto: goto, start: start, end: end })
+                Inst::Bytes(InstBytes { goto, start, end })
             }
         }
     }
@@ -1019,7 +1016,7 @@ impl<'a, 'b> CompileClass<'a, 'b> {
         let mut last_hole = Hole::None;
         for byte_range in seq {
             let key = SuffixCacheKey {
-                from_inst: from_inst,
+                from_inst,
                 start: byte_range.start,
                 end: byte_range.end,
             };
@@ -1109,7 +1106,7 @@ impl SuffixCache {
             }
         }
         *pos = self.dense.len();
-        self.dense.push(SuffixCacheEntry { key: key, pc: pc });
+        self.dense.push(SuffixCacheEntry { key, pc });
         None
     }
 
@@ -1120,8 +1117,8 @@ impl SuffixCache {
     fn hash(&self, suffix: &SuffixCacheKey) -> usize {
         // Basic FNV-1a hash as described:
         // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
-        const FNV_PRIME: u64 = 1099511628211;
-        let mut h = 14695981039346656037;
+        const FNV_PRIME: u64 = 1_099_511_628_211;
+        let mut h = 14_695_981_039_346_656_037;
         h = (h ^ (suffix.from_inst as u64)).wrapping_mul(FNV_PRIME);
         h = (h ^ (suffix.start as u64)).wrapping_mul(FNV_PRIME);
         h = (h ^ (suffix.end as u64)).wrapping_mul(FNV_PRIME);

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -454,10 +454,10 @@ impl<'a> Fsm<'a> {
         let mut cache = cache.borrow_mut();
         let cache = &mut cache.dfa;
         let mut dfa = Fsm {
-            prog: prog,
+            prog,
             start: 0, // filled in below
-            at: at,
-            quit_after_match: quit_after_match,
+            at,
+            quit_after_match,
             last_match_si: STATE_UNKNOWN,
             last_cache_flush: at,
             cache: &mut cache.inner,
@@ -484,10 +484,10 @@ impl<'a> Fsm<'a> {
         let mut cache = cache.borrow_mut();
         let cache = &mut cache.dfa_reverse;
         let mut dfa = Fsm {
-            prog: prog,
+            prog,
             start: 0, // filled in below
-            at: at,
-            quit_after_match: quit_after_match,
+            at,
+            quit_after_match,
             last_match_si: STATE_UNKNOWN,
             last_cache_flush: at,
             cache: &mut cache.inner,
@@ -515,9 +515,9 @@ impl<'a> Fsm<'a> {
         let mut cache = cache.borrow_mut();
         let cache = &mut cache.dfa;
         let mut dfa = Fsm {
-            prog: prog,
+            prog,
             start: 0, // filled in below
-            at: at,
+            at,
             quit_after_match: false,
             last_match_si: STATE_UNKNOWN,
             last_cache_flush: at,
@@ -1608,11 +1608,7 @@ struct StateMap {
 
 impl StateMap {
     fn new(num_byte_classes: usize) -> StateMap {
-        StateMap {
-            map: HashMap::new(),
-            states: vec![],
-            num_byte_classes: num_byte_classes,
-        }
+        StateMap { map: HashMap::new(), states: vec![], num_byte_classes }
     }
 
     fn len(&self) -> usize {
@@ -1648,7 +1644,7 @@ impl Transitions {
     /// The number of byte classes corresponds to the stride. Every state will
     /// have `num_byte_classes` slots for transitions.
     fn new(num_byte_classes: usize) -> Transitions {
-        Transitions { table: vec![], num_byte_classes: num_byte_classes }
+        Transitions { table: vec![], num_byte_classes }
     }
 
     /// Returns the total number of states currently in this table.
@@ -1698,27 +1694,27 @@ impl Transitions {
 
 impl StateFlags {
     fn is_match(&self) -> bool {
-        self.0 & 0b0000000_1 > 0
+        self.0 & 0b0000_0001 > 0
     }
 
     fn set_match(&mut self) {
-        self.0 |= 0b0000000_1;
+        self.0 |= 0b0000_0001;
     }
 
     fn is_word(&self) -> bool {
-        self.0 & 0b000000_1_0 > 0
+        self.0 & 0b0000_0010 > 0
     }
 
     fn set_word(&mut self) {
-        self.0 |= 0b000000_1_0;
+        self.0 |= 0b0000_0010;
     }
 
     fn has_empty(&self) -> bool {
-        self.0 & 0b00000_1_00 > 0
+        self.0 & 0b0000_0100 > 0
     }
 
     fn set_empty(&mut self) {
-        self.0 |= 0b00000_1_00;
+        self.0 |= 0b0000_0100;
     }
 }
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -288,10 +288,10 @@ impl ExecBuilder {
             exprs.push(expr);
         }
         Ok(Parsed {
-            exprs: exprs,
+            exprs,
             prefixes: prefixes.unwrap_or_else(Literals::empty),
             suffixes: suffixes.unwrap_or_else(Literals::empty),
-            bytes: bytes,
+            bytes,
         })
     }
 
@@ -311,7 +311,7 @@ impl ExecBuilder {
                 match_type: MatchType::Nothing,
             });
             let pool = ExecReadOnly::new_pool(&ro);
-            return Ok(Exec { ro: ro, pool });
+            return Ok(Exec { ro, pool });
         }
         let parsed = self.parse()?;
         let mut nfa = Compiler::new()
@@ -340,12 +340,12 @@ impl ExecBuilder {
 
         let mut ro = ExecReadOnly {
             res: self.options.pats,
-            nfa: nfa,
-            dfa: dfa,
-            dfa_reverse: dfa_reverse,
+            nfa,
+            dfa,
+            dfa_reverse,
             suffixes: LiteralSearcher::suffixes(parsed.suffixes),
             #[cfg(feature = "perf-literal")]
-            ac: ac,
+            ac,
             match_type: MatchType::Nothing,
         };
         ro.match_type = ro.choose_match_type(self.match_type);

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -127,7 +127,7 @@ impl From<usize> for Ref<'static> {
 /// If no such valid reference could be found, None is returned.
 fn find_cap_ref(replacement: &[u8]) -> Option<CaptureRef<'_>> {
     let mut i = 0;
-    let rep: &[u8] = replacement.as_ref();
+    let rep: &[u8] = replacement;
     if rep.len() <= 1 || rep[0] != b'$' {
         return None;
     }
@@ -136,7 +136,7 @@ fn find_cap_ref(replacement: &[u8]) -> Option<CaptureRef<'_>> {
         return find_cap_ref_braced(rep, i + 1);
     }
     let mut cap_end = i;
-    while rep.get(cap_end).map_or(false, is_valid_cap_letter) {
+    while rep.get(cap_end).copied().map_or(false, is_valid_cap_letter) {
         cap_end += 1;
     }
     if cap_end == i {
@@ -183,8 +183,8 @@ fn find_cap_ref_braced(rep: &[u8], mut i: usize) -> Option<CaptureRef<'_>> {
 }
 
 /// Returns true if and only if the given byte is allowed in a capture name.
-fn is_valid_cap_letter(b: &u8) -> bool {
-    match *b {
+fn is_valid_cap_letter(b: u8) -> bool {
+    match b {
         b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'_' => true,
         _ => false,
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -160,7 +160,7 @@ impl<'t> Input for CharInput<'t> {
             InputAt { pos: self.len(), c: None.into(), byte: None, len: 0 }
         } else {
             let c = decode_utf8(&self[i..]).map(|(c, _)| c).into();
-            InputAt { pos: i, c: c, byte: None, len: c.len_utf8() }
+            InputAt { pos: i, c, byte: None, len: c.len_utf8() }
         }
     }
 
@@ -231,7 +231,7 @@ pub struct ByteInput<'t> {
 impl<'t> ByteInput<'t> {
     /// Return a new byte-based input reader for the given string.
     pub fn new(text: &'t [u8], only_utf8: bool) -> ByteInput<'t> {
-        ByteInput { text: text, only_utf8: only_utf8 }
+        ByteInput { text, only_utf8 }
     }
 }
 

--- a/src/literal/imp.rs
+++ b/src/literal/imp.rs
@@ -57,10 +57,10 @@ impl LiteralSearcher {
     fn new(lits: Literals, matcher: Matcher) -> Self {
         let complete = lits.all_complete();
         LiteralSearcher {
-            complete: complete,
+            complete,
             lcp: Memmem::new(lits.longest_common_prefix()),
             lcs: Memmem::new(lits.longest_common_suffix()),
-            matcher: matcher,
+            matcher,
         }
     }
 

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -15,7 +15,7 @@ impl<'r, 't> Pattern<'t> for &'r Regex {
 
     fn into_searcher(self, haystack: &'t str) -> RegexSearcher<'r, 't> {
         RegexSearcher {
-            haystack: haystack,
+            haystack,
             it: self.find_iter(haystack),
             last_step_end: 0,
             next_match: None,

--- a/src/pikevm.rs
+++ b/src/pikevm.rs
@@ -100,7 +100,7 @@ impl<'r, I: Input> Fsm<'r, I> {
         cache.clist.resize(prog.len(), prog.captures.len());
         cache.nlist.resize(prog.len(), prog.captures.len());
         let at = input.at(start);
-        Fsm { prog: prog, stack: &mut cache.stack, input: input }.exec_(
+        Fsm { prog, stack: &mut cache.stack, input }.exec_(
             &mut cache.clist,
             &mut cache.nlist,
             matches,

--- a/src/prog.rs
+++ b/src/prog.rs
@@ -233,7 +233,7 @@ impl fmt::Debug for Program {
             if pc == self.start {
                 write!(f, " (start)")?;
             }
-            write!(f, "\n")?;
+            writeln!(f)?;
         }
         Ok(())
     }

--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -53,7 +53,7 @@ impl<'t> Match<'t> {
     /// Creates a new match from the given haystack and byte offsets.
     #[inline]
     fn new(haystack: &'t [u8], start: usize, end: usize) -> Match<'t> {
-        Match { text: haystack, start: start, end: end }
+        Match { text: haystack, start, end }
     }
 }
 
@@ -255,7 +255,7 @@ impl Regex {
     pub fn captures<'t>(&self, text: &'t [u8]) -> Option<Captures<'t>> {
         let mut locs = self.capture_locations();
         self.captures_read_at(&mut locs, text, 0).map(move |_| Captures {
-            text: text,
+            text,
             locs: locs.0,
             named_groups: self.0.capture_name_idx().clone(),
         })
@@ -723,7 +723,7 @@ impl<'r, 't> Iterator for CaptureMatches<'r, 't> {
     fn next(&mut self) -> Option<Captures<'t>> {
         self.0.next().map(|locs| Captures {
             text: self.0.text(),
-            locs: locs,
+            locs,
             named_groups: self.0.regex().capture_name_idx().clone(),
         })
     }

--- a/src/re_trait.rs
+++ b/src/re_trait.rs
@@ -139,7 +139,7 @@ pub trait RegularExpression: Sized + fmt::Debug {
     /// Returns an iterator over all non-overlapping successive leftmost-first
     /// matches.
     fn find_iter(self, text: &Self::Text) -> Matches<'_, Self> {
-        Matches { re: self, text: text, last_end: 0, last_match: None }
+        Matches { re: self, text, last_end: 0, last_match: None }
     }
 
     /// Returns an iterator over all non-overlapping successive leftmost-first

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -61,7 +61,7 @@ impl<'t> Match<'t> {
     /// Creates a new match from the given haystack and byte offsets.
     #[inline]
     fn new(haystack: &'t str, start: usize, end: usize) -> Match<'t> {
-        Match { text: haystack, start: start, end: end }
+        Match { text: haystack, start, end }
     }
 }
 
@@ -311,7 +311,7 @@ impl Regex {
     pub fn captures<'t>(&self, text: &'t str) -> Option<Captures<'t>> {
         let mut locs = self.capture_locations();
         self.captures_read_at(&mut locs, text, 0).map(move |_| Captures {
-            text: text,
+            text,
             locs: locs.0,
             named_groups: self.0.capture_name_idx().clone(),
         })
@@ -1114,7 +1114,7 @@ impl<'r, 't> Iterator for CaptureMatches<'r, 't> {
     fn next(&mut self) -> Option<Captures<'t>> {
         self.0.next().map(|locs| Captures {
             text: self.0.text(),
-            locs: locs,
+            locs,
             named_groups: self.0.regex().capture_name_idx().clone(),
         })
     }

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -108,7 +108,7 @@ pub fn decode_utf8(src: &[u8]) -> Option<(char, usize)> {
                 | ((b2 & !TAG_CONT) as u32) << 6
                 | ((b3 & !TAG_CONT) as u32);
             match cp {
-                0x10000..=0x10FFFF => char::from_u32(cp).map(|cp| (cp, 4)),
+                0x10000..=0x0010_FFFF => char::from_u32(cp).map(|cp| (cp, 4)),
                 _ => None,
             }
         }


### PR DESCRIPTION
Some lints have been intentionally ignored, especially:
* any lints that would change public APIs (like `&self` -> `self`)
* any lints that would introduce new public APIs (like `impl Default` over `fn new()`)

It seems in some cases, struct initialization with redundant `field: field` was on purpose if one field (at least) was not redundant. This PR does "simplify" those cases, but that might not be wanted?