### PR TITLE
Inline format-args

### DIFF
--- a/regex-capi/Cargo.toml
+++ b/regex-capi/Cargo.toml
@@ -11,7 +11,7 @@ description = """
 A C API for Rust's regular expression library.
 """
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "rure"

--- a/regex-capi/src/error.rs
+++ b/regex-capi/src/error.rs
@@ -61,7 +61,7 @@ ffi_fn! {
 ffi_fn! {
     fn rure_error_message(err: *mut Error) -> *const c_char {
         let err = unsafe { &mut *err };
-        let cmsg = match CString::new(format!("{}", err)) {
+        let cmsg = match CString::new(format!("{err}")) {
             Ok(msg) => msg,
             Err(err) => {
                 // I guess this can probably happen if the regex itself has a

--- a/regex-capi/src/macros.rs
+++ b/regex-capi/src/macros.rs
@@ -18,10 +18,7 @@ macro_rules! ffi_fn {
                     } else {
                         "UNABLE TO SHOW RESULT OF PANIC.".to_owned()
                     };
-                    let _ = writeln!(
-                        &mut io::stderr(),
-                        "panic unwind caught, aborting: {:?}",
-                        msg);
+                    let _ = writeln!(&mut io::stderr(), "panic unwind caught, aborting: {msg:?}");
                     unsafe { abort() }
                 }
             }

--- a/regex-capi/src/rure.rs
+++ b/regex-capi/src/rure.rs
@@ -82,7 +82,7 @@ ffi_fn! {
         let re = rure_compile(
             pat, len, RURE_DEFAULT_FLAGS, ptr::null(), &mut err);
         if err.is_err() {
-            let _ = writeln!(&mut io::stderr(), "{}", err);
+            let _ = writeln!(&mut io::stderr(), "{err}");
             let _ = writeln!(
                 &mut io::stderr(), "aborting from rure_compile_must");
             unsafe { abort() }
@@ -579,7 +579,7 @@ ffi_fn! {
         let mut err = Error::new(ErrorKind::None);
         let esc = rure_escape(pat, len, &mut err);
         if err.is_err() {
-            let _ = writeln!(&mut io::stderr(), "{}", err);
+            let _ = writeln!(&mut io::stderr(), "{err}");
             let _ = writeln!(
                 &mut io::stderr(), "aborting from rure_escape_must");
             unsafe { abort() }

--- a/regex-lite/src/hir/parse.rs
+++ b/regex-lite/src/hir/parse.rs
@@ -593,8 +593,7 @@ impl<'a> Parser<'a> {
             'u' => 4,
             'U' => 8,
             unk => unreachable!(
-                "invalid start of fixed length hexadecimal number {}",
-                unk
+                "invalid start of fixed length hexadecimal number {unk}"
             ),
         };
         if !self.bump_and_bump_space() {
@@ -720,7 +719,7 @@ impl<'a> Parser<'a> {
             '?' => (0, Some(1)),
             '*' => (0, None),
             '+' => (1, None),
-            unk => unreachable!("unrecognized repetition operator '{}'", unk),
+            unk => unreachable!("unrecognized repetition operator '{unk}'"),
         };
         let mut greedy = true;
         if self.bump() && self.char() == '?' {
@@ -1216,7 +1215,7 @@ impl<'a> Parser<'a> {
             'd' | 'D' => posix_class("digit").unwrap(),
             's' | 'S' => posix_class("space").unwrap(),
             'w' | 'W' => posix_class("word").unwrap(),
-            unk => unreachable!("invalid Perl class \\{}", unk),
+            unk => unreachable!("invalid Perl class \\{unk}"),
         });
         if ch.is_ascii_uppercase() {
             class.negate();

--- a/regex-lite/src/nfa.rs
+++ b/regex-lite/src/nfa.rs
@@ -136,7 +136,7 @@ impl core::fmt::Debug for NFA {
         writeln!(f, "NFA(")?;
         writeln!(f, "pattern: {}", self.pattern)?;
         for (sid, state) in self.states.iter().enumerate() {
-            writeln!(f, "{:07?}: {:?}", sid, state)?;
+            writeln!(f, "{sid:07?}: {state:?}")?;
         }
         writeln!(f, ")")?;
         Ok(())
@@ -206,14 +206,14 @@ impl core::fmt::Debug for State {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match *self {
             State::Char { target, ch } => {
-                write!(f, "{:?} => {:?}", ch, target)
+                write!(f, "{ch:?} => {target:?}")
             }
             State::Ranges { target, ref ranges } => {
                 for (i, &(start, end)) in ranges.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{:?}-{:?} => {:?}", start, end, target)?;
+                    write!(f, "{start:?}-{end:?} => {target:?}")?;
                 }
                 Ok(())
             }
@@ -225,18 +225,18 @@ impl core::fmt::Debug for State {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{:?}", sid)?;
+                    write!(f, "{sid:?}")?;
                 }
                 write!(f, ")")
             }
             State::Goto { target, look: None } => {
-                write!(f, "goto({:?})", target)
+                write!(f, "goto({target:?})")
             }
             State::Goto { target, look: Some(look) } => {
-                write!(f, "{:?} => {:?}", look, target)
+                write!(f, "{look:?} => {target:?}")
             }
             State::Capture { target, slot } => {
-                write!(f, "capture(slot={:?}) => {:?}", slot, target,)
+                write!(f, "capture(slot={slot:?}) => {target:?}")
             }
             State::Fail => write!(f, "FAIL"),
             State::Match => {

--- a/regex-lite/src/string.rs
+++ b/regex-lite/src/string.rs
@@ -1798,7 +1798,7 @@ impl<'h> Captures<'h> {
             .nfa()
             .static_explicit_captures_len()
             .expect("number of capture groups can vary in a match");
-        assert_eq!(N, len, "asked for {} groups, but must ask for {}", N, len);
+        assert_eq!(N, len, "asked for {N} groups, but must ask for {len}");
         let mut matched = self.iter().flatten();
         let whole_match = matched.next().expect("a match").as_str();
         let group_matches = [0; N].map(|_| {
@@ -1965,7 +1965,7 @@ impl<'h> core::fmt::Debug for Captures<'h> {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(f, "{}", self.0)?;
                 if let Some(name) = self.1 {
-                    write!(f, "/{:?}", name)?;
+                    write!(f, "/{name:?}")?;
                 }
                 Ok(())
             }
@@ -2013,7 +2013,7 @@ impl<'h> core::ops::Index<usize> for Captures<'h> {
     fn index(&self, i: usize) -> &str {
         self.get(i)
             .map(|m| m.as_str())
-            .unwrap_or_else(|| panic!("no group at index '{}'", i))
+            .unwrap_or_else(|| panic!("no group at index '{i}'"))
     }
 }
 
@@ -2039,7 +2039,7 @@ impl<'h, 'n> core::ops::Index<&'n str> for Captures<'h> {
     fn index<'a>(&'a self, name: &'n str) -> &'a str {
         self.name(name)
             .map(|m| m.as_str())
-            .unwrap_or_else(|| panic!("no group named '{}'", name))
+            .unwrap_or_else(|| panic!("no group named '{name}'"))
     }
 }
 

--- a/regex-lite/tests/string.rs
+++ b/regex-lite/tests/string.rs
@@ -23,8 +23,7 @@ fn run_test(re: &Regex, test: &RegexTest) -> TestResult {
         Ok(hay) => hay,
         Err(err) => {
             return TestResult::fail(&format!(
-                "haystack is not valid UTF-8: {}",
-                err
+                "haystack is not valid UTF-8: {err}",
             ));
         }
     };
@@ -45,7 +44,7 @@ fn run_test(re: &Regex, test: &RegexTest) -> TestResult {
                 .map(|caps| testify_captures(&caps));
             TestResult::captures(it)
         }
-        name => TestResult::fail(&format!("unrecognized test name: {}", name)),
+        name => TestResult::fail(&format!("unrecognized test name: {name}")),
     }
 }
 

--- a/regex-test/lib.rs
+++ b/regex-test/lib.rs
@@ -153,17 +153,17 @@ impl RegexTests {
     /// The given group name is assigned to all loaded tests.
     pub fn load_slice(&mut self, group_name: &str, data: &[u8]) -> Result<()> {
         let data = std::str::from_utf8(&data).with_context(|| {
-            format!("data in {} is not valid UTF-8", group_name)
+            format!("data in {group_name} is not valid UTF-8")
         })?;
         let mut index = 1;
         let mut tests: RegexTests =
             toml::from_str(&data).with_context(|| {
-                format!("error decoding TOML for '{}'", group_name)
+                format!("error decoding TOML for '{group_name}'")
             })?;
         for t in &mut tests.tests {
             t.group = group_name.to_string();
             if t.name.is_empty() {
-                t.name = format!("{}", index);
+                t.name = format!("{index}");
                 index += 1;
             }
             t.full_name = format!("{}/{}", t.group, t.name);
@@ -1103,7 +1103,7 @@ impl RegexTestFailureKind {
         let mut buf = String::new();
         match *self {
             RegexTestFailureKind::UserFailure { ref why } => {
-                write!(buf, "failed by implementor because: {}", why)?;
+                write!(buf, "failed by implementor because: {why}")?;
             }
             RegexTestFailureKind::IsMatch => {
                 if test.is_match() {
@@ -1142,13 +1142,13 @@ impl RegexTestFailureKind {
                 write!(buf, "expected regex to NOT compile, but it did")?;
             }
             RegexTestFailureKind::CompileError { ref err } => {
-                write!(buf, "expected regex to compile, failed: {}", err)?;
+                write!(buf, "expected regex to compile, failed: {err}")?;
             }
             RegexTestFailureKind::UnexpectedPanicCompile(ref msg) => {
-                write!(buf, "got unexpected panic while compiling:\n{}", msg)?;
+                write!(buf, "got unexpected panic while compiling:\n{msg}")?;
             }
             RegexTestFailureKind::UnexpectedPanicSearch(ref msg) => {
-                write!(buf, "got unexpected panic while searching:\n{}", msg)?;
+                write!(buf, "got unexpected panic while searching:\n{msg}")?;
             }
         }
         Ok(buf)

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,8 +71,7 @@ impl core::fmt::Display for Error {
             Error::Syntax(ref err) => err.fmt(f),
             Error::CompiledTooBig(limit) => write!(
                 f,
-                "Compiled regex exceeds size limit of {} bytes.",
-                limit
+                "Compiled regex exceeds size limit of {limit} bytes.",
             ),
         }
     }
@@ -88,9 +87,9 @@ impl core::fmt::Debug for Error {
             Error::Syntax(ref err) => {
                 let hr: String = core::iter::repeat('~').take(79).collect();
                 writeln!(f, "Syntax(")?;
-                writeln!(f, "{}", hr)?;
-                writeln!(f, "{}", err)?;
-                writeln!(f, "{}", hr)?;
+                writeln!(f, "{hr}")?;
+                writeln!(f, "{err}")?;
+                writeln!(f, "{hr}")?;
                 write!(f, ")")?;
                 Ok(())
             }

--- a/src/regex/bytes.rs
+++ b/src/regex/bytes.rs
@@ -1770,7 +1770,7 @@ impl<'h> Captures<'h> {
             .expect("number of capture groups can vary in a match")
             .checked_sub(1)
             .expect("number of groups is always greater than zero");
-        assert_eq!(N, len, "asked for {} groups, but must ask for {}", N, len);
+        assert_eq!(N, len, "asked for {N} groups, but must ask for {len}");
         // The regex-automata variant of extract is a bit more permissive.
         // It doesn't require the number of matching capturing groups to be
         // static, and you can even request fewer groups than what's there. So
@@ -1925,7 +1925,7 @@ impl<'h> core::fmt::Debug for Captures<'h> {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(f, "{}", self.0)?;
                 if let Some(name) = self.1 {
-                    write!(f, "/{:?}", name)?;
+                    write!(f, "/{name:?}")?;
                 }
                 Ok(())
             }
@@ -1975,7 +1975,7 @@ impl<'h> core::ops::Index<usize> for Captures<'h> {
     fn index<'a>(&'a self, i: usize) -> &'a [u8] {
         self.get(i)
             .map(|m| m.as_bytes())
-            .unwrap_or_else(|| panic!("no group at index '{}'", i))
+            .unwrap_or_else(|| panic!("no group at index '{i}'"))
     }
 }
 
@@ -2001,7 +2001,7 @@ impl<'h, 'n> core::ops::Index<&'n str> for Captures<'h> {
     fn index<'a>(&'a self, name: &'n str) -> &'a [u8] {
         self.name(name)
             .map(|m| m.as_bytes())
-            .unwrap_or_else(|| panic!("no group named '{}'", name))
+            .unwrap_or_else(|| panic!("no group named '{name}'"))
     }
 }
 

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -1775,7 +1775,7 @@ impl<'h> Captures<'h> {
             .expect("number of capture groups can vary in a match")
             .checked_sub(1)
             .expect("number of groups is always greater than zero");
-        assert_eq!(N, len, "asked for {} groups, but must ask for {}", N, len);
+        assert_eq!(N, len, "asked for {N} groups, but must ask for {len}");
         // The regex-automata variant of extract is a bit more permissive.
         // It doesn't require the number of matching capturing groups to be
         // static, and you can even request fewer groups than what's there. So
@@ -1930,7 +1930,7 @@ impl<'h> core::fmt::Debug for Captures<'h> {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(f, "{}", self.0)?;
                 if let Some(name) = self.1 {
-                    write!(f, "/{:?}", name)?;
+                    write!(f, "/{name:?}")?;
                 }
                 Ok(())
             }
@@ -1978,7 +1978,7 @@ impl<'h> core::ops::Index<usize> for Captures<'h> {
     fn index<'a>(&'a self, i: usize) -> &'a str {
         self.get(i)
             .map(|m| m.as_str())
-            .unwrap_or_else(|| panic!("no group at index '{}'", i))
+            .unwrap_or_else(|| panic!("no group at index '{i}'"))
     }
 }
 
@@ -2004,7 +2004,7 @@ impl<'h, 'n> core::ops::Index<&'n str> for Captures<'h> {
     fn index<'a>(&'a self, name: &'n str) -> &'a str {
         self.name(name)
             .map(|m| m.as_str())
-            .unwrap_or_else(|| panic!("no group named '{}'", name))
+            .unwrap_or_else(|| panic!("no group named '{name}'"))
     }
 }
 

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -10,7 +10,7 @@ macro_rules! regex {
 fn unclosed_group_error() {
     let err = Regex::new(r"(").unwrap_err();
     let msg = err.to_string();
-    assert!(msg.contains("unclosed group"), "error message: {:?}", msg);
+    assert!(msg.contains("unclosed group"), "error message: {msg:?}");
 }
 
 #[test]

--- a/tests/suite_bytes.rs
+++ b/tests/suite_bytes.rs
@@ -36,7 +36,7 @@ fn run_test(re: &Regex, test: &RegexTest) -> TestResult {
                 .map(|caps| testify_captures(&caps));
             TestResult::captures(it)
         }
-        name => TestResult::fail(&format!("unrecognized test name: {}", name)),
+        name => TestResult::fail(&format!("unrecognized test name: {name}")),
     }
 }
 

--- a/tests/suite_bytes_set.rs
+++ b/tests/suite_bytes_set.rs
@@ -20,7 +20,7 @@ fn run_test(re: &RegexSet, test: &RegexTest) -> TestResult {
     match test.additional_name() {
         "is_match" => TestResult::matched(re.is_match(test.haystack())),
         "which" => TestResult::which(re.matches(test.haystack()).iter()),
-        name => TestResult::fail(&format!("unrecognized test name: {}", name)),
+        name => TestResult::fail(&format!("unrecognized test name: {name}")),
     }
 }
 

--- a/tests/suite_string.rs
+++ b/tests/suite_string.rs
@@ -23,8 +23,7 @@ fn run_test(re: &Regex, test: &RegexTest) -> TestResult {
         Ok(hay) => hay,
         Err(err) => {
             return TestResult::fail(&format!(
-                "haystack is not valid UTF-8: {}",
-                err
+                "haystack is not valid UTF-8: {err}",
             ));
         }
     };
@@ -45,7 +44,7 @@ fn run_test(re: &Regex, test: &RegexTest) -> TestResult {
                 .map(|caps| testify_captures(&caps));
             TestResult::captures(it)
         }
-        name => TestResult::fail(&format!("unrecognized test name: {}", name)),
+        name => TestResult::fail(&format!("unrecognized test name: {name}")),
     }
 }
 

--- a/tests/suite_string_set.rs
+++ b/tests/suite_string_set.rs
@@ -21,15 +21,14 @@ fn run_test(re: &RegexSet, test: &RegexTest) -> TestResult {
         Ok(hay) => hay,
         Err(err) => {
             return TestResult::fail(&format!(
-                "haystack is not valid UTF-8: {}",
-                err
+                "haystack is not valid UTF-8: {err}",
             ));
         }
     };
     match test.additional_name() {
         "is_match" => TestResult::matched(re.is_match(hay)),
         "which" => TestResult::which(re.matches(hay).iter()),
-        name => TestResult::fail(&format!("unrecognized test name: {}", name)),
+        name => TestResult::fail(&format!("unrecognized test name: {name}")),
     }
 }
 


### PR DESCRIPTION
This makes the code a bit easier to read and smaller.

Some of it was done with this command, and later fixed by hand:

```
 cargo clippy --workspace --allow-dirty --fix --benches --tests --bins -- -A clippy::all -W clippy::uninlined_format_args
 ```