### PR TITLE
docs: clarify Captures::len includes non-matching captures

### DIFF
--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -989,7 +989,7 @@ impl<'t> Captures<'t> {
         expand_str(self, replacement, dst)
     }
 
-    /// Returns the number of captured groups.
+    /// Returns the number of capture groups (even if they didn't match).
     ///
     /// This is always at least `1`, since every regex has at least one capture
     /// group that corresponds to the full match.


### PR DESCRIPTION
This caught me out: mentally I map "captured groups" to the _successful_ captures; capture groups that didn't capture anything weren't "captured." I understand why the function returns what it does in retrospect, but hopefully this can help someone else.