### PR TITLE
regex-automata/test: ignore some tests in 32-bit targets

### DIFF
--- a/regex-automata/src/dfa/dense.rs
+++ b/regex-automata/src/dfa/dense.rs
@@ -879,6 +879,7 @@ impl Config {
     ///
     /// ```
     /// # if cfg!(miri) { return Ok(()); } // miri takes too long
+    /// # if !cfg!(target_pointer_width = "64") { return Ok(()); } // see #1039
     /// use regex_automata::{dfa::{dense, Automaton}, Input};
     ///
     /// // 600KB isn't enough!
@@ -912,6 +913,7 @@ impl Config {
     ///
     /// ```
     /// # if cfg!(miri) { return Ok(()); } // miri takes too long
+    /// # if !cfg!(target_pointer_width = "64") { return Ok(()); } // see #1039
     /// use regex_automata::{
     ///     dfa::{dense, Automaton, StartKind},
     ///     Anchored, Input,

--- a/regex-automata/src/util/captures.rs
+++ b/regex-automata/src/util/captures.rs
@@ -433,6 +433,7 @@ impl Captures {
     ///
     /// ```
     /// # if cfg!(miri) { return Ok(()); } // miri takes too long
+    /// # if !cfg!(target_pointer_width = "64") { return Ok(()); } // see #1039
     /// use regex_automata::{nfa::thompson::pikevm::PikeVM, Span, Match};
     ///
     /// let re = PikeVM::new(r"^(?P<first>\pL+)\s+(?P<last>\pL+)$")?;


### PR DESCRIPTION
One of these tests (the captures one) is very specific to 64-bit since it uses a numeric literal that is bigger than what can be fit into 32 bits.

The other two tests, for determinize_size_limit, are not specific to 64-bit targets but do somewhat depend on the specific memory usages in play. We could probably find some limits that work for both 32-bit and 64-bit, but since 'cross' doesn't run doc tests, doing this is pretty annoying. So just ignore the tests.

Fixes #1039