### PR TITLE
impl: fix prefix literal matching bug

### DIFF
--- a/regex-syntax/src/hir/translate.rs
+++ b/regex-syntax/src/hir/translate.rs
@@ -3288,6 +3288,12 @@ mod tests {
     }
 
     #[test]
+    fn analysis_look_set_prefix_any() {
+        let p = props(r"(?-u)(?i:(?:\b|_)win(?:32|64|dows)?(?:\b|_))");
+        assert!(p.look_set_prefix_any().contains(Look::WordAscii));
+    }
+
+    #[test]
     fn analysis_is_anchored() {
         let is_start = |p| props(p).look_set_prefix().contains(Look::Start);
         let is_end = |p| props(p).look_set_suffix().contains(Look::End);

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -274,18 +274,18 @@ impl ExecBuilder {
                     // prefixes, so disable them.
                     prefixes = None;
                 } else if is_set
-                    && props.look_set_prefix().contains(Look::Start)
+                    && props.look_set_prefix_any().contains(Look::Start)
                 {
                     // Regex sets with anchors do not go well with literal
                     // optimizations.
                     prefixes = None;
-                } else if props.look_set_prefix().contains_word() {
+                } else if props.look_set_prefix_any().contains_word() {
                     // The new literal extractor ignores look-around while
                     // the old one refused to extract prefixes from regexes
                     // that began with a \b. These old creaky regex internals
                     // can't deal with it, so we drop it.
                     prefixes = None;
-                } else if props.look_set().contains(Look::StartLF) {
+                } else if props.look_set_prefix_any().contains(Look::StartLF) {
                     // Similar to the reasoning for word boundaries, this old
                     // regex engine can't handle literal prefixes with '(?m:^)'
                     // at the beginning of a regex.
@@ -298,15 +298,16 @@ impl ExecBuilder {
                     // Partial anchors unfortunately make it hard to use
                     // suffixes, so disable them.
                     suffixes = None;
-                } else if is_set && props.look_set_suffix().contains(Look::End)
+                } else if is_set
+                    && props.look_set_suffix_any().contains(Look::End)
                 {
                     // Regex sets with anchors do not go well with literal
                     // optimizations.
                     suffixes = None;
-                } else if props.look_set_suffix().contains_word() {
+                } else if props.look_set_suffix_any().contains_word() {
                     // See the prefix case for reasoning here.
                     suffixes = None;
-                } else if props.look_set().contains(Look::EndLF) {
+                } else if props.look_set_suffix_any().contains(Look::EndLF) {
                     // See the prefix case for reasoning here.
                     suffixes = None;
                 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -220,3 +220,23 @@ matiter!(empty_group_find, r"()Ј01", "zЈ01", (1, 5));
 
 // See: https://github.com/rust-lang/regex/issues/862
 mat!(non_greedy_question_literal, r"ab??", "ab", Some((0, 1)));
+
+// See: https://github.com/rust-lang/regex/issues/981
+#[cfg(feature = "unicode")]
+#[test]
+fn regression_bad_word_boundary() {
+    let re = regex_new!(r#"(?i:(?:\b|_)win(?:32|64|dows)?(?:\b|_))"#).unwrap();
+    let hay = "ubi-Darwin-x86_64.tar.gz";
+    assert!(!re.is_match(text!(hay)));
+    let hay = "ubi-Windows-x86_64.zip";
+    assert!(re.is_match(text!(hay)));
+}
+
+// See: https://github.com/rust-lang/regex/issues/982
+#[cfg(feature = "unicode-perl")]
+#[test]
+fn regression_unicode_perl_not_enabled() {
+    let pat = r"(\d+\s?(years|year|y))?\s?(\d+\s?(months|month|m))?\s?(\d+\s?(weeks|week|w))?\s?(\d+\s?(days|day|d))?\s?(\d+\s?(hours|hour|h))?";
+    let re = regex_new!(pat);
+    assert!(re.is_ok());
+}


### PR DESCRIPTION
This commit fixes a bug where it was possible to report a match where none existed. Basically, in the current regex crate, it just cannot deal with a mixture of look-around assertions in the prefix of a pattern and prefix literal optimizations. Before 1.8, this was handled by simply refusing to extract literals in that case. But in 1.8, with a rewrite of the literal extractor, literals are now extracted for patterns like this:

    (?i:(?:\b|_)win(?:32|64|dows)?(?:\b|_))

So in 1.8, since it was still using the old engines that can't deal with this, I added some extra logic to throw away any extracted prefix literals if a look-around assertion occurred in the prefix of the pattern. The problem is that the logic I used was "always occurs in the prefix of the pattern" instead of "may occur in the prefix of the pattern." In the pattern above, it's the latter case. So it slipped by and the regex engine tried to use the prefix literals to accelerat the search. This in turn caused mishandling of the `\b` and led to a false positive match.

The specific reason why the current regex engines can't deal with this is because they weren't designed to handle searches that took the surrounding context into account when resolving look-around assertions. It was a pretty big oversight on my part many years ago.

The new engines we'll be migrating to Real Soon Now don't have this problem and can deal with the prefix literal optimizations while correctly handling look-around assertions in the prefix.

Fixes #981