### PR TITLE
allow starting DFA in noncontinuous bytes

### DIFF
--- a/regex-automata/src/dfa/automaton.rs
+++ b/regex-automata/src/dfa/automaton.rs
@@ -8,6 +8,7 @@ use crate::{
         primitives::{PatternID, StateID},
         search::{Anchored, HalfMatch, Input, MatchError},
     },
+    Span,
 };
 
 /// A trait describing the interface of a deterministic finite automaton (DFA).
@@ -253,6 +254,14 @@ pub unsafe trait Automaton {
         input: &Input<'_>,
     ) -> Result<StateID, MatchError>;
 
+    /// TODO
+    fn start_state_forward_with(
+        &self,
+        mode: Anchored,
+        look_behind: Option<u8>,
+        span: Span,
+    ) -> Result<StateID, MatchError>;
+
     /// Return the ID of the start state for this lazy DFA when executing a
     /// reverse search.
     ///
@@ -278,6 +287,14 @@ pub unsafe trait Automaton {
     fn start_state_reverse(
         &self,
         input: &Input<'_>,
+    ) -> Result<StateID, MatchError>;
+
+    /// TODO
+    fn start_state_reverse_with(
+        &self,
+        mode: Anchored,
+        look_ahead: Option<u8>,
+        span: Span,
     ) -> Result<StateID, MatchError>;
 
     /// If this DFA has a universal starting state for the given anchor mode
@@ -1807,11 +1824,31 @@ unsafe impl<'a, A: Automaton + ?Sized> Automaton for &'a A {
     }
 
     #[inline]
+    fn start_state_forward_with(
+        &self,
+        mode: Anchored,
+        look_behind: Option<u8>,
+        span: Span,
+    ) -> Result<StateID, MatchError> {
+        (**self).start_state_forward_with(mode, look_behind, span)
+    }
+
+    #[inline]
     fn start_state_reverse(
         &self,
         input: &Input<'_>,
     ) -> Result<StateID, MatchError> {
         (**self).start_state_reverse(input)
+    }
+
+    #[inline]
+    fn start_state_reverse_with(
+        &self,
+        mode: Anchored,
+        look_behind: Option<u8>,
+        span: Span,
+    ) -> Result<StateID, MatchError> {
+        (**self).start_state_reverse_with(mode, look_behind, span)
     }
 
     #[inline]

--- a/regex-automata/src/util/start.rs
+++ b/regex-automata/src/util/start.rs
@@ -73,23 +73,39 @@ impl StartByteMap {
 
     /// Return the forward starting configuration for the given `input`.
     #[cfg_attr(feature = "perf-inline", inline(always))]
+    #[cfg(test)]
     pub(crate) fn fwd(&self, input: &Input) -> Start {
-        match input
-            .start()
-            .checked_sub(1)
-            .and_then(|i| input.haystack().get(i))
-        {
-            None => Start::Text,
-            Some(&byte) => self.get(byte),
-        }
+        self.fwd_with(
+            input
+                .start()
+                .checked_sub(1)
+                .and_then(|i| input.haystack().get(i))
+                .copied(),
+        )
     }
 
     /// Return the reverse starting configuration for the given `input`.
     #[cfg_attr(feature = "perf-inline", inline(always))]
+    #[cfg(test)]
     pub(crate) fn rev(&self, input: &Input) -> Start {
-        match input.haystack().get(input.end()) {
+        self.rev_with(input.haystack().get(input.end()).copied())
+    }
+
+    /// Return the forward starting configuration for the given `look_behind`
+    #[cfg_attr(feature = "perf-inline", inline(always))]
+    pub(crate) fn fwd_with(&self, look_behind: Option<u8>) -> Start {
+        match look_behind {
             None => Start::Text,
-            Some(&byte) => self.get(byte),
+            Some(byte) => self.get(byte),
+        }
+    }
+
+    /// Return the reverse starting configuration for the given `look_ahead`.
+    #[cfg_attr(feature = "perf-inline", inline(always))]
+    pub(crate) fn rev_with(&self, look_ahead: Option<u8>) -> Start {
+        match look_ahead {
+            None => Start::Text,
+            Some(byte) => self.get(byte),
         }
     }
 


### PR DESCRIPTION
regex-automtaton already supports transversing the DFA one byte at a time with
`next_state`. This is potentially very useful when scanning noncontinuous data
like network stream or a rope data structures as commonly used in editors.

However, to start the DFA with `start_state_forward`/`start_state_reverse`
currently requires an `Input` and will look ahead/look one byte behind the
span boundaries. To support that (especially when using prefilters/literal
optimization) a streaming use case can not provide such a haystack easily (it
can be worked around with a temporary array and copying one byte over but its
extremely brittle/hacky).

This PR adds the `start_state_forward_with`/`start_state_reverse_with`
function which allow passing the information extracted from the Input directly.

This is currently a draft because I haven't added proper documentation yet. I wanted to wait whether you were open to this change in general before writing the docs.
