### PR TITLE
docs: fix inconsistent usage of a/an in `rure.h`

### DIFF
--- a/regex-capi/include/rure.h
+++ b/regex-capi/include/rure.h
@@ -12,7 +12,7 @@ extern "C" {
 /*
  * rure is the type of a compiled regular expression.
  *
- * An rure can be safely used from multiple threads simultaneously.
+ * A rure can be safely used from multiple threads simultaneously.
  */
 typedef struct rure rure;
 


### PR DESCRIPTION
A small fix for a typo in a documentation comment in the `rure.h` header file.