### PR TITLE
fix: Notate only the start of the character class on error

### DIFF
--- a/regex-syntax/README.md
+++ b/regex-syntax/README.md
@@ -53,7 +53,7 @@ for extreme optimization, and therefore, use of `unsafe`.
 
 The standard for using `unsafe` in this crate is extremely high because this
 crate is intended to be reasonably safe to use with user supplied regular
-expressions. Therefore, while their may be bugs in the regex parser itself,
+expressions. Therefore, while there may be bugs in the regex parser itself,
 they should _never_ result in memory unsafety unless there is either a bug
 in the compiler or the standard library. (Since `regex-syntax` has zero
 dependencies.)

--- a/regex-syntax/src/ast/mod.rs
+++ b/regex-syntax/src/ast/mod.rs
@@ -15,7 +15,7 @@ mod visitor;
 /// An error that occurred while parsing a regular expression into an abstract
 /// syntax tree.
 ///
-/// Note that note all ASTs represents a valid regular expression. For example,
+/// Note that not all ASTs represents a valid regular expression. For example,
 /// an AST is constructed without error for `\p{Quux}`, but `Quux` is not a
 /// valid Unicode property name. That particular error is reported when
 /// translating an AST to the high-level intermediate representation (`HIR`).

--- a/regex-syntax/src/ast/parse.rs
+++ b/regex-syntax/src/ast/parse.rs
@@ -1927,7 +1927,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
             }));
             if !self.bump_and_bump_space() {
                 return Err(self.error(
-                    Span::new(start, self.pos()),
+                    Span::new(start, start),
                     ast::ErrorKind::ClassUnclosed,
                 ));
             }
@@ -5515,14 +5515,23 @@ bar
         assert_eq!(
             parser("[-").parse_set_class_open().unwrap_err(),
             TestError {
-                span: span(0..2),
+                span: span(0..0),
                 kind: ast::ErrorKind::ClassUnclosed,
             }
         );
         assert_eq!(
             parser("[--").parse_set_class_open().unwrap_err(),
             TestError {
-                span: span(0..3),
+                span: span(0..0),
+                kind: ast::ErrorKind::ClassUnclosed,
+            }
+        );
+
+        // See: https://github.com/rust-lang/regex/issues/792
+        assert_eq!(
+            parser("(?x)[-#]").parse_with_comments().unwrap_err(),
+            TestError {
+                span: span(4..4),
                 kind: ast::ErrorKind::ClassUnclosed,
             }
         );

--- a/regex-syntax/src/error.rs
+++ b/regex-syntax/src/error.rs
@@ -182,7 +182,7 @@ impl<'p> Spans<'p> {
             if line_count <= 1 { 0 } else { line_count.to_string().len() };
         let mut spans = Spans {
             pattern: &fmter.pattern,
-            line_number_width: line_number_width,
+            line_number_width,
             by_line: vec![vec![]; line_count],
             multi_line: vec![],
         };


### PR DESCRIPTION
This closes https://github.com/rust-lang/regex/issues/792.
