### PR TITLE
doc: fix typo in `is_meta_character` func description

### DIFF
--- a/regex-syntax/src/lib.rs
+++ b/regex-syntax/src/lib.rs
@@ -195,7 +195,7 @@ pub fn escape_into(text: &str, buf: &mut String) {
     }
 }
 
-/// Returns true if the give character has significance in a regex.
+/// Returns true if the given character has significance in a regex.
 ///
 /// These are the only characters that are allowed to be escaped, with one
 /// exception: an ASCII space character may be escaped when extended mode (with


### PR DESCRIPTION
Before: 
* _Returns true if the `give` character_ 

After:
* _Returns true if the `given` character_ 