### PR TITLE
ci: switch to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@v1
       with:
-        override: true
         toolchain: ${{ matrix.rust }}
-        profile: minimal
 
     - name: Install and configure Cross
       if: matrix.target != ''
@@ -163,11 +161,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@v1
       with:
-        override: true
         toolchain: stable
-        profile: minimal
         components: rustfmt
     - name: Check formatting
       run: |


### PR DESCRIPTION
The actions-rs/toolchain we were using appears dead:
https://github.com/actions-rs/toolchain/issues/216

Here's dtolnay's take: https://github.com/dtolnay/rust-toolchain

In particular, it looks like a much more maintainable path here. For
this one, if it ever goes unmaintained, I can maintain it myself without
too much fuss.

See also: https://old.reddit.com/r/rust/comments/vyx4oj/actionsrs_organization_became_unmaintained/ig54zv7/