### PR TITLE
syntax/utf8: avoid a spurious vector reallocation

### DIFF
--- a/regex-syntax/src/utf8.rs
+++ b/regex-syntax/src/utf8.rs
@@ -302,9 +302,9 @@ impl Utf8Sequences {
     /// Create a new iterator over UTF-8 byte ranges for the scalar value range
     /// given.
     pub fn new(start: char, end: char) -> Self {
-        let mut it = Utf8Sequences { range_stack: vec![] };
-        it.push(u32::from(start), u32::from(end));
-        it
+        let range =
+            ScalarRange { start: u32::from(start), end: u32::from(end) };
+        Utf8Sequences { range_stack: vec![range] }
     }
 
     /// reset resets the scalar value range.


### PR DESCRIPTION
This reworks `Utf8Sequences` logic in order to avoid allocating a 0-sized vector and immediately reallocating it for the initial element. Directly create the populated vector instead.