### PR TITLE
More generic impl of Replacer for closures

### DIFF
--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -2570,6 +2570,20 @@ impl<'a> Replacer for &'a Cow<'a, str> {
     }
 }
 
+/// Blanket implementation of `Replacer` for closures.
+///
+/// This implementation is basically the following, except that the return type
+/// `T` may optionally depend on lifetime `'a`.
+///
+/// ```ignore
+/// impl<F, T> Replacer for F
+/// where
+///     F: for<'a> FnMut(&a Captures<'_>) -> T,
+///     T: AsRef<str>, // `T` may also depend on `'a`, which cannot be expressed easily
+/// {
+///     /* … */
+/// }
+/// ```
 impl<F: for<'a> ReplacerClosure<'a>> Replacer for F {
     fn replace_append(&mut self, caps: &Captures<'_>, dst: &mut String) {
         dst.push_str((*self)(caps).as_ref());

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -2375,7 +2375,7 @@ impl<'c, 'h> core::iter::FusedIterator for SubCaptureMatches<'c, 'h> {}
 /// [`Replacer`].
 pub trait ReplacerClosure<'a>
 where
-    Self: FnMut(&'a Captures<'a>) -> <Self as ReplacerClosure>::Output,
+    Self: FnMut(&'a Captures<'_>) -> <Self as ReplacerClosure<'a>>::Output,
 {
     /// Return type of the closure (may depend on lifetime `'a`).
     type Output: AsRef<str>;
@@ -2383,7 +2383,7 @@ where
 
 impl<'a, F: ?Sized, O> ReplacerClosure<'a> for F
 where
-    F: FnMut(&'a Captures<'a>) -> O,
+    F: FnMut(&'a Captures<'_>) -> O,
     O: AsRef<str>,
 {
     type Output = O;

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -2374,8 +2374,8 @@ impl<'c, 'h> core::iter::FusedIterator for SubCaptureMatches<'c, 'h> {}
 /// Contains helper trait for blanket implementation for [`Replacer`].
 mod replacer_closure {
     use super::*;
-    /// If a closure implements this for all `'a` and `'b`, then it also
-    /// implements [`Replacer`].
+    /// If a closure implements this for all `'a`, then it also implements
+    /// [`Replacer`].
     pub trait ReplacerClosure<'a>
     where
         Self: FnMut(&'a Captures<'_>) -> <Self as ReplacerClosure<'a>>::Output,

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -2375,14 +2375,15 @@ impl<'c, 'h> core::iter::FusedIterator for SubCaptureMatches<'c, 'h> {}
 /// without specifying the closure's return type.
 pub trait GenericFnMut1Arg<Arg>
 where
-    Self: FnMut(Arg) -> <Self as GenericFnMut1Arg<Arg>>::Output
+    Self: FnMut(Arg) -> <Self as GenericFnMut1Arg<Arg>>::Output,
 {
     /// Return type of the closure.
     type Output;
 }
 
 impl<T: ?Sized, Arg, Ret> GenericFnMut1Arg<Arg> for T
-where T: FnMut(Arg) -> Ret,
+where
+    T: FnMut(Arg) -> Ret,
 {
     type Output = Ret;
 }

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -2452,7 +2452,7 @@ use replacer_closure::*;
 /// [closure lifetime binders]: https://rust-lang.github.io/rfcs/3216-closure-lifetime-binder.html
 ///
 /// ```
-/// use regex::{Captures, Regex, Replacer};
+/// use regex::{Captures, Regex};
 /// use std::borrow::Cow;
 ///
 /// fn coerce<F: for<'a> FnMut(&'a Captures<'_>) -> Cow<'a, str>>(f: F) -> F {

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -2469,7 +2469,7 @@ use replacer_closure::*;
 ///
 /// The same example using closure lifetime binders:
 ///
-/// ```
+/// ```ignore
 /// #![feature(closure_lifetime_binder)]
 ///
 /// use regex::{Captures, Regex, Replacer};

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -2378,14 +2378,14 @@ mod replacer_closure {
     /// [`Replacer`].
     pub trait ReplacerClosure<'a>
     where
-        Self: FnMut(&'a Captures<'_>) -> <Self as ReplacerClosure<'a>>::Output,
+        Self: FnMut(&'a Captures<'a>) -> <Self as ReplacerClosure<'a>>::Output,
     {
         /// Return type of the closure (may depend on lifetime `'a`).
         type Output: AsRef<str>;
     }
     impl<'a, F: ?Sized, O> ReplacerClosure<'a> for F
     where
-        F: FnMut(&'a Captures<'_>) -> O,
+        F: FnMut(&'a Captures<'a>) -> O,
         O: AsRef<str>,
     {
         type Output = O;
@@ -2429,8 +2429,10 @@ use replacer_closure::*;
 /// # Implementation by closures
 ///
 /// Closures that take an argument of type  `&'a Captures<'b>` for any `'a` and
-/// `'b: 'a` and which return a type `T: AsRef<str>` (that may depend on `'a`)
-/// implement the `Replacer` trait through a blanket implementation.
+/// `'b: 'a` and which return a type `T: AsRef<str>` (that may depend on `'a`
+/// or `'b`) implement the `Replacer` trait through a [blanket implementation].
+///
+/// [blanket implementation]: Self#impl-Replacer-for-F
 ///
 /// A simple example looks like this:
 ///
@@ -2578,7 +2580,7 @@ impl<'a> Replacer for &'a Cow<'a, str> {
 /// ```ignore
 /// impl<F, T> Replacer for F
 /// where
-///     F: for<'a> FnMut(&a Captures<'_>) -> T,
+///     F: for<'a> FnMut(&'a Captures<'a>) -> T,
 ///     T: AsRef<str>, // `T` may also depend on `'a`, which cannot be expressed easily
 /// {
 ///     /* … */

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -170,20 +170,4 @@ mod replacer_closure_lifetimes {
         );
         assert_eq!(s, "x");
     }
-    // Additionally demand that its sufficient if the closure accepts a single
-    // lifetime `'u` which is used both for the reference to and the lifetime
-    // argument of the `Captures` argument. Note that `Captures<'u>` is
-    // covariant over `'u`.
-    #[test]
-    fn unified_lifetime() {
-        fn coerce<F: for<'u> FnMut(&'u Captures<'u>) -> Cow<'u, str>>(
-            f: F,
-        ) -> F {
-            f
-        }
-        let s = Regex::new("x")
-            .unwrap()
-            .replace_all("x", coerce(|caps| Cow::Borrowed(&caps[0])));
-        assert_eq!(s, "x");
-    }
 }


### PR DESCRIPTION
Implement `Replacer` also for closures that return a type which depends on lifetime of the argument. This allows performing a no-op replacement where the closure returns the whole match, for example, without needing to clone the captured string.

See [Conditional regex replacement](https://users.rust-lang.org/t/conditional-regex-replacement/97174?u=jbe) on URLO for the genesis of this approach.