### PR TITLE
update doc examples to use `once_cell` instead of `lazy_static`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regex"
-version = "1.6.0"  #:version
+version = "1.6.0" #:version
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -17,9 +17,7 @@ exclude = ["/scripts/*", "/.github/*"]
 edition = "2018"
 
 [workspace]
-members = [
-  "bench", "regex-capi", "regex-debug", "regex-syntax",
-]
+members = ["bench", "regex-capi", "regex-debug", "regex-syntax"]
 
 [lib]
 # There are no benchmarks in the library code itself
@@ -122,11 +120,14 @@ default-features = false
 
 [dev-dependencies]
 # For examples.
-lazy_static = "1"
+once_cell = "1"
 # For property based tests.
 quickcheck = { version = "1.0.3", default-features = false }
 # For generating random test data.
-rand = { version = "0.8.3", default-features = false, features = ["getrandom", "small_rng"] }
+rand = { version = "0.8.3", default-features = false, features = [
+  "getrandom",
+  "small_rng",
+] }
 # To check README's example
 # TODO: Re-enable this once the MSRV is 1.43 or greater.
 # See: https://github.com/rust-lang/regex/issues/684

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -74,7 +74,7 @@ crate provides an answer that works well:
 
 In other words, the `Lazy` construct enables us to define a `Regex` *as if*
 it were a global static value. What is actually happening under the covers is
-that the code inside the macro (i.e., `Regex::new(...)`) is run on *first use*
+that the code inside the closure (i.e., `Regex::new(...)`) is run on *first use*
 of `MY_REGEX` via a `Deref` impl. The implementation is admittedly magical, but
 it's self contained and everything works exactly as you expect. In particular,
 `MY_REGEX` can be used from multiple threads without wrapping it in an `Arc` or

--- a/README.md
+++ b/README.md
@@ -90,19 +90,18 @@ allocations internally to the matching engines.
 
 In Rust, it can sometimes be a pain to pass regular expressions around if
 they're used from inside a helper function. Instead, we recommend using the
-[`lazy_static`](https://crates.io/crates/lazy_static) crate to ensure that
+[`once_cell`](https://crates.io/crates/once_cell) crate to ensure that
 regular expressions are compiled exactly once.
 
 For example:
 
 ```rust,ignore
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 fn some_helper_function(text: &str) -> bool {
-    lazy_static! {
-        static ref RE: Regex = Regex::new("...").unwrap();
-    }
-    RE.is_match(text)
+    static MY_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new("...").unwrap());
+    MY_REGEX.is_match(text)
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,23 +56,21 @@ optimizations that reuse allocations internally to the matching engines.
 
 In Rust, it can sometimes be a pain to pass regular expressions around if
 they're used from inside a helper function. Instead, we recommend using the
-[`lazy_static`](https://crates.io/crates/lazy_static) crate to ensure that
+[`once_cell`](https://crates.io/crates/once_cell) crate to ensure that
 regular expressions are compiled exactly once.
 
 For example:
 
 ```rust
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 fn some_helper_function(text: &str) -> bool {
-    lazy_static! {
-        static ref RE: Regex = Regex::new("...").unwrap();
-    }
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new("...").unwrap());
     RE.is_match(text)
 }
 
-fn main() {}
+# fn main() {}
 ```
 
 Specifically, in this example, the regex will be compiled when it is used for


### PR DESCRIPTION
this change is useful because of the proposed addition of the `once_cell` api into std. users using the `once_cell` pattern will find it easier to swap to the `std` versions when/if they are merged.