### PR TITLE
doc: Fix typos in rustdoc

### DIFF
--- a/regex-lite/src/string.rs
+++ b/regex-lite/src/string.rs
@@ -948,7 +948,7 @@ impl Regex {
     /// Returns the end byte offset of the first match in the haystack given.
     ///
     /// This method may have the same performance characteristics as
-    /// `is_match`. Behaviorlly, it doesn't just report whether it match
+    /// `is_match`. Behaviorally, it doesn't just report whether it match
     /// occurs, but also the end offset for a match. In particular, the offset
     /// returned *may be shorter* than the proper end of the leftmost-first
     /// match that you would find via [`Regex::find`].

--- a/src/regex/bytes.rs
+++ b/src/regex/bytes.rs
@@ -965,7 +965,7 @@ impl Regex {
     /// Returns the end byte offset of the first match in the haystack given.
     ///
     /// This method may have the same performance characteristics as
-    /// `is_match`. Behaviorlly, it doesn't just report whether it match
+    /// `is_match`. Behaviorally, it doesn't just report whether it match
     /// occurs, but also the end offset for a match. In particular, the offset
     /// returned *may be shorter* than the proper end of the leftmost-first
     /// match that you would find via [`Regex::find`].

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -952,7 +952,7 @@ impl Regex {
     /// Returns the end byte offset of the first match in the haystack given.
     ///
     /// This method may have the same performance characteristics as
-    /// `is_match`. Behaviorlly, it doesn't just report whether it match
+    /// `is_match`. Behaviorally, it doesn't just report whether it match
     /// occurs, but also the end offset for a match. In particular, the offset
     /// returned *may be shorter* than the proper end of the leftmost-first
     /// match that you would find via [`Regex::find`].


### PR DESCRIPTION
This PR corrects three instances of the same misspelling.