### PR TITLE
Add sanity limits for arbitrary-based fuzzers

### DIFF
--- a/fuzz/ast-fuzzers.options
+++ b/fuzz/ast-fuzzers.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 65536

--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -14,5 +14,8 @@ targets=(
   ast_fuzz_match_bytes
 )
 for target in "${targets[@]}"; do
-  cp fuzz/target/x86_64-unknown-linux-gnu/release/$target $OUT/
+  cp "fuzz/target/x86_64-unknown-linux-gnu/release/${target}" "${OUT}/"
+  if [[ "$target" == ast_* ]]; then
+    cp fuzz/ast-fuzzers.options "${OUT}/${target}.options"
+  fi
 done


### PR DESCRIPTION
Prevents situations where arbitrary-derive may cause a stack overflow due to recursion guard limitations.