### PR TITLE
syntax: optimize some functions in IntervalSet.

### DIFF
--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -236,7 +236,7 @@ impl<I: Interval> IntervalSet<I> {
         }
 
         self.ranges.drain(..drain_end);
-        self.folded = self.folded && other.folded;
+        self.folded = self.ranges.is_empty() || (self.folded && other.folded);
     }
 
     /// Compute the symmetric difference of the two sets, in place.

--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -321,28 +321,29 @@ impl<I: Interval> IntervalSet<I> {
             return;
         }
 
-        // There should be a way to do this in-place with constant memory,
-        // but I couldn't figure out a simple way to do it. So just append
-        // the negation to the end of this range, and then drain it before
-        // we're done.
-        let drain_end = self.ranges.len();
-
         // We do checked arithmetic below because of the canonical ordering
         // invariant.
         if self.ranges[0].lower() > I::Bound::min_value() {
-            let upper = self.ranges[0].lower().decrement();
-            self.ranges.push(I::create(I::Bound::min_value(), upper));
+            let mut pre_upper = self.ranges[0].upper();
+            self.ranges[0] = I::create(I::Bound::min_value(), self.ranges[0].lower().decrement());
+            for i in 1..self.ranges.len() {
+                let lower = pre_upper.increment();
+                pre_upper = self.ranges[i].upper();
+                self.ranges[i] = I::create(lower, self.ranges[i].lower().decrement());
+            }
+            if pre_upper < I::Bound::max_value() {
+                self.ranges.push(I::create(pre_upper.increment(), I::Bound::max_value()));
+            }
+        } else {
+            for i in 1..self.ranges.len() {
+                self.ranges[i - 1] = I::create(self.ranges[i - 1].upper().increment(), self.ranges[i].lower().decrement());
+            }
+            if self.ranges.last().unwrap().upper() < I::Bound::max_value() {
+                self.ranges.last_mut().map(|range| *range = I::create(range.upper().increment(), I::Bound::max_value()));
+            } else {
+                self.ranges.pop();
+            }
         }
-        for i in 1..drain_end {
-            let lower = self.ranges[i - 1].upper().increment();
-            let upper = self.ranges[i].lower().decrement();
-            self.ranges.push(I::create(lower, upper));
-        }
-        if self.ranges[drain_end - 1].upper() < I::Bound::max_value() {
-            let lower = self.ranges[drain_end - 1].upper().increment();
-            self.ranges.push(I::create(lower, I::Bound::max_value()));
-        }
-        self.ranges.drain(..drain_end);
         // We don't need to update whether this set is folded or not, because
         // it is conservatively preserved through negation. Namely, if a set
         // is not folded, then it is possible that its negation is folded, for
@@ -356,6 +357,7 @@ impl<I: Interval> IntervalSet<I> {
         // of case folded characters. Negating it in turn means that all
         // equivalence classes in the set are negated, and any equivalence
         // class that was previously not in the set is now entirely in the set.
+        self.folded = self.ranges.is_empty() || self.folded;
     }
 
     /// Converts this set into a canonical ordering.

--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -351,7 +351,7 @@ impl<I: Interval> IntervalSet<I> {
         // and merge them if possible. Otherwise, we make it the
         // range as the last one.
         let mut newi = 0;
-        for oldi in 1..self.ranges.len() {    
+        for oldi in 1..self.ranges.len() {
             if let Some(union) = self.ranges[newi].union(&self.ranges[oldi]) {
                 self.ranges[newi] = union;
             } else {

--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -266,7 +266,8 @@ impl<I: Interval> IntervalSet<I> {
         let mut b_range = Some(other.ranges[b]);
         for a in 0..drain_end {
             self.ranges.push(self.ranges[a]);
-            while b_range.is_some_and(|r| r.lower() <= self.ranges[a].upper())
+            while b_range.is_some()
+                && b_range.unwrap().lower() <= self.ranges[a].upper()
             {
                 let (range1, range2) = match self
                     .ranges

--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -192,34 +192,13 @@ impl<I: Interval> IntervalSet<I> {
         // Folks seem to suggest interval or segment trees, but I'd like to
         // avoid the overhead (both runtime and conceptual) of that.
         //
-        // The following is basically my Shitty First Draft. Therefore, in
-        // order to grok it, you probably need to read each line carefully.
-        // Simplifications are most welcome!
-        //
         // Remember, we can assume the canonical format invariant here, which
         // says that all ranges are sorted, not overlapping and not adjacent in
         // each class.
         let drain_end = self.ranges.len();
-        let (mut a, mut b) = (0, 0);
-        'LOOP: while a < drain_end && b < other.ranges.len() {
-            // Basically, the easy cases are when neither range overlaps with
-            // each other. If the `b` range is less than our current `a`
-            // range, then we can skip it and move on.
-            if other.ranges[b].upper() < self.ranges[a].lower() {
-                b += 1;
-                continue;
-            }
-            // ... similarly for the `a` range. If it's less than the smallest
-            // `b` range, then we can add it as-is.
-            if self.ranges[a].upper() < other.ranges[b].lower() {
-                let range = self.ranges[a];
-                self.ranges.push(range);
-                a += 1;
-                continue;
-            }
-            // Otherwise, we have overlapping ranges.
-            assert!(!self.ranges[a].is_intersection_empty(&other.ranges[b]));
 
+        let mut b = 0;
+        for a in 0..drain_end {
             // This part is tricky and was non-obvious to me without looking
             // at explicit examples (see the tests). The trickiness stems from
             // two things: 1) subtracting a range from another range could
@@ -231,45 +210,31 @@ impl<I: Interval> IntervalSet<I> {
             // For example, if our `a` range is `a-t` and our next three `b`
             // ranges are `a-c`, `g-i`, `r-t` and `x-z`, then we need to apply
             // subtraction three times before moving on to the next `a` range.
-            let mut range = self.ranges[a];
+            self.ranges.push(self.ranges[a]);
+            // Only when `b` is not above `a`, `b` might apply to current
+            // `a` range.
             while b < other.ranges.len()
-                && !range.is_intersection_empty(&other.ranges[b])
-            {
-                let old_range = range;
-                range = match range.difference(&other.ranges[b]) {
-                    (None, None) => {
-                        // We lost the entire range, so move on to the next
-                        // without adding this one.
-                        a += 1;
-                        continue 'LOOP;
+                && other.ranges[b].lower() <= self.ranges[a].upper() {
+                match self.ranges.pop().unwrap().difference(&other.ranges[b]) {
+                    (Some(range1), None) | (None, Some(range1)) => {
+                        self.ranges.push(range1);
                     }
-                    (Some(range1), None) | (None, Some(range1)) => range1,
                     (Some(range1), Some(range2)) => {
                         self.ranges.push(range1);
-                        range2
+                        self.ranges.push(range2);
                     }
-                };
-                // It's possible that the `b` range has more to contribute
-                // here. In particular, if it is greater than the original
-                // range, then it might impact the next `a` range *and* it
-                // has impacted the current `a` range as much as possible,
-                // so we can quit. We don't bump `b` so that the next `a`
-                // range can apply it.
-                if other.ranges[b].upper() > old_range.upper() {
-                    break;
+                    (None, None) => {}
                 }
-                // Otherwise, the next `b` range might apply to the current
+                // The next `b` range might apply to the current
                 // `a` range.
                 b += 1;
             }
-            self.ranges.push(range);
-            a += 1;
+            // It's possible that the last `b` range has more to
+            // contribute to the next `a`. We don't bump the last
+            // `b` so that the next `a` range can apply it.
+            b = b.saturating_sub(1);
         }
-        while a < drain_end {
-            let range = self.ranges[a];
-            self.ranges.push(range);
-            a += 1;
-        }
+
         self.ranges.drain(..drain_end);
         self.folded = self.folded && other.folded;
     }

--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -347,12 +347,12 @@ impl<I: Interval> IntervalSet<I> {
         self.ranges.sort();
         assert!(!self.ranges.is_empty());
 
-        // We maintains the canonicalization results in-place at `0..newi`.
+        // We maintain the canonicalization results in-place at `0..newi`.
         // `newi` will keep track of the end of the canonicalized ranges.
         let mut newi = 0;
         for oldi in 1..self.ranges.len() {
             // The last new range gets merged with currnet old range when unionable.
-            // If not, we store it as the new range at the current `newi`.
+            // If not, we update `newi` and store it as a new range.
             if let Some(union) = self.ranges[newi].union(&self.ranges[oldi]) {
                 self.ranges[newi] = union;
             } else {

--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -97,6 +97,7 @@ impl<I: Interval> IntervalSet<I> {
         let mut drain_end = self.ranges.len();
         while drain_end > 0
             && self.ranges[drain_end - 1].lower() > interval.upper()
+            && !self.ranges[drain_end - 1].is_contiguous(&interval)
         {
             drain_end -= 1;
         }
@@ -106,7 +107,7 @@ impl<I: Interval> IntervalSet<I> {
         {
             self.ranges[drain_end - 1] =
                 self.ranges[drain_end - 1].union(&interval).unwrap();
-            for i in 0..drain_end - 1 {
+            for i in (0..drain_end - 1).rev() {
                 if let Some(union) =
                     self.ranges[drain_end - 1].union(&self.ranges[i])
                 {

--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -347,11 +347,12 @@ impl<I: Interval> IntervalSet<I> {
         self.ranges.sort();
         assert!(!self.ranges.is_empty());
 
-        // We consistently try to merge range with previous range
-        // and merge them if possible. Otherwise, we make it the
-        // range as the last one.
+        // We maintains the canonicalization results in-place at `0..newi`.
+        // `newi` will keep track of the end of the canonicalized ranges.
         let mut newi = 0;
         for oldi in 1..self.ranges.len() {
+            // The last new range gets merged with currnet old range when unionable.
+            // If not, we store it as the new range at the current `newi`.
             if let Some(union) = self.ranges[newi].union(&self.ranges[oldi]) {
                 self.ranges[newi] = union;
             } else {


### PR DESCRIPTION
Replace the canonicalize function the in-place way with constant memory.
Replace the negate function the in-place way with constant memory.
Simplify the difference function without changing the algorithm.
Implement symmetric_difference function like others.
Implement push function like others.
Force the symmetric_difference function in Interval return ranges in order.