### PR TITLE
cargo: Ensure 'perf' doesn't enable 'std' implicitly

### DIFF
--- a/regex-automata/Cargo.toml
+++ b/regex-automata/Cargo.toml
@@ -44,7 +44,7 @@ perf = ["perf-inline", "perf-literal"]
 perf-inline = []
 perf-literal = ["perf-literal-substring", "perf-literal-multisubstring"]
 perf-literal-substring = ["aho-corasick?/perf-literal", "dep:memchr"]
-perf-literal-multisubstring = ["std", "dep:aho-corasick"]
+perf-literal-multisubstring = ["dep:aho-corasick"]
 
 # Enables all Unicode features. This expands if new Unicode features are added.
 unicode = [

--- a/regex-automata/src/lib.rs
+++ b/regex-automata/src/lib.rs
@@ -451,6 +451,10 @@ useful in trying to understand what the meta regex engine is doing.
 
 ### Performance features
 
+**Note**:
+  To get performance benefits offered by the SIMD, `std` must be enabled.
+  None of the `perf-*` features will enable `std` implicitly.
+
 * **perf** - Enables all of the below features.
 * **perf-inline** - When enabled, `inline(always)` is used in (many) strategic
 locations to help performance at the expense of longer compile times and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1183,6 +1183,10 @@ default are noted.
 
 ### Performance features
 
+**Note**:
+  To get performance benefits offered by the SIMD, `std` must be enabled.
+  None of the `perf-*` features will enable `std` implicitly.
+
 * **perf** -
   Enables all performance related features except for `perf-dfa-full`. This
   feature is enabled by default is intended to cover all reasonable features


### PR DESCRIPTION
Enabling `perf-literal` in the `regex` implicitly enables `std` (through `perf-literal-multisubstring` in the `regex-automata`). Effectively, it is impossible to use enable `perf` for no-std targets.

Quoting @BurntSushi:
> I think one could make the argument that features like perf-literal-multisubstring are generally orthogonal to whether a dependency on std should be introduced. Indeed, that feature does enable optimizations other than SIMD. So it seems perfectly cromulent to me that one might want to enable it without dependency on std.

> So I think here is what I propose:
>  - Remove the std feature from perf-literal-multisubstring.
>  - Add a new section to the crate features docs prominently calling out that some of the SIMD optimizations require a dependency on std. And that most features, including perf-* features, will not also implicitly add a dependency on std. Instead, it is expected that users configuring the features for the crate will do that.

Fixes https://github.com/rust-lang/regex/discussions/1147