### PR TITLE
upgrade to memchr 2.6 to bring in aarch64 improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ std = [
 # to actually emit the log messages somewhere.
 logging = [
   "aho-corasick?/logging",
+  "memchr?/logging",
   "regex-automata/logging",
 ]
 # The 'use_std' feature is DEPRECATED. It will be removed in regex 2. Until
@@ -167,7 +168,7 @@ optional = true
 
 # For skipping along search text quickly when a leading byte is known.
 [dependencies.memchr]
-version = "2.5.0"
+version = "2.6.0"
 optional = true
 
 # For the actual regex engines.

--- a/fuzz/fuzz_targets/ast_fuzz_match.rs
+++ b/fuzz/fuzz_targets/ast_fuzz_match.rs
@@ -25,11 +25,12 @@ fuzz_target!(|data: FuzzData| -> Corpus {
     let _ = env_logger::try_init();
 
     let pattern = format!("{}", data.ast);
-    let Ok(re) = RegexBuilder::new(&pattern).size_limit(1<<20).build() else {
+    let Ok(re) = RegexBuilder::new(&pattern).size_limit(1 << 20).build()
+    else {
         return Corpus::Reject;
     };
-    re.is_match(&data.haystack);
-    re.find(&data.haystack);
-    re.captures(&data.haystack).map_or(0, |c| c.len());
+    let _ = re.is_match(&data.haystack);
+    let _ = re.find(&data.haystack);
+    let _ = re.captures(&data.haystack).map_or(0, |c| c.len());
     Corpus::Keep
 });

--- a/fuzz/fuzz_targets/ast_fuzz_match_bytes.rs
+++ b/fuzz/fuzz_targets/ast_fuzz_match_bytes.rs
@@ -25,11 +25,12 @@ fuzz_target!(|data: FuzzData| -> Corpus {
     let _ = env_logger::try_init();
 
     let pattern = format!("{}", data.ast);
-    let Ok(re) = RegexBuilder::new(&pattern).size_limit(1<<20).build() else {
+    let Ok(re) = RegexBuilder::new(&pattern).size_limit(1 << 20).build()
+    else {
         return Corpus::Reject;
     };
-    re.is_match(&data.haystack);
-    re.find(&data.haystack);
-    re.captures(&data.haystack).map_or(0, |c| c.len());
+    let _ = re.is_match(&data.haystack);
+    let _ = re.find(&data.haystack);
+    let _ = re.captures(&data.haystack).map_or(0, |c| c.len());
     Corpus::Keep
 });

--- a/regex-automata/Cargo.toml
+++ b/regex-automata/Cargo.toml
@@ -21,7 +21,7 @@ bench = false
 default = ["std", "syntax", "perf", "unicode", "meta", "nfa", "dfa", "hybrid"]
 std = ["regex-syntax?/std", "memchr?/std", "aho-corasick?/std", "alloc"]
 alloc = []
-logging = ["dep:log", "aho-corasick?/logging"]
+logging = ["dep:log", "aho-corasick?/logging", "memchr?/logging"]
 
 syntax = ["dep:regex-syntax", "alloc"]
 
@@ -84,7 +84,7 @@ internal-instrument-pikevm = ["logging", "std"]
 [dependencies]
 aho-corasick = { version = "1.0.0", optional = true, default-features = false }
 log = { version = "0.4.14", optional = true }
-memchr = { version = "2.5.0", optional = true, default-features = false }
+memchr = { version = "2.6.0", optional = true, default-features = false }
 regex-syntax = { path = "../regex-syntax", version = "0.7.4", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This bumps the minimum memchr version to 2.6, which brings in massive improvements to aarch64 for single substring search. We also can now enable the new `alloc` feature in `memchr` when `alloc` is enable for `regex` and `regex-automata`.

We also squash some warnings.

[1]: https://github.com/BurntSushi/memchr/pull/129