### PR TITLE
Use is_match_at instead of shortest_match_at

### DIFF
--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -578,7 +578,7 @@ impl Regex {
     /// context into consideration. For example, the `\A` anchor can only
     /// match when `start == 0`.
     pub fn is_match_at(&self, text: &[u8], start: usize) -> bool {
-        self.shortest_match_at(text, start).is_some()
+        self.0.searcher().is_match_at(text, start)
     }
 
     /// Returns the same as find, but starts the search at the given

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -636,7 +636,7 @@ impl Regex {
     /// context into consideration. For example, the `\A` anchor can only
     /// match when `start == 0`.
     pub fn is_match_at(&self, text: &str, start: usize) -> bool {
-        self.shortest_match_at(text, start).is_some()
+        self.0.searcher_str().is_match_at(text, start)
     }
 
     /// Returns the same as find, but starts the search at the given


### PR DESCRIPTION
Local benchmarks show up to 15% reduction in terms of number of
retired instructions executed and at least 5% reduction in terms
of CPU time.

I hope there aren't any drawbacks with this change.

cc @BurntSushi 