### PR TITLE
Fix s flag documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ Most features of the regular expressions in this crate are Unicode aware. Here
 are some examples:
 
 * `.` will match any valid UTF-8 encoded Unicode scalar value except for `\n`.
-  (To also match `\n`, enable the `s` flag, e.g., `(?s:.)`.)
+  (To also match `\n`, enable the `s` flag, e.g., `(?s)`.)
 * `\w`, `\d` and `\s` are Unicode aware. For example, `\s` will match all forms
   of whitespace categorized by Unicode.
 * `\b` matches a Unicode word boundary.


### PR DESCRIPTION
`(?s:.)` mislead me while I was working with the regex crate to capture a paragraph. Replacing flag declaration with `(?s)` fixed my problem.