### PR TITLE
PR: add codes key/legend for debug output in regex-automata

### DIFF
--- a/regex-automata/src/dfa/dense.rs
+++ b/regex-automata/src/dfa/dense.rs
@@ -3092,9 +3092,9 @@ impl<T: AsRef<[u32]>> fmt::Debug for DFA<T> {
             };
             write!(f, "{:06?}: ", id)?;
             state.fmt(f)?;
-            write!(f, "\n")?;
+            writeln!(f)?;
         }
-        writeln!(f, "")?;
+        writeln!(f)?;
         for (i, (start_id, anchored, sty)) in self.starts().enumerate() {
             let id = if f.alternate() {
                 start_id.as_usize()
@@ -3113,7 +3113,7 @@ impl<T: AsRef<[u32]>> fmt::Debug for DFA<T> {
             writeln!(f, "  {:?} => {:06?}", sty, id)?;
         }
         if self.pattern_len() > 1 {
-            writeln!(f, "")?;
+            writeln!(f)?;
             for i in 0..self.ms.len() {
                 let id = self.ms.match_state_id(self, i);
                 let id = if f.alternate() {
@@ -3129,7 +3129,7 @@ impl<T: AsRef<[u32]>> fmt::Debug for DFA<T> {
                     }
                     write!(f, "{:?}", pid)?;
                 }
-                writeln!(f, "")?;
+                writeln!(f)?;
             }
         }
         writeln!(f, "state length: {:?}", self.state_len())?;

--- a/regex-automata/src/dfa/dense.rs
+++ b/regex-automata/src/dfa/dense.rs
@@ -3077,6 +3077,11 @@ impl<T: AsRef<[u32]>> DFA<T> {
 
 impl<T: AsRef<[u32]>> fmt::Debug for DFA<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "\nCodes:\tD - Dead State, Q - Quit State, > - Start State,\
+            \n\t\tA - Accel State, * - Match State\n"
+        )?;
         writeln!(f, "dense::DFA(")?;
         for state in self.states() {
             fmt_state_indicator(f, self, state.id())?;

--- a/regex-automata/src/dfa/onepass.rs
+++ b/regex-automata/src/dfa/onepass.rs
@@ -2395,6 +2395,7 @@ impl core::fmt::Debug for DFA {
             Ok(())
         }
 
+        writeln!(f, "\nCodes:\tD - Dead State, * - Match State\n")?;
         writeln!(f, "onepass::DFA(")?;
         for index in 0..self.state_len() {
             let sid = StateID::must(index);

--- a/regex-automata/src/dfa/onepass.rs
+++ b/regex-automata/src/dfa/onepass.rs
@@ -2413,9 +2413,9 @@ impl core::fmt::Debug for DFA {
             }
             write!(f, ": ")?;
             debug_state_transitions(f, self, sid)?;
-            write!(f, "\n")?;
+            writeln!(f)?;
         }
-        writeln!(f, "")?;
+        writeln!(f)?;
         for (i, &sid) in self.starts.iter().enumerate() {
             if i == 0 {
                 writeln!(f, "START(ALL): {:?}", sid.as_usize())?;

--- a/regex-automata/src/dfa/sparse.rs
+++ b/regex-automata/src/dfa/sparse.rs
@@ -1073,6 +1073,11 @@ impl<'a> DFA<&'a [u8]> {
 
 impl<T: AsRef<[u8]>> fmt::Debug for DFA<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "\nCodes:\tD - Dead State, Q - Quit State, > - Start State,\
+            \n\t\tA - Accel State, * - Match State\n"
+        )?;
         writeln!(f, "sparse::DFA(")?;
         for state in self.tt.states() {
             fmt_state_indicator(f, self, state.id())?;

--- a/regex-automata/src/dfa/sparse.rs
+++ b/regex-automata/src/dfa/sparse.rs
@@ -1083,7 +1083,7 @@ impl<T: AsRef<[u8]>> fmt::Debug for DFA<T> {
             fmt_state_indicator(f, self, state.id())?;
             writeln!(f, "{:06?}: {:?}", state.id().as_usize(), state)?;
         }
-        writeln!(f, "")?;
+        writeln!(f)?;
         for (i, (start_id, anchored, sty)) in self.st.iter().enumerate() {
             if i % self.st.stride == 0 {
                 match anchored {

--- a/regex-automata/src/nfa/thompson/nfa.rs
+++ b/regex-automata/src/nfa/thompson/nfa.rs
@@ -1458,6 +1458,7 @@ impl Inner {
 
 impl fmt::Debug for Inner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "\nCodes:\t^ - Start Anchored, > - Start Unanchored\n")?;
         writeln!(f, "thompson::NFA(")?;
         for (sid, state) in self.states.iter().with_state_ids() {
             let status = if sid == self.start_anchored {

--- a/regex-automata/src/nfa/thompson/nfa.rs
+++ b/regex-automata/src/nfa/thompson/nfa.rs
@@ -1472,13 +1472,13 @@ impl fmt::Debug for Inner {
         }
         let pattern_len = self.start_pattern.len();
         if pattern_len > 1 {
-            writeln!(f, "")?;
+            writeln!(f)?;
             for pid in 0..pattern_len {
                 let sid = self.start_pattern[pid];
                 writeln!(f, "START({:06?}): {:?}", pid, sid.as_usize())?;
             }
         }
-        writeln!(f, "")?;
+        writeln!(f)?;
         writeln!(
             f,
             "transition equivalence classes: {:?}",


### PR DESCRIPTION
While I was looking at debug outputs of DFAs I found myself wondering what some of the symbols meant. `D` & `Q` were fairly intuitive, but it took me some additional digging to figure out what some of the other symbols meant. I took some inspiration from networking command output and added it to the debug output for the 3 DFA types (onepass, dense, & sparse) as well as the Thompson NFA.

Output of a network command: 
![image](https://github.com/rust-lang/regex/assets/29098151/5c13249b-e6e9-4cec-9f50-668afe444dbe)

My proposed change:
![image](https://github.com/rust-lang/regex/assets/29098151/52ac06c3-6b62-4fbd-8719-5dd752567e83)

You can see the `Codes` key/legend added at the top of the debug output.

It's a rather small PR, but I felt that the extra detail may help someone looking at the debug output in the future.
