### PR TITLE
cargo: set 'default-features = false' for memchr and aho-corasick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+1.10.3 (TBD)
+============
+This is a new patch release that fixes the feature configuration of optional
+dependencies.
+
+Bug fixes:
+
+* [BUG #1147](https://github.com/rust-lang/regex/issues/1147):
+Set `default-features=false` for the `memchr` and `aho-corasick` dependencies.
+
+
 1.10.2 (2023-10-16)
 ===================
 This is a new patch release that fixes a search regression where incorrect

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,11 +165,13 @@ pattern = []
 [dependencies.aho-corasick]
 version = "1.0.0"
 optional = true
+default-features = false
 
 # For skipping along search text quickly when a leading byte is known.
 [dependencies.memchr]
 version = "2.6.0"
 optional = true
+default-features = false
 
 # For the actual regex engines.
 [dependencies.regex-automata]


### PR DESCRIPTION
I'm not sure how this one slipped by. Without this, I'd suppose that
no-std support doesn't actually work? Or at least, one would have to
disable the use of both memchr and aho-corasick entirely, since they
depend on std by default. Not quite sure how to test this.

Fixes #1147
