### PR TITLE
Fix return value of `match_indices` in pattern example

### DIFF
--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -129,7 +129,7 @@ impl<'t> From<Match<'t>> for Range<usize> {
 /// assert!(haystack.contains(&re));
 /// assert_eq!(haystack.find(&re), Some(1));
 /// assert_eq!(haystack.match_indices(&re).collect::<Vec<_>>(),
-///            vec![(1, 4), (5, 8)]);
+///            vec![(1, "111"), (5, "222")]);
 /// assert_eq!(haystack.split(&re).collect::<Vec<_>>(), vec!["a", "b", "c"]);
 /// ```
 #[derive(Clone)]


### PR DESCRIPTION
The pattern example on `Regex` assumes that std's [`match_indices`](https://doc.rust-lang.org/std/primitive.str.html#method.match_indices) returns a pair of offsets while it actually returns an offset and a matching string slice. This wasn't catched by tests because the example is ignored (it needs nightly).