### PR TITLE
regex-lite: fix compilation of doctests on 32-bit architectures

### DIFF
--- a/regex-lite/src/string.rs
+++ b/regex-lite/src/string.rs
@@ -2063,7 +2063,6 @@ impl<'h, 'n> core::ops::Index<&'n str> for Captures<'h> {
 /// This example shows how to create and use `CaptureLocations` in a search.
 ///
 /// ```
-/// # if !cfg!(target_pointer_width = "64") { return; } // see #1041
 /// use regex_lite::Regex;
 ///
 /// let re = Regex::new(r"(?<first>\w+)\s+(?<last>\w+)").unwrap();
@@ -2076,7 +2075,10 @@ impl<'h, 'n> core::ops::Index<&'n str> for Captures<'h> {
 ///
 /// // Asking for an invalid capture group always returns None.
 /// assert_eq!(None, locs.get(3));
+/// # // literals are too big for 32-bit usize: #1041
+/// # #[cfg(target_pointer_width = "64")]
 /// assert_eq!(None, locs.get(34973498648));
+/// # #[cfg(target_pointer_width = "64")]
 /// assert_eq!(None, locs.get(9944060567225171988));
 /// ```
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This is a followup for #1041. Returning early on non-64-bit architectures is not enough in this case, since the doctest actually fails to compile due to two numeric literals being too large for `usize` on 32-bit architectures.

With this change, "lib" and "doc" tests for the the regex-lite crate pass on all CPU architectures that I have access to.