### PR TITLE
Added `participating_captures_len`

### DIFF
--- a/regex-syntax/src/hir/mod.rs
+++ b/regex-syntax/src/hir/mod.rs
@@ -579,9 +579,11 @@ impl Hir {
                     let x = info.is_alternation_literal() && e.is_literal();
                     info.set_alternation_literal(x);
                 }
-                let mut capture_counts = exprs.iter().map(|e| e.info.static_capture_count);
+                let mut capture_counts =
+                    exprs.iter().map(|e| e.info.static_capture_count);
                 let first = capture_counts.next().unwrap_or(Some(0));
-                info.static_capture_count = capture_counts.fold(first, |a, b| if a == b { a } else { None });
+                info.static_capture_count = capture_counts
+                    .fold(first, |a, b| if a == b { a } else { None });
                 Hir { kind: HirKind::Alternation(exprs), info }
             }
         }
@@ -732,7 +734,7 @@ impl Hir {
     pub fn is_alternation_literal(&self) -> bool {
         self.info.is_alternation_literal()
     }
-    
+
     /// Returns the number of captures groups that would participate in a
     /// successful match of this expression. If this number can not be
     /// statically determined from the regex this function returns `None`.

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -149,7 +149,8 @@ impl Compiler {
             self.compiled.start = dotstar_patch.entry;
         }
         self.compiled.captures = vec![None];
-        self.compiled.participating_captures_len = expr.participating_captures_len();
+        self.compiled.participating_captures_len =
+            expr.participating_captures_len();
         let patch =
             self.c_capture(0, expr)?.unwrap_or_else(|| self.next_inst());
         if self.compiled.needs_dotstar() {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -149,6 +149,7 @@ impl Compiler {
             self.compiled.start = dotstar_patch.entry;
         }
         self.compiled.captures = vec![None];
+        self.compiled.participating_captures_len = expr.participating_captures_len();
         let patch =
             self.c_capture(0, expr)?.unwrap_or_else(|| self.next_inst());
         if self.compiled.needs_dotstar() {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -70,7 +70,7 @@ struct ExecReadOnly {
     /// A compiled program that is used in the NFA simulation and backtracking.
     /// It can be byte-based or Unicode codepoint based.
     ///
-    /// N.B. It is not possibly to make this byte-based from the public API.
+    /// N.B. It is not possible to make this byte-based from the public API.
     /// It is only used for testing byte based programs in the NFA simulations.
     nfa: Program,
     /// A compiled byte based program for DFA execution. This is only used
@@ -1310,6 +1310,13 @@ impl Exec {
     /// group position).
     pub fn capture_name_idx(&self) -> &Arc<HashMap<String, usize>> {
         &self.ro.nfa.capture_name_idx
+    }
+
+    /// Returns the number of participating captures that this regex will
+    /// return on a successful match. If this number can not be statically
+    /// determined from the regex this function returns `None`.
+    pub fn participating_captures_len(&self) -> Option<usize> {
+        self.ro.nfa.participating_captures_len
     }
 }
 

--- a/src/prog.rs
+++ b/src/prog.rs
@@ -25,6 +25,9 @@ pub struct Program {
     /// The ordered sequence of all capture groups extracted from the AST.
     /// Unnamed groups are `None`.
     pub captures: Vec<Option<String>>,
+    /// The number of capture groups that participate in a successful match.
+    /// None if this can't be determined statically at compile time.
+    pub participating_captures_len: Option<usize>,
     /// Pointers to all named capture groups into `captures`.
     pub capture_name_idx: Arc<HashMap<String, usize>>,
     /// A pointer to the start instruction. This can vary depending on how
@@ -82,6 +85,7 @@ impl Program {
             insts: vec![],
             matches: vec![],
             captures: vec![],
+            participating_captures_len: None,
             capture_name_idx: Arc::new(HashMap::new()),
             start: 0,
             byte_classes: vec![0; 256],

--- a/src/prog.rs
+++ b/src/prog.rs
@@ -12,7 +12,7 @@ use crate::literal::LiteralSearcher;
 /// `InstPtr` represents the index of an instruction in a regex program.
 pub type InstPtr = usize;
 
-/// Program is a sequence of instructions and various facts about thos
+/// Program is a sequence of instructions and various facts about those
 /// instructions.
 #[derive(Clone)]
 pub struct Program {

--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -666,6 +666,13 @@ impl Regex {
     pub fn captures_len(&self) -> usize {
         self.0.capture_names().len()
     }
+    
+    /// Returns the number of participating captures that this regex will
+    /// return on a successful match. If this number can not be statically
+    /// determined from the regex this function returns `None`.
+    pub fn participating_captures_len(&self) -> Option<usize> {
+        self.0.participating_captures_len()
+    }
 
     /// Returns an empty set of capture locations that can be reused in
     /// multiple calls to `captures_read` or `captures_read_at`.

--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -666,7 +666,7 @@ impl Regex {
     pub fn captures_len(&self) -> usize {
         self.0.capture_names().len()
     }
-    
+
     /// Returns the number of participating captures that this regex will
     /// return on a successful match. If this number can not be statically
     /// determined from the regex this function returns `None`.

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -724,7 +724,7 @@ impl Regex {
     pub fn captures_len(&self) -> usize {
         self.0.capture_names().len()
     }
-    
+
     /// Returns the number of participating captures that this regex will
     /// return on a successful match. If this number can not be statically
     /// determined from the regex this function returns `None`.

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -724,6 +724,13 @@ impl Regex {
     pub fn captures_len(&self) -> usize {
         self.0.capture_names().len()
     }
+    
+    /// Returns the number of participating captures that this regex will
+    /// return on a successful match. If this number can not be statically
+    /// determined from the regex this function returns `None`.
+    pub fn participating_captures_len(&self) -> Option<usize> {
+        self.0.participating_captures_len()
+    }
 
     /// Returns an empty set of capture locations that can be reused in
     /// multiple calls to `captures_read` or `captures_read_at`.

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -129,6 +129,44 @@ fn capture_index_lifetime() {
 }
 
 #[test]
+fn participating_captures_len() {
+    let tests = [
+        ("", Some(0)),
+        ("foo|bar", Some(0)),
+        ("(foo)|bar", None),
+        ("foo|(bar)", None),
+        ("(foo|bar)", Some(1)),
+        ("(a|b|c|d|e|f)", Some(1)),
+        ("(a)|(b)|(c)|(d)|(e)|(f)", Some(1)),
+        ("(a)(b)|(c)(d)|(e)(f)", Some(2)),
+        ("(a)(b)(c)|(d)(e)(f)", Some(3)),
+        ("(a)(b)(c)(d)(e)(f)", Some(6)),
+        ("(a)(b)(extra)|(a)(b)()", Some(3)),
+        ("(a)(b)((?:extra)?)", Some(3)),
+        ("(a)(b)(extra)?", None),
+        ("(foo)|(bar)", Some(1)),
+        ("(foo)(bar)", Some(2)),
+        ("(foo)+(bar)", Some(2)),
+        ("(foo)*(bar)", None),
+        ("(foo)?{0}", Some(0)),
+        ("(foo)?{1}", None),
+        ("(foo){1}", Some(1)),
+        ("(foo){1,}", Some(1)),
+        ("(foo){1,}?", Some(1)),
+        ("(foo){0,}", None),
+        ("(foo)(?:bar)", Some(1)),
+        ("(foo(?:bar)+)(?:baz(boo))", Some(2)),
+        ("(?P<bar>foo)(?:bar)(bal|loon)", Some(2)),
+        (r"(?:(\w)(\s))?", None),
+        (r#"<(a)[^>]+href="([^"]+)"|<(img)[^>]+src="([^"]+)""#, Some(2)),
+    ];
+    for (test_regex, expected) in tests {
+        let re = regex!(test_regex);
+        assert_eq!(re.participating_captures_len(), expected, "for regex {test_regex}");
+    }
+}
+
+#[test]
 fn capture_misc() {
     let re = regex!(r"(.)(?P<a>a)?(.)(?P<b>.)");
     let cap = re.captures(t!("abc")).unwrap();

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -157,12 +157,15 @@ fn participating_captures_len() {
         ("(foo)(?:bar)", Some(1)),
         ("(foo(?:bar)+)(?:baz(boo))", Some(2)),
         ("(?P<bar>foo)(?:bar)(bal|loon)", Some(2)),
-        (r"(?:(\w)(\s))?", None),
         (r#"<(a)[^>]+href="([^"]+)"|<(img)[^>]+src="([^"]+)""#, Some(2)),
     ];
     for (test_regex, expected) in tests {
         let re = regex!(test_regex);
-        assert_eq!(re.participating_captures_len(), expected, "for regex {test_regex}");
+        assert_eq!(
+            re.participating_captures_len(),
+            expected,
+            "for regex {test_regex}"
+        );
     }
 }
 


### PR DESCRIPTION
Long overdue, but this is the first step towards adding https://github.com/rust-lang/regex/issues/824, as greenlit by @BurntSushi.

This new method of `Regex` returns the number of capture groups that will be filled during a successful match, or `None` if this can't be statically determined during `Regex` compile time.