### PR TITLE
Implement `TryFrom<{&str, String}>` for `Regex`

### DIFF
--- a/regex-lite/src/string.rs
+++ b/regex-lite/src/string.rs
@@ -117,6 +117,24 @@ impl core::str::FromStr for Regex {
     }
 }
 
+impl TryFrom<&str> for Regex {
+    type Error = Error;
+
+    /// Attempts to parse a string into a regular expression
+    fn try_from(s: &str) -> Result<Regex, Error> {
+        Regex::new(s)
+    }
+}
+
+impl TryFrom<String> for Regex {
+    type Error = Error;
+
+    /// Attempts to parse a string into a regular expression
+    fn try_from(s: String) -> Result<Regex, Error> {
+        Regex::new(&s)
+    }
+}
+
 /// Core regular expression methods.
 impl Regex {
     /// Compiles a regular expression. Once compiled, it can be used repeatedly

--- a/src/regex/bytes.rs
+++ b/src/regex/bytes.rs
@@ -1,4 +1,4 @@
-use alloc::{borrow::Cow, sync::Arc, vec::Vec};
+use alloc::{borrow::Cow, string::String, sync::Arc, vec::Vec};
 
 use regex_automata::{meta, util::captures, Input, PatternID};
 
@@ -121,6 +121,24 @@ impl core::str::FromStr for Regex {
     /// Attempts to parse a string into a regular expression
     fn from_str(s: &str) -> Result<Regex, Error> {
         Regex::new(s)
+    }
+}
+
+impl TryFrom<&str> for Regex {
+    type Error = Error;
+
+    /// Attempts to parse a string into a regular expression
+    fn try_from(s: &str) -> Result<Regex, Error> {
+        Regex::new(s)
+    }
+}
+
+impl TryFrom<String> for Regex {
+    type Error = Error;
+
+    /// Attempts to parse a string into a regular expression
+    fn try_from(s: String) -> Result<Regex, Error> {
+        Regex::new(&s)
     }
 }
 

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -126,6 +126,24 @@ impl core::str::FromStr for Regex {
     }
 }
 
+impl TryFrom<&str> for Regex {
+    type Error = Error;
+
+    /// Attempts to parse a string into a regular expression
+    fn try_from(s: &str) -> Result<Regex, Error> {
+        Regex::new(s)
+    }
+}
+
+impl TryFrom<String> for Regex {
+    type Error = Error;
+
+    /// Attempts to parse a string into a regular expression
+    fn try_from(s: String) -> Result<Regex, Error> {
+        Regex::new(&s)
+    }
+}
+
 /// Core regular expression methods.
 impl Regex {
     /// Compiles a regular expression. Once compiled, it can be used repeatedly


### PR DESCRIPTION
This enables builder APIs to take `T: TryInto<Regex>`, where `T` can be a string or a preconstructed `Regex` instance.