### PR TITLE
Add a feature to regex-syntax that enables look-around expressions

### DIFF
--- a/regex-syntax/Cargo.toml
+++ b/regex-syntax/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "regex-syntax"
 version = "0.7.5"  #:version
-authors = ["The Rust Project Developers", "Andrew Gallant <jamslam@gmail.com>"]
+authors = ["Andrew Gallant <jamslam@gmail.com>", "Mateus Yoshiaki <ahoyiski@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/regex/tree/master/regex-syntax"
 documentation = "https://docs.rs/regex-syntax"
@@ -33,6 +33,8 @@ unicode-gencat = []
 unicode-perl = []
 unicode-script = []
 unicode-segment = []
+
+look-ahead-and-behind = []
 
 [dependencies]
 arbitrary = { version = "1.3.0", features = ["derive"], optional = true }

--- a/regex-syntax/README.md
+++ b/regex-syntax/README.md
@@ -64,6 +64,11 @@ or all of these data tables. If a regular expression attempts to use Unicode
 data that is not available, then an error will occur when translating the `Ast`
 to the `Hir`.
 
+There are also look-aheads and look-behinds (`(?=a)` and `(?<=a)`), which this
+crate supports, but are not supported by `regex`, so they are disabled by
+default. One can enable them in their own projects by adding the feature
+"look-ahead-and-behind" to the enabled features of `regex-syntax`.
+
 The full set of features one can disable are
 [in the "Crate features" section of the documentation](https://docs.rs/regex-syntax/*/#crate-features).
 

--- a/regex-syntax/src/ast/print.rs
+++ b/regex-syntax/src/ast/print.rs
@@ -206,13 +206,13 @@ impl<W: fmt::Write> Writer<W> {
                 self.fmt_flags(flags)?;
                 self.wtr.write_str(":")
             }
-            #[cfg(feature="look-ahead-and-behind")]
+            #[cfg(feature = "look-ahead-and-behind")]
             LookAhead { negate } => {
                 self.wtr.write_str("(?")?;
                 let end = if negate { "!" } else { "=" };
                 self.wtr.write_str(end)
             }
-            #[cfg(feature="look-ahead-and-behind")]
+            #[cfg(feature = "look-ahead-and-behind")]
             LookBehind { negate } => {
                 self.wtr.write_str("(?<")?;
                 let end = if negate { "!" } else { "=" };

--- a/regex-syntax/src/ast/visitor.rs
+++ b/regex-syntax/src/ast/visitor.rs
@@ -335,7 +335,7 @@ impl<'a> HeapVisitor<'a> {
                 // If this is a union or a binary op, then we might have
                 // additional inductive steps to process.
                 if let Some(x) = self.pop_class(frame) {
-                    if let ClassFrame::BinaryRHS { ref op, .. } = x {
+                    if let ClassFrame::BinaryRHS { op, .. } = x {
                         visitor.visit_class_set_binary_op_in(op)?;
                     }
                     ast = x.child();
@@ -386,8 +386,8 @@ impl<'a> HeapVisitor<'a> {
     /// Build a stack frame for the given class node if one is needed (which
     /// occurs if and only if there are child nodes). Otherwise, return None.
     fn induct_class(&self, ast: &ClassInduct<'a>) -> Option<ClassFrame<'a>> {
-        match *ast {
-            ClassInduct::Item(&ast::ClassSetItem::Bracketed(ref x)) => {
+        match ast {
+            ClassInduct::Item(ast::ClassSetItem::Bracketed(x)) => {
                 match x.kind {
                     ast::ClassSet::Item(ref item) => {
                         Some(ClassFrame::Union { head: item, tail: &[] })
@@ -397,7 +397,7 @@ impl<'a> HeapVisitor<'a> {
                     }
                 }
             }
-            ClassInduct::Item(&ast::ClassSetItem::Union(ref x)) => {
+            ClassInduct::Item(ast::ClassSetItem::Union(x)) => {
                 if x.items.is_empty() {
                     None
                 } else {
@@ -454,15 +454,11 @@ impl<'a> ClassFrame<'a> {
     /// Perform the next inductive step on this frame and return the next
     /// child class node to visit.
     fn child(&self) -> ClassInduct<'a> {
-        match *self {
+        match self {
             ClassFrame::Union { head, .. } => ClassInduct::Item(head),
             ClassFrame::Binary { op, .. } => ClassInduct::BinaryOp(op),
-            ClassFrame::BinaryLHS { ref lhs, .. } => {
-                ClassInduct::from_set(lhs)
-            }
-            ClassFrame::BinaryRHS { ref rhs, .. } => {
-                ClassInduct::from_set(rhs)
-            }
+            ClassFrame::BinaryLHS { lhs, .. } => ClassInduct::from_set(lhs),
+            ClassFrame::BinaryRHS { rhs, .. } => ClassInduct::from_set(rhs),
         }
     }
 }

--- a/regex-syntax/src/debug.rs
+++ b/regex-syntax/src/debug.rs
@@ -51,7 +51,11 @@ impl<'a> core::fmt::Debug for Bytes<'a> {
             match ch {
                 '\0' => write!(f, "\\0")?,
                 // ASCII control characters except \0, \n, \r, \t
-                '\x01'..='\x08' | '\x0b' | '\x0c' | '\x0e'..='\x19' | '\x7f' => {
+                '\x01'..='\x08'
+                | '\x0b'
+                | '\x0c'
+                | '\x0e'..='\x19'
+                | '\x7f' => {
                     write!(f, "\\x{:02x}", u32::from(ch))?;
                 }
                 _ => write!(f, "{}", ch.escape_debug())?,

--- a/regex-syntax/src/error.rs
+++ b/regex-syntax/src/error.rs
@@ -152,7 +152,9 @@ struct Spans<'p> {
 
 impl<'p> Spans<'p> {
     /// Build a sequence of spans from a formatter.
-    fn from_formatter<'e, E: core::fmt::Display>(fmter: &'p Formatter<'e, E>) -> Spans<'p> {
+    fn from_formatter<'e, E: core::fmt::Display>(
+        fmter: &'p Formatter<'e, E>,
+    ) -> Spans<'p> {
         let mut line_count = fmter.pattern.lines().count();
         // If the pattern ends with a `\n` literal, then our line count is
         // off by one, since a span can occur immediately after the last `\n`,
@@ -160,11 +162,8 @@ impl<'p> Spans<'p> {
         if fmter.pattern.ends_with('\n') {
             line_count += 1;
         }
-        let line_number_width = if line_count <= 1 {
-            0
-        } else {
-            line_count.to_string().len()
-        };
+        let line_number_width =
+            if line_count <= 1 { 0 } else { line_count.to_string().len() };
         let mut spans = Spans {
             pattern: fmter.pattern,
             line_number_width,

--- a/regex-syntax/src/error.rs
+++ b/regex-syntax/src/error.rs
@@ -112,14 +112,13 @@ impl<'e, E: core::fmt::Display> core::fmt::Display for Formatter<'e, E> {
                 }
                 writeln!(f, "{}", notes.join("\n"))?;
             }
-            write!(f, "error: {}", self.err)?;
+            write!(f, "error: {}", self.err)
         } else {
             writeln!(f, "regex parse error:")?;
             let notated = Spans::from_formatter(self).notate();
             write!(f, "{}", notated)?;
-            write!(f, "error: {}", self.err)?;
+            write!(f, "error: {}", self.err)
         }
-        Ok(())
     }
 }
 
@@ -153,9 +152,7 @@ struct Spans<'p> {
 
 impl<'p> Spans<'p> {
     /// Build a sequence of spans from a formatter.
-    fn from_formatter<'e, E: core::fmt::Display>(
-        fmter: &'p Formatter<'e, E>,
-    ) -> Spans<'p> {
+    fn from_formatter<'e, E: core::fmt::Display>(fmter: &'p Formatter<'e, E>) -> Spans<'p> {
         let mut line_count = fmter.pattern.lines().count();
         // If the pattern ends with a `\n` literal, then our line count is
         // off by one, since a span can occur immediately after the last `\n`,
@@ -163,17 +160,20 @@ impl<'p> Spans<'p> {
         if fmter.pattern.ends_with('\n') {
             line_count += 1;
         }
-        let line_number_width =
-            if line_count <= 1 { 0 } else { line_count.to_string().len() };
+        let line_number_width = if line_count <= 1 {
+            0
+        } else {
+            line_count.to_string().len()
+        };
         let mut spans = Spans {
-            pattern: &fmter.pattern,
+            pattern: fmter.pattern,
             line_number_width,
             by_line: vec![vec![]; line_count],
             multi_line: vec![],
         };
-        spans.add(fmter.span.clone());
+        spans.add(*fmter.span);
         if let Some(span) = fmter.aux_span {
-            spans.add(span.clone());
+            spans.add(*span);
         }
         spans
     }
@@ -226,16 +226,13 @@ impl<'p> Spans<'p> {
         for _ in 0..self.line_number_padding() {
             notes.push(' ');
         }
-        let mut pos = 0;
         for span in spans {
-            for _ in pos..(span.start.column - 1) {
+            for _ in 0..(span.start.column - 1) {
                 notes.push(' ');
-                pos += 1;
             }
             let note_len = span.end.column.saturating_sub(span.start.column);
             for _ in 0..core::cmp::max(1, note_len) {
                 notes.push('^');
-                pos += 1;
             }
         }
         Some(notes)

--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -455,7 +455,7 @@ pub trait Interval:
             return (None, None);
         }
         if self.is_intersection_empty(other) {
-            return (Some(self.clone()), None);
+            return (Some(*self), None);
         }
         let add_lower = other.lower() > self.lower();
         let add_upper = other.upper() < self.upper();
@@ -486,11 +486,11 @@ pub trait Interval:
         other: &Self,
     ) -> (Option<Self>, Option<Self>) {
         let union = match self.union(other) {
-            None => return (Some(self.clone()), Some(other.clone())),
+            None => return (Some(*self), Some(*other)),
             Some(union) => union,
         };
         let intersection = match self.intersect(other) {
-            None => return (Some(self.clone()), Some(other.clone())),
+            None => return (Some(*self), Some(*other)),
             Some(intersection) => intersection,
         };
         union.difference(&intersection)


### PR DESCRIPTION
This PR adds a feature (`look-ahead-and-behind`) that enables the previously prohibited look-ahead and look-behind expressions (`(?=a)`, `(?<=a)`) from producing an `Ast`. This feature is disabled by default, since `regex` does not support these types of expressions, but it can be useful to others that are importing just the `regex-syntax` crate.

By default, nothing actually changes (besides some additional docs that I've added), and the code is essentially the same, returning the same error when these expressions are used. The error message, however, has been changed, instead of saying that these expressions are unsupported, it mentions that you can enable them with this feature.

The PR also returns an error when a look-ahead expression is followed by something, or when a look-behind is preceded by something. The kinds of these errors are, respectively, `ast::ErrorKind::LookAheadBeforeEnd` and `ast::ErrorKind::LookBehindAfterStart`, both inaccessible with the feature disabled.

These errors are smart in the way that they determine if something is concatenated or not, for example,`(start 1)((((?<=start 2))))` is not valid, but `(start 1)|((((?<=start 2))))` is.

This error reporting is, technically speaking, not necessary, as some regex engines don't really care about the position of look-around expressions, but for my use case, this is important. But if you feel like it doesn't belong, I could just move this to another feature or something like that.

Initially this PR was going to just be a standalone crate, and as with all my crates, I ran clippy over the code, and fixed a bunch of clippy warnings, which are also in this crate. There are also some minor functionality changes in some parts of the functions that I modified, which are used even with this feature disabled, but they are purely syntactic and not semantic.

I know that this PR doesn't really make much sense in the context of the `regex` crate, but it seems incorrect to make just a few changes to a crate, and just publish it to `crates.io`, filling the website with two almost identical crates.