### PR TITLE
doc: fix typo in module-level doc

### DIFF
--- a/regex-lite/src/lib.rs
+++ b/regex-lite/src/lib.rs
@@ -107,7 +107,7 @@ fn main() {
 }
 ```
 
-Foruth, run it with `cargo run`:
+Fourth, run it with `cargo run`:
 
 ```text
 $ cargo run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ fn main() {
 }
 ```
 
-Foruth, run it with `cargo run`:
+Fourth, run it with `cargo run`:
 
 ```text
 $ cargo run


### PR DESCRIPTION
A typo I found when browsing the docs.