### PR TITLE
Implement Display trait for string::Match

### DIFF
--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -1549,6 +1549,12 @@ impl<'h> Match<'h> {
     }
 }
 
+impl<'h> std::fmt::Display for Match<'h> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 impl<'h> core::fmt::Debug for Match<'h> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("Match")


### PR DESCRIPTION
I regularly have to convert matches of a named capture group into a string, which with the current master branch is achieved by `capture.as_str().to_string()`. This PR implements the `Display` trait to simplify the given snippet into `capture.to_string()`.