### PR TITLE
[docs] Fix words duplication in docs `extract`

### DIFF
--- a/regex-lite/src/string.rs
+++ b/regex-lite/src/string.rs
@@ -1717,7 +1717,7 @@ impl<'h> Captures<'h> {
     ///
     /// This returns a tuple where the first element corresponds to the full
     /// substring of the haystack that matched the regex. The second element is
-    /// an array of substrings, with each corresponding to the to the substring
+    /// an array of substrings, with each corresponding to the substring
     /// that matched for a particular capture group.
     ///
     /// # Panics

--- a/regex-lite/src/string.rs
+++ b/regex-lite/src/string.rs
@@ -1717,8 +1717,8 @@ impl<'h> Captures<'h> {
     ///
     /// This returns a tuple where the first element corresponds to the full
     /// substring of the haystack that matched the regex. The second element is
-    /// an array of substrings, with each corresponding to the substring
-    /// that matched for a particular capture group.
+    /// an array of substrings, with each corresponding to the substring that
+    /// matched for a particular capture group.
     ///
     /// # Panics
     ///

--- a/src/regex/bytes.rs
+++ b/src/regex/bytes.rs
@@ -1711,7 +1711,7 @@ impl<'h> Captures<'h> {
     ///
     /// This returns a tuple where the first element corresponds to the full
     /// substring of the haystack that matched the regex. The second element is
-    /// an array of substrings, with each corresponding to the to the substring
+    /// an array of substrings, with each corresponding to the substring
     /// that matched for a particular capture group.
     ///
     /// # Panics

--- a/src/regex/bytes.rs
+++ b/src/regex/bytes.rs
@@ -1711,8 +1711,8 @@ impl<'h> Captures<'h> {
     ///
     /// This returns a tuple where the first element corresponds to the full
     /// substring of the haystack that matched the regex. The second element is
-    /// an array of substrings, with each corresponding to the substring
-    /// that matched for a particular capture group.
+    /// an array of substrings, with each corresponding to the substring that
+    /// matched for a particular capture group.
     ///
     /// # Panics
     ///

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -1716,7 +1716,7 @@ impl<'h> Captures<'h> {
     ///
     /// This returns a tuple where the first element corresponds to the full
     /// substring of the haystack that matched the regex. The second element is
-    /// an array of substrings, with each corresponding to the to the substring
+    /// an array of substrings, with each corresponding to the substring
     /// that matched for a particular capture group.
     ///
     /// # Panics

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -1716,8 +1716,8 @@ impl<'h> Captures<'h> {
     ///
     /// This returns a tuple where the first element corresponds to the full
     /// substring of the haystack that matched the regex. The second element is
-    /// an array of substrings, with each corresponding to the substring
-    /// that matched for a particular capture group.
+    /// an array of substrings, with each corresponding to the substring that
+    /// matched for a particular capture group.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Fix words duplication in docs `extract` in three files.