### PR TITLE
Syntax: Make \p{Sc} work

### DIFF
--- a/regex-syntax/src/unicode.rs
+++ b/regex-syntax/src/unicode.rs
@@ -243,7 +243,9 @@ impl<'a> ClassQuery<'a> {
         // a general category. (Currently, we don't even support the
         // 'Case_Folding' property. But if we do in the future, users will be
         // required to spell it out.)
-        if norm != "cf" {
+        // 'sc' refers to the 'Currency_Symbol' general category, but is also
+        // the abbreviation for the 'Script' property.
+        if norm != "cf" && norm != "sc" {
             if let Some(canon) = canonical_prop(&norm)? {
                 return Ok(CanonicalClassQuery::Binary(canon));
             }

--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -77,6 +77,7 @@ mat!(uni_class_gencat_format, r"\p{Format}", "\u{E007F}", Some((0, 4)));
 // See: https://github.com/rust-lang/regex/issues/719
 mat!(uni_class_gencat_format_abbrev1, r"\p{cf}", "\u{E007F}", Some((0, 4)));
 mat!(uni_class_gencat_format_abbrev2, r"\p{gc=cf}", "\u{E007F}", Some((0, 4)));
+mat!(uni_class_gencat_format_abbrev3, r"\p{Sc}", "$", Some((0, 1)));
 mat!(
     uni_class_gencat_initial_punctuation,
     r"\p{Initial_Punctuation}",


### PR DESCRIPTION
I am not completely sure if this change introduces some unwanted side effects, as there seems to be support for the 'Script' property, which is not the case for the 'Case_Folding' property


Fixes #835
Related #719 b1489c8