### PR TITLE
Use `#[non_exhaustive]` attribute instead of `__Nonexhaustive` enum variant hack

### DIFF
--- a/regex-syntax/src/ast/mod.rs
+++ b/regex-syntax/src/ast/mod.rs
@@ -202,13 +202,15 @@ impl error::Error for Error {
             GroupUnclosed => "unclosed group",
             GroupUnopened => "unopened group",
             NestLimitExceeded(_) => "nest limit exceeded",
+            RepetitionCountDecimalEmpty => {
+                "invalid decimal in repetition quantifier"
+            }
             RepetitionCountInvalid => "invalid repetition count range",
             RepetitionCountUnclosed => "unclosed counted repetition",
             RepetitionMissing => "repetition operator missing expression",
             UnicodeClassInvalid => "invalid Unicode character class",
             UnsupportedBackreference => "backreferences are not supported",
             UnsupportedLookAround => "look-around is not supported",
-            _ => unreachable!(),
         }
     }
 }

--- a/regex-syntax/src/ast/mod.rs
+++ b/regex-syntax/src/ast/mod.rs
@@ -66,6 +66,7 @@ impl Error {
 
 /// The type of an error that occurred while building an AST.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// The capturing group limit was exceeded.
     ///
@@ -169,13 +170,6 @@ pub enum ErrorKind {
     /// `(?<!re)`. Note that all of these syntaxes are otherwise invalid; this
     /// error is used to improve the user experience.
     UnsupportedLookAround,
-    /// Hints that destructuring should not be exhaustive.
-    ///
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl error::Error for Error {
@@ -310,7 +304,6 @@ impl fmt::Display for ErrorKind {
                 "look-around, including look-ahead and look-behind, \
                  is not supported"
             ),
-            _ => unreachable!(),
         }
     }
 }

--- a/regex-syntax/src/error.rs
+++ b/regex-syntax/src/error.rs
@@ -11,6 +11,7 @@ pub type Result<T> = result::Result<T, Error>;
 
 /// This error type encompasses any error that can be returned by this crate.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Error {
     /// An error that occurred while translating concrete syntax into abstract
     /// syntax (AST).
@@ -18,13 +19,6 @@ pub enum Error {
     /// An error that occurred while translating abstract syntax into a high
     /// level intermediate representation (HIR).
     Translate(hir::Error),
-    /// Hints that destructuring should not be exhaustive.
-    ///
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl From<ast::Error> for Error {
@@ -46,7 +40,6 @@ impl error::Error for Error {
         match *self {
             Error::Parse(ref x) => x.description(),
             Error::Translate(ref x) => x.description(),
-            _ => unreachable!(),
         }
     }
 }
@@ -56,7 +49,6 @@ impl fmt::Display for Error {
         match *self {
             Error::Parse(ref x) => x.fmt(f),
             Error::Translate(ref x) => x.fmt(f),
-            _ => unreachable!(),
         }
     }
 }

--- a/regex-syntax/src/hir/mod.rs
+++ b/regex-syntax/src/hir/mod.rs
@@ -54,6 +54,7 @@ impl Error {
 
 /// The type of an error that occurred while building an `Hir`.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// This error occurs when a Unicode feature is used when Unicode
     /// support is disabled. For example `(?-u:\pL)` would trigger this error.
@@ -81,13 +82,6 @@ pub enum ErrorKind {
     /// Note that this restriction in the translator may be removed in the
     /// future.
     EmptyClassNotAllowed,
-    /// Hints that destructuring should not be exhaustive.
-    ///
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ErrorKind {
@@ -109,7 +103,6 @@ impl ErrorKind {
                  (make sure the unicode-case feature is enabled)"
             }
             EmptyClassNotAllowed => "empty character classes are not allowed",
-            __Nonexhaustive => unreachable!(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,19 +3,13 @@ use std::iter::repeat;
 
 /// An error that occurred during parsing or compiling a regular expression.
 #[derive(Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Error {
     /// A syntax error.
     Syntax(String),
     /// The compiled program exceeded the set size limit.
     /// The argument is the size limit imposed.
     CompiledTooBig(usize),
-    /// Hints that destructuring should not be exhaustive.
-    ///
-    /// This enum may grow additional variants, so this makes sure clients
-    /// don't count on exhaustive matching. (Otherwise, adding a new variant
-    /// could break existing code.)
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl ::std::error::Error for Error {
@@ -25,7 +19,6 @@ impl ::std::error::Error for Error {
         match *self {
             Error::Syntax(ref err) => err,
             Error::CompiledTooBig(_) => "compiled program too big",
-            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -39,7 +32,6 @@ impl fmt::Display for Error {
                 "Compiled regex exceeds size limit of {} bytes.",
                 limit
             ),
-            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -62,9 +54,6 @@ impl fmt::Debug for Error {
             }
             Error::CompiledTooBig(limit) => {
                 f.debug_tuple("CompiledTooBig").field(&limit).finish()
-            }
-            Error::__Nonexhaustive => {
-                f.debug_tuple("__Nonexhaustive").finish()
             }
         }
     }


### PR DESCRIPTION
[`#[non_exhaustive]`](https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute) was added at [Rust 1.40](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1400-2019-12-19). Since MSRV of this project is 1.41.1, the attribute is available. This PR replaces `__Nonexhaustive` enum variant hack with the attribute.

The benefits to use the attribute are:

- The attribute is dedicated for this use case. So compiler's error message is better than an error around `__Nonexhausitve` variant.
- `#[non_exhaustive]` allows the exhaustive pattern check at `match` in the crate where the enum/struct is implemented. This can catch bugs like 31d78a6.