### PR TITLE
chore: attempt to re-enable mipsel in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           target: powerpc64-unknown-linux-gnu
         - build: stable-mipsel
           os: ubuntu-latest
-          rust: stable
+          rust: 1.72.0
           target: mipsel-unknown-linux-gnu
         - build: stable-s390x
           os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           target: powerpc64-unknown-linux-gnu
         - build: stable-mipsel
           os: ubuntu-latest
-          rust: 1.72.0
+          rust: 1.71.0
           target: mipsel-unknown-linux-gnu
         - build: stable-s390x
           os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
           os: ubuntu-latest
           rust: stable
           target: powerpc64-unknown-linux-gnu
+        - build: stable-mipsel
+          os: ubuntu-latest
+          rust: stable
+          target: mipsel-unknown-linux-gnu
         - build: stable-s390x
           os: ubuntu-latest
           rust: stable


### PR DESCRIPTION
This set of changes attempts to address feedback in #1113 that mipsel targets couldn't be supported since they aren't working in CI. I'm also encountering the issue called out there. While I can't claim to know how to fix the original issue - I know a thing about cross compiling so here we go.

Raising this as a draft while I struggle with the CI runners.