### PR TITLE
More efficient interval algorithms

### DIFF
--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -331,7 +331,7 @@ impl<I: Interval> IntervalSet<I> {
         // negation, so it's skipped, and its upper bound is used as the first
         // leftward margin.
         let (margin, skip_first) = match first_range.lower() == I::Bound::MIN {
-            false => (I::Bound::MAX, false),
+            false => (I::Bound::MIN, false),
             true => match first_range.upper().try_increment() {
                 Some(bound) => (bound, true),
                 // The current range covers everything, so its negation is the empty set

--- a/regex-syntax/src/hir/mod.rs
+++ b/regex-syntax/src/hir/mod.rs
@@ -17,7 +17,7 @@ equivalent regex pattern string, it is unlikely to look like the original due
 to its simplified structure.
 */
 
-use core::{char, cmp};
+use core::{char, cmp, slice};
 
 use alloc::{
     boxed::Box,
@@ -29,7 +29,7 @@ use alloc::{
 
 use crate::{
     ast::Span,
-    hir::interval::{Interval, IntervalSet, IntervalSetIter},
+    hir::interval::{Interval, IntervalSet},
     unicode,
 };
 
@@ -1086,7 +1086,7 @@ impl ClassUnicode {
     ///
     /// The iterator yields ranges in ascending order.
     pub fn iter(&self) -> ClassUnicodeIter<'_> {
-        ClassUnicodeIter(self.set.iter())
+        ClassUnicodeIter(self.set.intervals().iter())
     }
 
     /// Return the underlying ranges as a slice.
@@ -1227,13 +1227,17 @@ impl ClassUnicode {
 ///
 /// The lifetime `'a` refers to the lifetime of the underlying class.
 #[derive(Debug)]
-pub struct ClassUnicodeIter<'a>(IntervalSetIter<'a, ClassUnicodeRange>);
+pub struct ClassUnicodeIter<'a>(slice::Iter<'a, ClassUnicodeRange>);
 
 impl<'a> Iterator for ClassUnicodeIter<'a> {
     type Item = &'a ClassUnicodeRange;
 
     fn next(&mut self) -> Option<&'a ClassUnicodeRange> {
         self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 
@@ -1385,7 +1389,7 @@ impl ClassBytes {
     ///
     /// The iterator yields ranges in ascending order.
     pub fn iter(&self) -> ClassBytesIter<'_> {
-        ClassBytesIter(self.set.iter())
+        ClassBytesIter(self.set.intervals().iter())
     }
 
     /// Return the underlying ranges as a slice.
@@ -1505,13 +1509,17 @@ impl ClassBytes {
 ///
 /// The lifetime `'a` refers to the lifetime of the underlying class.
 #[derive(Debug)]
-pub struct ClassBytesIter<'a>(IntervalSetIter<'a, ClassBytesRange>);
+pub struct ClassBytesIter<'a>(slice::Iter<'a, ClassBytesRange>);
 
 impl<'a> Iterator for ClassBytesIter<'a> {
     type Item = &'a ClassBytesRange;
 
     fn next(&mut self) -> Option<&'a ClassBytesRange> {
         self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 


### PR DESCRIPTION
This PR implements linear time and constant space algorithms for a few of the interval operations:

- `canonicalize`: track the current "merge target", and merge each interval into the target if they overlap. The merge target is always shifted left as appropriate, so that we can simply truncate the list afterwards. 
- `negate`: replace each interval with the negated interval to its left, then finally add the trailing interval on the right. Take care to avoid the leftmost and rightmost intervals if they're empty.
- `union`: merge the two lists of ranges with an iterator that outputs them all in sorted order. Merge them as they come, if they're adjacent, and construct a new vec out of them. The rewritten version operates in linear time but might cause more allocation pressure (since it always builds a new vec), but the old version was unconditionally concatenating the two vectors before canonicalizing, so it seems like a wash. My understanding from [this section on merge sorts](https://en.wikipedia.org/wiki/Merge_sort#Analysis) is that merging a pair of sorted lists is either difficult or impossible in O(1) space, so I didn't worry about this too much.