### PR TITLE
automata: remove some unsafe code

### DIFF
--- a/regex-automata/Cargo.toml
+++ b/regex-automata/Cargo.toml
@@ -87,6 +87,7 @@ aho-corasick = { version = "1.0.0", optional = true, default-features = false }
 log = { version = "0.4.14", optional = true }
 memchr = { version = "2.6.0", optional = true, default-features = false }
 regex-syntax = { path = "../regex-syntax", version = "0.8.2", optional = true, default-features = false }
+zerocopy = { version = "0.7.32", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 anyhow = "1.0.69"

--- a/regex-automata/src/util/primitives.rs
+++ b/regex-automata/src/util/primitives.rs
@@ -34,6 +34,8 @@ use core::num::NonZeroUsize;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
+
 use crate::util::int::{Usize, U16, U32, U64};
 
 /// A `usize` that can never be `usize::MAX`.
@@ -138,7 +140,18 @@ impl core::fmt::Debug for NonMaxUsize {
 /// an invalid value can be done in entirely safe code. This may in turn result
 /// in panics or silent logical errors.
 #[derive(
-    Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord,
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    Hash,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    FromZeroes,
+    FromBytes,
+    AsBytes,
 )]
 #[repr(transparent)]
 pub struct SmallIndex(u32);
@@ -746,7 +759,19 @@ pub struct PatternID(SmallIndex);
 ///
 /// See the [`SmallIndex`] type for more information about what it means for
 /// a state ID to be a "small index."
-#[derive(Clone, Copy, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(
+    Clone,
+    Copy,
+    Default,
+    Eq,
+    Hash,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    FromZeroes,
+    FromBytes,
+    AsBytes,
+)]
 #[repr(transparent)]
 pub struct StateID(SmallIndex);
 

--- a/regex-automata/src/util/wire.rs
+++ b/regex-automata/src/util/wire.rs
@@ -45,6 +45,7 @@ use core::{cmp, mem::size_of};
 
 #[cfg(feature = "alloc")]
 use alloc::{vec, vec::Vec};
+use zerocopy::{AsBytes, FromBytes};
 
 use crate::util::{
     int::Pointer,
@@ -268,32 +269,16 @@ impl core::fmt::Display for DeserializeError {
 /// Safely converts a `&[u32]` to `&[StateID]` with zero cost.
 #[cfg_attr(feature = "perf-inline", inline(always))]
 pub(crate) fn u32s_to_state_ids(slice: &[u32]) -> &[StateID] {
-    // SAFETY: This is safe because StateID is defined to have the same memory
-    // representation as a u32 (it is repr(transparent)). While not every u32
-    // is a "valid" StateID, callers are not permitted to rely on the validity
-    // of StateIDs for memory safety. It can only lead to logical errors. (This
-    // is why StateID::new_unchecked is safe.)
-    unsafe {
-        core::slice::from_raw_parts(
-            slice.as_ptr().cast::<StateID>(),
-            slice.len(),
-        )
-    }
+    // PANICS: This is guaranteed to succeed since `u32` and `StateID` have the
+    // same size and alignment.
+    StateID::slice_from(slice.as_bytes()).unwrap()
 }
 
 /// Safely converts a `&mut [u32]` to `&mut [StateID]` with zero cost.
 pub(crate) fn u32s_to_state_ids_mut(slice: &mut [u32]) -> &mut [StateID] {
-    // SAFETY: This is safe because StateID is defined to have the same memory
-    // representation as a u32 (it is repr(transparent)). While not every u32
-    // is a "valid" StateID, callers are not permitted to rely on the validity
-    // of StateIDs for memory safety. It can only lead to logical errors. (This
-    // is why StateID::new_unchecked is safe.)
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            slice.as_mut_ptr().cast::<StateID>(),
-            slice.len(),
-        )
-    }
+    // PANICS: This is guaranteed to succeed since `u32` and `StateID` have the
+    // same size and alignment.
+    StateID::mut_slice_from(slice.as_bytes_mut()).unwrap()
 }
 
 /// Safely converts a `&[u32]` to `&[PatternID]` with zero cost.


### PR DESCRIPTION
Note that the changes in `wire.rs` require zerocopy's "derive" feature, but the changes in `accel.rs` do not. If you'd prefer not to take a dependency on a proc macro derive, we can still salvage some of this PR.