### PR TITLE
Support `(?<` syntax for named capture groups

### DIFF
--- a/regex-syntax/src/ast/mod.rs
+++ b/regex-syntax/src/ast/mod.rs
@@ -1203,7 +1203,9 @@ impl Group {
     /// Returns true if and only if this group is capturing.
     pub fn is_capturing(&self) -> bool {
         match self.kind {
-            GroupKind::CaptureIndex(_) | GroupKind::CaptureName(_) => true,
+            GroupKind::CaptureIndex(_)
+            | GroupKind::CaptureName(_)
+            | GroupKind::CapturePName(_) => true,
             GroupKind::NonCapturing(_) => false,
         }
     }
@@ -1214,7 +1216,9 @@ impl Group {
     pub fn capture_index(&self) -> Option<u32> {
         match self.kind {
             GroupKind::CaptureIndex(i) => Some(i),
-            GroupKind::CaptureName(ref x) => Some(x.index),
+            GroupKind::CaptureName(ref x) | GroupKind::CapturePName(ref x) => {
+                Some(x.index)
+            }
             GroupKind::NonCapturing(_) => None,
         }
     }
@@ -1225,8 +1229,10 @@ impl Group {
 pub enum GroupKind {
     /// `(a)`
     CaptureIndex(u32),
-    /// `(?P<name>a)`
+    /// `(?<name>a)`
     CaptureName(CaptureName),
+    /// `(?P<name>a)`
+    CapturePName(CaptureName),
     /// `(?:a)` and `(?i:a)`
     NonCapturing(Flags),
 }

--- a/regex-syntax/src/ast/mod.rs
+++ b/regex-syntax/src/ast/mod.rs
@@ -1203,9 +1203,7 @@ impl Group {
     /// Returns true if and only if this group is capturing.
     pub fn is_capturing(&self) -> bool {
         match self.kind {
-            GroupKind::CaptureIndex(_)
-            | GroupKind::CaptureName(_)
-            | GroupKind::CapturePName(_) => true,
+            GroupKind::CaptureIndex(_) | GroupKind::CaptureName { .. } => true,
             GroupKind::NonCapturing(_) => false,
         }
     }
@@ -1216,9 +1214,7 @@ impl Group {
     pub fn capture_index(&self) -> Option<u32> {
         match self.kind {
             GroupKind::CaptureIndex(i) => Some(i),
-            GroupKind::CaptureName(ref x) | GroupKind::CapturePName(ref x) => {
-                Some(x.index)
-            }
+            GroupKind::CaptureName { ref name, .. } => Some(name.index),
             GroupKind::NonCapturing(_) => None,
         }
     }
@@ -1229,10 +1225,13 @@ impl Group {
 pub enum GroupKind {
     /// `(a)`
     CaptureIndex(u32),
-    /// `(?<name>a)`
-    CaptureName(CaptureName),
-    /// `(?P<name>a)`
-    CapturePName(CaptureName),
+    /// `(?<name>a)` or `(?P<name>a)`
+    CaptureName {
+        /// True if the `?P<` syntax is used and false if the `?<` syntax is used.
+        starts_with_p: bool,
+        /// The capture name.
+        name: CaptureName,
+    },
     /// `(?:a)` and `(?i:a)`
     NonCapturing(Flags),
 }

--- a/regex-syntax/src/ast/parse.rs
+++ b/regex-syntax/src/ast/parse.rs
@@ -3826,6 +3826,21 @@ bar
     #[test]
     fn parse_capture_name() {
         assert_eq!(
+            parser("(?<a>z)").parse(),
+            Ok(Ast::Group(ast::Group {
+                span: span(0..7),
+                kind: ast::GroupKind::CaptureName {
+                    starts_with_p: false,
+                    name: ast::CaptureName {
+                        span: span(3..4),
+                        name: s("a"),
+                        index: 1,
+                    }
+                },
+                ast: Box::new(lit('z', 5)),
+            }))
+        );
+        assert_eq!(
             parser("(?P<a>z)").parse(),
             Ok(Ast::Group(ast::Group {
                 span: span(0..8),

--- a/regex-syntax/src/ast/parse.rs
+++ b/regex-syntax/src/ast/parse.rs
@@ -1195,7 +1195,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
             ));
         }
         let inner_span = self.span();
-        if self.bump_if("?P<") {
+        if self.bump_if("?P<") || self.bump_if("?<") {
             let capture_index = self.next_capture_index(open_span)?;
             let cap = self.parse_capture_name(capture_index)?;
             Ok(Either::Right(ast::Group {

--- a/regex-syntax/src/ast/parse.rs
+++ b/regex-syntax/src/ast/parse.rs
@@ -1196,10 +1196,17 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
         }
         let inner_span = self.span();
         let mut has_p = false;
-        if self.bump_if("?<") || {has_p = true; self.bump_if("?P<")} {
+        if self.bump_if("?<") || {
+            has_p = true;
+            self.bump_if("?P<")
+        } {
             let capture_index = self.next_capture_index(open_span)?;
             let cap = self.parse_capture_name(capture_index)?;
-            let kind = if has_p { ast::GroupKind::CapturePName } else { ast::GroupKind::CaptureName } ;
+            let kind = if has_p {
+                ast::GroupKind::CapturePName
+            } else {
+                ast::GroupKind::CaptureName
+            };
             Ok(Either::Right(ast::Group {
                 span: open_span,
                 kind: kind(cap),

--- a/regex-syntax/src/ast/parse.rs
+++ b/regex-syntax/src/ast/parse.rs
@@ -1195,12 +1195,14 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
             ));
         }
         let inner_span = self.span();
-        if self.bump_if("?P<") || self.bump_if("?<") {
+        let mut has_p = false;
+        if self.bump_if("?<") || {has_p = true; self.bump_if("?P<")} {
             let capture_index = self.next_capture_index(open_span)?;
             let cap = self.parse_capture_name(capture_index)?;
+            let kind = if has_p { ast::GroupKind::CapturePName } else { ast::GroupKind::CaptureName } ;
             Ok(Either::Right(ast::Group {
                 span: open_span,
-                kind: ast::GroupKind::CaptureName(cap),
+                kind: kind(cap),
                 ast: Box::new(Ast::Empty(self.span())),
             }))
         } else if self.bump_if("?") {
@@ -2799,7 +2801,7 @@ bar
                     flag_set(pat, 0..4, ast::Flag::IgnoreWhitespace, false),
                     Ast::Group(ast::Group {
                         span: span_range(pat, 4..pat.len()),
-                        kind: ast::GroupKind::CaptureName(ast::CaptureName {
+                        kind: ast::GroupKind::CapturePName(ast::CaptureName {
                             span: span_range(pat, 9..12),
                             name: s("foo"),
                             index: 1,
@@ -3822,7 +3824,7 @@ bar
             parser("(?P<a>z)").parse(),
             Ok(Ast::Group(ast::Group {
                 span: span(0..8),
-                kind: ast::GroupKind::CaptureName(ast::CaptureName {
+                kind: ast::GroupKind::CapturePName(ast::CaptureName {
                     span: span(4..5),
                     name: s("a"),
                     index: 1,
@@ -3834,7 +3836,7 @@ bar
             parser("(?P<abc>z)").parse(),
             Ok(Ast::Group(ast::Group {
                 span: span(0..10),
-                kind: ast::GroupKind::CaptureName(ast::CaptureName {
+                kind: ast::GroupKind::CapturePName(ast::CaptureName {
                     span: span(4..7),
                     name: s("abc"),
                     index: 1,
@@ -3847,7 +3849,7 @@ bar
             parser("(?P<a_1>z)").parse(),
             Ok(Ast::Group(ast::Group {
                 span: span(0..10),
-                kind: ast::GroupKind::CaptureName(ast::CaptureName {
+                kind: ast::GroupKind::CapturePName(ast::CaptureName {
                     span: span(4..7),
                     name: s("a_1"),
                     index: 1,
@@ -3860,7 +3862,7 @@ bar
             parser("(?P<a.1>z)").parse(),
             Ok(Ast::Group(ast::Group {
                 span: span(0..10),
-                kind: ast::GroupKind::CaptureName(ast::CaptureName {
+                kind: ast::GroupKind::CapturePName(ast::CaptureName {
                     span: span(4..7),
                     name: s("a.1"),
                     index: 1,
@@ -3873,7 +3875,7 @@ bar
             parser("(?P<a[1]>z)").parse(),
             Ok(Ast::Group(ast::Group {
                 span: span(0..11),
-                kind: ast::GroupKind::CaptureName(ast::CaptureName {
+                kind: ast::GroupKind::CapturePName(ast::CaptureName {
                     span: span(4..8),
                     name: s("a[1]"),
                     index: 1,

--- a/regex-syntax/src/ast/parse.rs
+++ b/regex-syntax/src/ast/parse.rs
@@ -1195,21 +1195,16 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
             ));
         }
         let inner_span = self.span();
-        let mut has_p = false;
-        if self.bump_if("?<") || {
-            has_p = true;
-            self.bump_if("?P<")
+        let mut starts_with_p = true;
+        if self.bump_if("?P<") || {
+            starts_with_p = false;
+            self.bump_if("?<")
         } {
             let capture_index = self.next_capture_index(open_span)?;
-            let cap = self.parse_capture_name(capture_index)?;
-            let kind = if has_p {
-                ast::GroupKind::CapturePName
-            } else {
-                ast::GroupKind::CaptureName
-            };
+            let name = self.parse_capture_name(capture_index)?;
             Ok(Either::Right(ast::Group {
                 span: open_span,
-                kind: kind(cap),
+                kind: ast::GroupKind::CaptureName { starts_with_p, name },
                 ast: Box::new(Ast::Empty(self.span())),
             }))
         } else if self.bump_if("?") {
@@ -2808,11 +2803,14 @@ bar
                     flag_set(pat, 0..4, ast::Flag::IgnoreWhitespace, false),
                     Ast::Group(ast::Group {
                         span: span_range(pat, 4..pat.len()),
-                        kind: ast::GroupKind::CapturePName(ast::CaptureName {
-                            span: span_range(pat, 9..12),
-                            name: s("foo"),
-                            index: 1,
-                        }),
+                        kind: ast::GroupKind::CaptureName {
+                            starts_with_p: true,
+                            name: ast::CaptureName {
+                                span: span_range(pat, 9..12),
+                                name: s("foo"),
+                                index: 1,
+                            }
+                        },
                         ast: Box::new(lit_with('a', span_range(pat, 14..15))),
                     }),
                 ]
@@ -3831,11 +3829,14 @@ bar
             parser("(?P<a>z)").parse(),
             Ok(Ast::Group(ast::Group {
                 span: span(0..8),
-                kind: ast::GroupKind::CapturePName(ast::CaptureName {
-                    span: span(4..5),
-                    name: s("a"),
-                    index: 1,
-                }),
+                kind: ast::GroupKind::CaptureName {
+                    starts_with_p: true,
+                    name: ast::CaptureName {
+                        span: span(4..5),
+                        name: s("a"),
+                        index: 1,
+                    }
+                },
                 ast: Box::new(lit('z', 6)),
             }))
         );
@@ -3843,11 +3844,14 @@ bar
             parser("(?P<abc>z)").parse(),
             Ok(Ast::Group(ast::Group {
                 span: span(0..10),
-                kind: ast::GroupKind::CapturePName(ast::CaptureName {
-                    span: span(4..7),
-                    name: s("abc"),
-                    index: 1,
-                }),
+                kind: ast::GroupKind::CaptureName {
+                    starts_with_p: true,
+                    name: ast::CaptureName {
+                        span: span(4..7),
+                        name: s("abc"),
+                        index: 1,
+                    }
+                },
                 ast: Box::new(lit('z', 8)),
             }))
         );
@@ -3856,11 +3860,14 @@ bar
             parser("(?P<a_1>z)").parse(),
             Ok(Ast::Group(ast::Group {
                 span: span(0..10),
-                kind: ast::GroupKind::CapturePName(ast::CaptureName {
-                    span: span(4..7),
-                    name: s("a_1"),
-                    index: 1,
-                }),
+                kind: ast::GroupKind::CaptureName {
+                    starts_with_p: true,
+                    name: ast::CaptureName {
+                        span: span(4..7),
+                        name: s("a_1"),
+                        index: 1,
+                    }
+                },
                 ast: Box::new(lit('z', 8)),
             }))
         );
@@ -3869,11 +3876,14 @@ bar
             parser("(?P<a.1>z)").parse(),
             Ok(Ast::Group(ast::Group {
                 span: span(0..10),
-                kind: ast::GroupKind::CapturePName(ast::CaptureName {
-                    span: span(4..7),
-                    name: s("a.1"),
-                    index: 1,
-                }),
+                kind: ast::GroupKind::CaptureName {
+                    starts_with_p: true,
+                    name: ast::CaptureName {
+                        span: span(4..7),
+                        name: s("a.1"),
+                        index: 1,
+                    }
+                },
                 ast: Box::new(lit('z', 8)),
             }))
         );
@@ -3882,11 +3892,14 @@ bar
             parser("(?P<a[1]>z)").parse(),
             Ok(Ast::Group(ast::Group {
                 span: span(0..11),
-                kind: ast::GroupKind::CapturePName(ast::CaptureName {
-                    span: span(4..8),
-                    name: s("a[1]"),
-                    index: 1,
-                }),
+                kind: ast::GroupKind::CaptureName {
+                    starts_with_p: true,
+                    name: ast::CaptureName {
+                        span: span(4..8),
+                        name: s("a[1]"),
+                        index: 1,
+                    }
+                },
                 ast: Box::new(lit('z', 9)),
             }))
         );

--- a/regex-syntax/src/ast/print.rs
+++ b/regex-syntax/src/ast/print.rs
@@ -505,6 +505,7 @@ mod tests {
     fn print_group() {
         roundtrip("(?i:a)");
         roundtrip("(?P<foo>a)");
+        roundtrip("(?<foo>a)");
         roundtrip("(a)");
     }
 

--- a/regex-syntax/src/ast/print.rs
+++ b/regex-syntax/src/ast/print.rs
@@ -158,6 +158,12 @@ impl<W: fmt::Write> Writer<W> {
         match ast.kind {
             CaptureIndex(_) => self.wtr.write_str("("),
             CaptureName(ref x) => {
+                self.wtr.write_str("(?<")?;
+                self.wtr.write_str(&x.name)?;
+                self.wtr.write_str(">")?;
+                Ok(())
+            }
+            CapturePName(ref x) => {
                 self.wtr.write_str("(?P<")?;
                 self.wtr.write_str(&x.name)?;
                 self.wtr.write_str(">")?;

--- a/regex-syntax/src/ast/print.rs
+++ b/regex-syntax/src/ast/print.rs
@@ -157,15 +157,10 @@ impl<W: fmt::Write> Writer<W> {
         use crate::ast::GroupKind::*;
         match ast.kind {
             CaptureIndex(_) => self.wtr.write_str("("),
-            CaptureName(ref x) => {
-                self.wtr.write_str("(?<")?;
-                self.wtr.write_str(&x.name)?;
-                self.wtr.write_str(">")?;
-                Ok(())
-            }
-            CapturePName(ref x) => {
-                self.wtr.write_str("(?P<")?;
-                self.wtr.write_str(&x.name)?;
+            CaptureName { ref name, starts_with_p } => {
+                let start = if starts_with_p { "(?P<" } else { "(?<" };
+                self.wtr.write_str(start)?;
+                self.wtr.write_str(&name.name)?;
                 self.wtr.write_str(">")?;
                 Ok(())
             }

--- a/regex-syntax/src/hir/translate.rs
+++ b/regex-syntax/src/hir/translate.rs
@@ -771,7 +771,8 @@ impl<'t, 'p> TranslatorI<'t, 'p> {
             ast::GroupKind::CaptureIndex(idx) => {
                 hir::GroupKind::CaptureIndex(idx)
             }
-            ast::GroupKind::CaptureName(ref capname) => {
+            ast::GroupKind::CaptureName(ref capname)
+            | ast::GroupKind::CapturePName(ref capname) => {
                 hir::GroupKind::CaptureName {
                     name: capname.name.clone(),
                     index: capname.index,

--- a/regex-syntax/src/hir/translate.rs
+++ b/regex-syntax/src/hir/translate.rs
@@ -771,11 +771,10 @@ impl<'t, 'p> TranslatorI<'t, 'p> {
             ast::GroupKind::CaptureIndex(idx) => {
                 hir::GroupKind::CaptureIndex(idx)
             }
-            ast::GroupKind::CaptureName(ref capname)
-            | ast::GroupKind::CapturePName(ref capname) => {
+            ast::GroupKind::CaptureName { ref name, .. } => {
                 hir::GroupKind::CaptureName {
-                    name: capname.name.clone(),
-                    index: capname.index,
+                    name: name.name.clone(),
+                    index: name.index,
                 }
             }
             ast::GroupKind::NonCapturing(_) => hir::GroupKind::NonCapturing,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,7 @@ regex matches `abc` at positions `0`, `1`, `2` and `3`.
 <pre class="rust">
 (exp)          numbered capture group (indexed by opening parenthesis)
 (?P&lt;name&gt;exp)  named (also numbered) capture group (allowed chars: [_0-9a-zA-Z.\[\]])
+(?&lt;name&gt;exp)   named (also numbered) capture group (allowed chars: [_0-9a-zA-Z.\[\]])
 (?:exp)        non-capturing group
 (?flags)       set flags within current group
 (?flags:exp)   set flags for exp (non-capturing)


### PR DESCRIPTION
In #955, we have discussed the inclusion of a new syntax, `(?<name>exp)` in addition to the existing one `(?P<name>exp)`.
This should make it easier for people coming from environments where `(?P<` is not supported (such as Java, JavaScript, .NET, Ruby, Boost) to use `regex`.

This PR implements the change and ensures that round-tripping of the AST is preserved.