### PR TITLE
Add split_inclusive

### DIFF
--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -318,6 +318,31 @@ impl Regex {
         Split { finder: self.find_iter(text), last: 0 }
     }
 
+    /// Returns an iterator of substrings of `text` delimited by a match of the
+    /// regular expression. Each element of the iterator will include the
+    /// delimiting match if it appears at the beginning of the element.
+    ///
+    /// This method will *not* copy the text given.
+    ///
+    /// # Example
+    ///
+    /// To split a string delimited by fruit and include the fruit:
+    ///
+    /// ```rust
+    /// # use regex::bytes::Regex;
+    /// # fn main() {
+    /// let re = Regex::new(r"(apple|banana|pear)").unwrap();
+    /// let fields: Vec<&[u8]> = re.split_inclusive(b"apples: 3 bananas: 2 pears: 4").collect();
+    /// assert_eq!(fields, vec![&b""[..], &b"apples: 3 "[..], &b"bananas: 2 "[..], &b"pears: 4"[..]]);
+    /// # }
+    /// ```
+    pub fn split_inclusive<'r, 't>(
+        &'r self,
+        text: &'t [u8],
+    ) -> SplitInclusive<'r, 't> {
+        SplitInclusive { finder: self.find_iter(text), last: 0 }
+    }
+
     /// Returns an iterator of at most `limit` substrings of `text` delimited
     /// by a match of the regular expression. (A `limit` of `0` will return no
     /// substrings.) Namely, each element of the iterator corresponds to text
@@ -766,6 +791,43 @@ impl<'r, 't> Iterator for Split<'r, 't> {
 }
 
 impl<'r, 't> FusedIterator for Split<'r, 't> {}
+
+/// Yields all substrings delimited by a regular expression match inclusive of
+/// the match.
+///
+/// `'r` is the lifetime of the compiled regular expression and `'t` is the
+/// lifetime of the byte string being split.
+#[derive(Debug)]
+pub struct SplitInclusive<'r, 't> {
+    finder: Matches<'r, 't>,
+    last: usize,
+}
+
+impl<'r, 't> Iterator for SplitInclusive<'r, 't> {
+    type Item = &'t [u8];
+
+    fn next(&mut self) -> Option<&'t [u8]> {
+        let text = self.finder.0.text();
+        match self.finder.next() {
+            None => {
+                if self.last > text.len() {
+                    None
+                } else {
+                    let s = &text[self.last..];
+                    self.last = text.len() + 1; // Next call will return None
+                    Some(s)
+                }
+            }
+            Some(m) => {
+                let matched = &text[self.last..m.start()];
+                self.last = m.start();
+                Some(matched)
+            }
+        }
+    }
+}
+
+impl<'r, 't> FusedIterator for SplitInclusive<'r, 't> {}
 
 /// Yields at most `N` substrings delimited by a regular expression match.
 ///

--- a/src/re_bytes.rs
+++ b/src/re_bytes.rs
@@ -318,22 +318,26 @@ impl Regex {
         Split { finder: self.find_iter(text), last: 0 }
     }
 
-    /// Returns an iterator of substrings of `text` delimited by a match of the
-    /// regular expression. Each element of the iterator will include the
-    /// delimiting match if it appears at the beginning of the element.
+    /// Returns an iterator of substrings of `text` separated by a match of the
+    /// regular expression. Differs from the iterator produced by split in that
+    /// split_inclusive leaves the matched part as the terminator of the
+    /// substring.
     ///
     /// This method will *not* copy the text given.
     ///
     /// # Example
     ///
-    /// To split a string delimited by fruit and include the fruit:
-    ///
     /// ```rust
     /// # use regex::bytes::Regex;
     /// # fn main() {
-    /// let re = Regex::new(r"(apple|banana|pear)").unwrap();
-    /// let fields: Vec<&[u8]> = re.split_inclusive(b"apples: 3 bananas: 2 pears: 4").collect();
-    /// assert_eq!(fields, vec![&b""[..], &b"apples: 3 "[..], &b"bananas: 2 "[..], &b"pears: 4"[..]]);
+    /// let re = Regex::new(r"\r?\n").unwrap();
+    /// let text = b"Mary had a little lamb\nlittle lamb\r\nlittle lamb.";
+    /// let v: Vec<&[u8]> = re.split_inclusive(text).collect();
+    /// assert_eq!(v, [
+    ///     &b"Mary had a little lamb\n"[..],
+    ///     &b"little lamb\r\n"[..],
+    ///     &b"little lamb."[..]
+    /// ]);
     /// # }
     /// ```
     pub fn split_inclusive<'r, 't>(
@@ -819,8 +823,8 @@ impl<'r, 't> Iterator for SplitInclusive<'r, 't> {
                 }
             }
             Some(m) => {
-                let matched = &text[self.last..m.start()];
-                self.last = m.start();
+                let matched = &text[self.last..m.end()];
+                self.last = m.end();
                 Some(matched)
             }
         }

--- a/src/re_unicode.rs
+++ b/src/re_unicode.rs
@@ -379,17 +379,13 @@ impl Regex {
     ///
     /// # Example
     ///
-    /// To split a string delimited by fruit and include the fruit:
-    ///
     /// ```rust
     /// # use regex::Regex;
     /// # fn main() {
-    /// let re = Regex::new(r"(apple|banana|pear)").unwrap();
-    /// let fields: Vec<&str> = re
-    ///     .split_inclusive("apples: 3 bananas: 2 pears: 4")
-    ///     .map(|s| s.trim())
-    ///     .collect();
-    /// assert_eq!(fields, vec!["", "apples: 3", "bananas: 2", "pears: 4"]);
+    /// let re = Regex::new(r"\r?\n").unwrap();
+    /// let text = "Mary had a little lamb\nlittle lamb\r\nlittle lamb.";
+    /// let v: Vec<&str> = re.split_inclusive(text).collect();
+    /// assert_eq!(v, ["Mary had a little lamb\n", "little lamb\r\n", "little lamb."]);
     /// # }
     /// ```
     pub fn split_inclusive<'r, 't>(
@@ -864,8 +860,8 @@ impl<'r, 't> Iterator for SplitInclusive<'r, 't> {
                 }
             }
             Some(m) => {
-                let matched = &text[self.last..m.start()];
-                self.last = m.start();
+                let matched = &text[self.last..m.end()];
+                self.last = m.end();
                 Some(matched)
             }
         }


### PR DESCRIPTION
This adds a new iterator type and a new method to both the byte and unicode version of `Regex`. Most of the code is copied from the ordinary split iterator. My doc example is probably terrible, but who doesn't like fruit?

Before opening this PR, I checked to see whether it's possible to mimic this behavior using, say, a non-capturing group with the regular split. If it is, I didn't manage to do it correctly, so maybe this is still useful to someone. No idea. In my own work, where I have wanted this, I have also wanted the captures associated with the pattern, so that might be a more useful contract than what is presented here.

Closes #681 