### PR TITLE
Add `split_inclusive()` to API

### DIFF
--- a/regex-automata/src/meta/regex.rs
+++ b/regex-automata/src/meta/regex.rs
@@ -3737,9 +3737,9 @@ mod tests {
             ),
         ];
         for (pattern, text, expected_output) in arr {
-            let mut out: Vec<_> = Regex::new(pattern).unwrap()
+            let out: Vec<_> = Regex::new(pattern).unwrap()
                 .split_inclusive(text)
-                .map(|span| &text[span])
+                .map(|sp| &text[sp])
                 .collect();
 
             assert_eq!(out, expected_output, "Regex: {}, Input: {}", pattern, text);


### PR DESCRIPTION
As mentioned in issues: #285, #330, and #681, there is a strong demand for a split function that includes the delimiter (the regex match) inside the output, i.e.:
```rust
let text = "2+2";
let re = Regex::new(r"([^\d]+)").unwrap();

let split: Vec<_> = re
    .split(text)
    .map(|span| &text[span])
    .collect();
assert_eq!(split, ["2", "2"]);


let split_inclusive: Vec<_> = re
    .split_inclusive(text)
    .map(|span| &text[span])
    .collect();
assert_eq!(split_inclusive, ["2", "+", "2"]);
```

This pull request does exactly this. 

The implementation is very similar to `split()`, except that the iterator of `inclusive_split()` will return two elements for each regex match,
 the first element is the **start** of the string up **until** the match, the second element is the **start** of the match to its **end**.

But of course, we can't return two elements at once (unless we want to return two-element tuples and then flatten it), so we will return the first, and the second will be saved in the field `span_to_yield` to be returned on the next call.

---

I implemented the function and added some tests, please let me know what you think about the approach, if everything is good to go I will go ahead and add the documentation and examples.


Note on the tests:
Some of the test cases were copied from the GH issue, they're all tested in Python to make sure that the output of `split_inclusive()` is the same as Python's `re.split()`.
I created a gist that has the same tests but in Python: https://gist.github.com/shner-elmo/7cd7c383fa882ab8cda743ec7a689b24

cheers