### PR TITLE
fuzz: do not use inherits in Cargo.toml

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -29,7 +29,9 @@ opt-level = 3
 debug = true
 
 [profile.dev]
-inherits = "release"
+opt-level = 3
+debug = true
 
 [profile.test]
-inherits = "release"
+opt-level = 3
+debug = true


### PR DESCRIPTION
to fix oss-fuzz build
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36474

cc @BurntSushi @DavidKorczynski