### PR TITLE
Fix the spelling of "insignificant" in two comments

### DIFF
--- a/regex-syntax/src/ast/parse.rs
+++ b/regex-syntax/src/ast/parse.rs
@@ -202,7 +202,7 @@ impl ParserBuilder {
 
     /// Enable verbose mode in the regular expression.
     ///
-    /// When enabled, verbose mode permits insigificant whitespace in many
+    /// When enabled, verbose mode permits insignificant whitespace in many
     /// places in the regular expression, as well as comments. Comments are
     /// started using `#` and continue until the end of the line.
     ///

--- a/regex-syntax/src/parser.rs
+++ b/regex-syntax/src/parser.rs
@@ -96,7 +96,7 @@ impl ParserBuilder {
 
     /// Enable verbose mode in the regular expression.
     ///
-    /// When enabled, verbose mode permits insigificant whitespace in many
+    /// When enabled, verbose mode permits insignificant whitespace in many
     /// places in the regular expression, as well as comments. Comments are
     /// started using `#` and continue until the end of the line.
     ///


### PR DESCRIPTION
I spotted this typo in the published version of https://rust-lang.github.io/regex/regex/index.html#example-replacement-with-named-capture-groups, although that page was fixed in an earlier PR (https://github.com/rust-lang/regex/pull/542).

This fixes the two other misspellings of "insignificant".