### PR TITLE
Allow use of `regex_syntax::is_meta_character` func from `regex` (and fix a minor docs typo)

### DIFF
--- a/regex-syntax/src/lib.rs
+++ b/regex-syntax/src/lib.rs
@@ -195,7 +195,7 @@ pub fn escape_into(text: &str, buf: &mut String) {
     }
 }
 
-/// Returns true if the give character has significance in a regex.
+/// Returns true if the given character has significance in a regex.
 ///
 /// These are the only characters that are allowed to be escaped, with one
 /// exception: an ASCII space character may be escaped when extended mode (with

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -629,7 +629,7 @@ pub use crate::re_builder::unicode::*;
 pub use crate::re_set::unicode::*;
 #[cfg(feature = "std")]
 pub use crate::re_unicode::{
-    escape, CaptureLocations, CaptureMatches, CaptureNames, Captures,
+    escape, is_meta_character, CaptureLocations, CaptureMatches, CaptureNames, Captures,
     Locations, Match, Matches, NoExpand, Regex, Replacer, ReplacerRef, Split,
     SplitN, SubCaptureMatches,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -629,9 +629,9 @@ pub use crate::re_builder::unicode::*;
 pub use crate::re_set::unicode::*;
 #[cfg(feature = "std")]
 pub use crate::re_unicode::{
-    escape, is_meta_character, CaptureLocations, CaptureMatches, CaptureNames, Captures,
-    Locations, Match, Matches, NoExpand, Regex, Replacer, ReplacerRef, Split,
-    SplitN, SubCaptureMatches,
+    escape, is_meta_character, CaptureLocations, CaptureMatches, CaptureNames,
+    Captures, Locations, Match, Matches, NoExpand, Regex, Replacer,
+    ReplacerRef, Split, SplitN, SubCaptureMatches,
 };
 
 /**

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -22,6 +22,19 @@ pub fn escape(text: &str) -> String {
     regex_syntax::escape(text)
 }
 
+/// Returns true if the given character has significance in a regex.
+///
+/// These are the only characters that are allowed to be escaped, with one
+/// exception: an ASCII space character may be escaped when extended mode (with
+/// the `x` flag) is enabled. In particular, `is_meta_character(' ')` returns
+/// `false`.
+///
+/// Note that the set of characters for which this function returns `true` or
+/// `false` is fixed and won't change in a semver compatible release.
+pub fn is_meta_character(c: char) -> bool {
+    regex_syntax::is_meta_character(c)
+}
+
 /// Match represents a single match of a regex in a haystack.
 ///
 /// The lifetime parameter `'t` refers to the lifetime of the matched text.


### PR DESCRIPTION
Hi, thanks for all the great regular expression work! (And a small request ;)

Currently `regex` offers the `escape` func from `regex-syntax`, which in turn calls `is_meta_character`; I find myself needing _that_ function, but not really wanting to have to maintain a reference to both crates due to the possibility that (one day!) the list of chars may be updated, and a version-mismatch might cause some minor issue before being spotted.

Given the presence of `escape`, are there any objections to also offering `is_meta_character`, as per this pull req? Would mean one less import (nice, given the size of the unicode tables), and guarantee that -no matter what changes in the future- the function will always return correctly as it is sure to be aligned with the underlying engine version.

Also: spotted/fixed a one-letter typo in the `is_meta_character` docs :)