### PR TITLE
Fix some dead_code warnings

### DIFF
--- a/regex-syntax/src/ast/print.rs
+++ b/regex-syntax/src/ast/print.rs
@@ -57,17 +57,16 @@ impl Printer {
     /// here are a `fmt::Formatter` (which is available in `fmt::Display`
     /// implementations) or a `&mut String`.
     pub fn print<W: fmt::Write>(&mut self, ast: &Ast, wtr: W) -> fmt::Result {
-        visitor::visit(ast, Writer { printer: self, wtr: wtr })
+        visitor::visit(ast, Writer { wtr: wtr })
     }
 }
 
 #[derive(Debug)]
-struct Writer<'p, W> {
-    printer: &'p mut Printer,
+struct Writer<W> {
     wtr: W,
 }
 
-impl<'p, W: fmt::Write> Visitor for Writer<'p, W> {
+impl<W: fmt::Write> Visitor for Writer<W> {
     type Output = ();
     type Err = fmt::Error;
 
@@ -153,7 +152,7 @@ impl<'p, W: fmt::Write> Visitor for Writer<'p, W> {
     }
 }
 
-impl<'p, W: fmt::Write> Writer<'p, W> {
+impl<W: fmt::Write> Writer<W> {
     fn fmt_group_pre(&mut self, ast: &ast::Group) -> fmt::Result {
         use crate::ast::GroupKind::*;
         match ast.kind {

--- a/regex-syntax/src/hir/print.rs
+++ b/regex-syntax/src/hir/print.rs
@@ -65,17 +65,16 @@ impl Printer {
     /// here are a `fmt::Formatter` (which is available in `fmt::Display`
     /// implementations) or a `&mut String`.
     pub fn print<W: fmt::Write>(&mut self, hir: &Hir, wtr: W) -> fmt::Result {
-        visitor::visit(hir, Writer { printer: self, wtr: wtr })
+        visitor::visit(hir, Writer { wtr: wtr })
     }
 }
 
 #[derive(Debug)]
-struct Writer<'p, W> {
-    printer: &'p mut Printer,
+struct Writer<W> {
     wtr: W,
 }
 
-impl<'p, W: fmt::Write> Visitor for Writer<'p, W> {
+impl<W: fmt::Write> Visitor for Writer<W> {
     type Output = ();
     type Err = fmt::Error;
 
@@ -209,7 +208,7 @@ impl<'p, W: fmt::Write> Visitor for Writer<'p, W> {
     }
 }
 
-impl<'p, W: fmt::Write> Writer<'p, W> {
+impl<W: fmt::Write> Writer<W> {
     fn write_literal_char(&mut self, c: char) -> fmt::Result {
         if is_meta_character(c) {
             self.wtr.write_str("\\")?;


### PR DESCRIPTION
```
warning: field is never read: `printer`
  --> regex-syntax/src/ast/print.rs:66:5
   |
66 |     printer: &'p mut Printer,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: field is never read: `printer`
  --> regex-syntax/src/hir/print.rs:74:5
   |
74 |     printer: &'p mut Printer,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^
```