### PR TITLE
Clarify CRLF mode effect

### DIFF
--- a/regex-lite/src/lib.rs
+++ b/regex-lite/src/lib.rs
@@ -569,7 +569,7 @@ assert_eq!((m.start(), m.end()), (5, 5));
 ```
 
 When both CRLF mode and multi-line mode are enabled, then `^` and `$` will
-match either `\r` and `\n`, but never in the middle of a `\r\n`:
+match either `\r` or `\n`, but never in the middle of a `\r\n`:
 
 ```
 use regex_lite::Regex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -833,7 +833,7 @@ assert_eq!((m.start(), m.end()), (5, 5));
 ```
 
 When both CRLF mode and multi-line mode are enabled, then `^` and `$` will
-match either `\r` and `\n`, but never in the middle of a `\r\n`:
+match either `\r` or `\n`, but never in the middle of a `\r\n`:
 
 ```
 use regex::Regex;


### PR DESCRIPTION
In multi-line CRLF mode (`?Rm`), the start-of-line and end-of-line assertions match either `\r` ***or*** `\n`; the current documentation says "and" instead. The use of "and" implies that the full two-byte `\r\n` sequence is required, but that's not the case; a lone `\n` still satisfies the assertions, as does a lone `\r`. "or" makes this clear, and was likely intended; "either $x and $y" doesn't make grammatical sense. You could argue for using "and/or" to emphasize that the assertions do match `\r\n` newlines, but I think doing so is probably unnecessary and what the "and" could be trying to communicate is much better said by the immediately following clause anyway.

Tested:

```text
[src/main.rs:5:5] Regex::new(r"(?Rm)^$")?.find_iter("\r\r\n\n").count() = 4
```