### PR TITLE
api: add `visit_concat_in` method `Visitor` traits

### DIFF
--- a/regex-syntax/src/ast/visitor.rs
+++ b/regex-syntax/src/ast/visitor.rs
@@ -49,7 +49,7 @@ pub trait Visitor {
     }
 
     /// This method is called between child nodes of a concatenation.
-    fn visit_concat_in(&mut self)-> Result<(), Self::Err> {
+    fn visit_concat_in(&mut self) -> Result<(), Self::Err> {
         Ok(())
     }
 

--- a/regex-syntax/src/ast/visitor.rs
+++ b/regex-syntax/src/ast/visitor.rs
@@ -48,6 +48,11 @@ pub trait Visitor {
         Ok(())
     }
 
+    /// This method is called between child nodes of a concatenation.
+    fn visit_concat_in(&mut self)-> Result<(), Self::Err> {
+        Ok(())
+    }
+
     /// This method is called on every [`ClassSetItem`](ast::ClassSetItem)
     /// before descending into child nodes.
     fn visit_class_set_item_pre(
@@ -228,8 +233,14 @@ impl<'a> HeapVisitor<'a> {
                 // If this is a concat/alternate, then we might have additional
                 // inductive steps to process.
                 if let Some(x) = self.pop(frame) {
-                    if let Frame::Alternation { .. } = x {
-                        visitor.visit_alternation_in()?;
+                    match x {
+                        Frame::Alternation { .. } => {
+                            visitor.visit_alternation_in()?;
+                        }
+                        Frame::Concat { .. } => {
+                            visitor.visit_concat_in()?;
+                        }
+                        _ => {}
                     }
                     ast = x.child();
                     self.stack.push((post_ast, x));

--- a/regex-syntax/src/hir/visitor.rs
+++ b/regex-syntax/src/hir/visitor.rs
@@ -41,6 +41,11 @@ pub trait Visitor {
     fn visit_alternation_in(&mut self) -> Result<(), Self::Err> {
         Ok(())
     }
+
+    /// This method is called between child nodes of a concatenation.
+    fn visit_concat_in(&mut self)-> Result<(), Self::Err> {
+        Ok(())
+    }
 }
 
 /// Executes an implementation of `Visitor` in constant stack space.
@@ -131,8 +136,14 @@ impl<'a> HeapVisitor<'a> {
                 // If this is a concat/alternate, then we might have additional
                 // inductive steps to process.
                 if let Some(x) = self.pop(frame) {
-                    if let Frame::Alternation { .. } = x {
-                        visitor.visit_alternation_in()?;
+                    match x {
+                        Frame::Alternation { .. } => {
+                            visitor.visit_alternation_in()?;
+                        }
+                        Frame::Concat { .. } => {
+                            visitor.visit_concat_in()?;
+                        }
+                        _ => {}
                     }
                     hir = x.child();
                     self.stack.push((post_hir, x));

--- a/regex-syntax/src/hir/visitor.rs
+++ b/regex-syntax/src/hir/visitor.rs
@@ -43,7 +43,7 @@ pub trait Visitor {
     }
 
     /// This method is called between child nodes of a concatenation.
-    fn visit_concat_in(&mut self)-> Result<(), Self::Err> {
+    fn visit_concat_in(&mut self) -> Result<(), Self::Err> {
         Ok(())
     }
 }


### PR DESCRIPTION
The `Visitor` trait already has a `visit_alternation_in` that is called between child nodes of an alternation, both in `ast` and `hir`. This adds a similar method that is called between child nodes of concat.

While using the `regexp_syntax` crate in [YARA-X](https://github.com/VirusTotal/yara-x) I came across the need of this method while traversing the HIR. I think this may be useful for more people.