### PR TITLE
unstable: fix `Pattern` trait implementation

### DIFF
--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,4 +1,4 @@
-use core::str::pattern::{Pattern, SearchStep, Searcher};
+use core::str::pattern::{Pattern, SearchStep, Searcher, Utf8Pattern};
 
 use crate::{Matches, Regex};
 
@@ -20,6 +20,10 @@ impl<'r> Pattern for &'r Regex {
             last_step_end: 0,
             next_match: None,
         }
+    }
+
+    fn as_utf8_pattern<'p>(&'p self) -> Option<Utf8Pattern<'p>> {
+        None
     }
 }
 


### PR DESCRIPTION
I am teetering on removing this cursed implementation.

The upstream change was made here: https://github.com/rust-lang/rust/pull/130223

Fixes #1231
