### PR TITLE
Fix rustdoc warning about automatic link

### DIFF
--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -31,7 +31,7 @@ considerably more complex than one might expect out of a DFA. A number of
 tricks are employed to make it fast. Tread carefully.
 
 N.B. While this implementation is heavily commented, Russ Cox's series of
-articles on regexes is strongly recommended: https://swtch.com/~rsc/regexp/
+articles on regexes is strongly recommended: <https://swtch.com/~rsc/regexp/>
 (As is the DFA implementation in RE2, which heavily influenced this
 implementation.)
 */


### PR DESCRIPTION
It fixes this warning when generating documentation:

```
warning: this URL is not a hyperlink
  --> src/dfa.rs:34:46
   |
34 | articles on regexes is strongly recommended: https://swtch.com/~rsc/regexp/
   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://swtch.com/~rsc/regexp/>`
   |
   = note: `#[warn(rustdoc::bare_urls)]` on by default
   = note: bare URLs are not automatically turned into clickable links
```