### PR TITLE
fix: improve literal extraction from certain repetitions

### DIFF
--- a/regex-syntax/src/hir/literal.rs
+++ b/regex-syntax/src/hir/literal.rs
@@ -477,7 +477,7 @@ impl Extractor {
                 }
                 seq
             }
-            hir::Repetition { min, max: Some(max), .. } if min < max => {
+            hir::Repetition { min, .. } =>{
                 assert!(min > 0); // handled above
                 let limit =
                     u32::try_from(self.limit_repeat).unwrap_or(u32::MAX);
@@ -490,10 +490,6 @@ impl Extractor {
                 }
                 seq.make_inexact();
                 seq
-            }
-            hir::Repetition { .. } => {
-                subseq.make_inexact();
-                subseq
             }
         }
     }
@@ -2654,6 +2650,21 @@ mod tests {
                 "cdghij", "cdghkl",
             ]),
             e(r"(ab|cd)(ef|gh)(ij|kl)")
+        );
+        
+        assert_eq!(
+            inexact([E("abab")], [E("abab")]),
+            e(r"(ab){2}")
+        );
+
+        assert_eq!(
+            inexact([I("abab")], [I("abab")]),
+            e(r"(ab){2,3}")
+        );
+
+        assert_eq!(
+            inexact([I("abab")], [I("abab")]),
+            e(r"(ab){2,}")
         );
     }
 

--- a/regex-syntax/src/hir/literal.rs
+++ b/regex-syntax/src/hir/literal.rs
@@ -477,7 +477,7 @@ impl Extractor {
                 }
                 seq
             }
-            hir::Repetition { min, .. } =>{
+            hir::Repetition { min, .. } => {
                 assert!(min > 0); // handled above
                 let limit =
                     u32::try_from(self.limit_repeat).unwrap_or(u32::MAX);
@@ -2651,21 +2651,12 @@ mod tests {
             ]),
             e(r"(ab|cd)(ef|gh)(ij|kl)")
         );
-        
-        assert_eq!(
-            inexact([E("abab")], [E("abab")]),
-            e(r"(ab){2}")
-        );
 
-        assert_eq!(
-            inexact([I("abab")], [I("abab")]),
-            e(r"(ab){2,3}")
-        );
+        assert_eq!(inexact([E("abab")], [E("abab")]), e(r"(ab){2}"));
 
-        assert_eq!(
-            inexact([I("abab")], [I("abab")]),
-            e(r"(ab){2,}")
-        );
+        assert_eq!(inexact([I("abab")], [I("abab")]), e(r"(ab){2,3}"));
+
+        assert_eq!(inexact([I("abab")], [I("abab")]), e(r"(ab){2,}"));
     }
 
     #[test]


### PR DESCRIPTION
When repetitions didn't have an explicit max value, like in `(ab){2,}` the literal extractor was producing sub-optimal literals, like `"ab"` instead of `"abab"`.

Close #1032