### PR TITLE
Suggest `std::sync::LazyLock` instead of `once_cell::sync::Lazy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,8 +187,6 @@ version = "0.8.5"
 default-features = false
 
 [dev-dependencies]
-# For examples.
-once_cell = "1.17.1"
 # For property based tests.
 quickcheck = { version = "1.0.3", default-features = false }
 # To check README's example

--- a/README.md
+++ b/README.md
@@ -80,18 +80,24 @@ compilation itself expensive, but this also prevents optimizations that reuse
 allocations internally to the matching engines.
 
 In Rust, it can sometimes be a pain to pass regular expressions around if
-they're used from inside a helper function. Instead, we recommend using the
-[`once_cell`](https://crates.io/crates/once_cell) crate to ensure that
-regular expressions are compiled exactly once. For example:
+they're used from inside a helper function. Instead, we recommend using
+[`std::sync::LazyLock`] stabilized in [Rust 1.80], the [`once_cell`] crate, or
+the [`lazy_static`] crate to ensure that regular expressions are compiled
+exactly once. For example:
+
+[`std::sync::LazyLock`]: https://doc.rust-lang.org/std/sync/struct.LazyLock.html
+[Rust 1.80]: https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html
+[`once_cell`]: https://crates.io/crates/once_cell
+[`lazy_static`]: https://crates.io/crates/lazy_static
 
 ```rust
 use {
-    once_cell::sync::Lazy,
+    std::sync::LazyLock,
     regex::Regex,
 };
 
 fn some_helper_function(haystack: &str) -> bool {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"...").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"...").unwrap());
     RE.is_match(haystack)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -471,10 +471,14 @@ to a few **milliseconds** depending on the size of the pattern.) Not only is
 compilation itself expensive, but this also prevents optimizations that reuse
 allocations internally to the regex engine.
 
-In Rust, it can sometimes be a pain to pass regexes around if they're used from
-inside a helper function. Instead, we recommend using crates like [`once_cell`]
-and [`lazy_static`] to ensure that patterns are compiled exactly once.
+In Rust, it can sometimes be a pain to pass regular expressions around if
+they're used from inside a helper function. Instead, we recommend using
+[`std::sync::LazyLock`] stabilized in [Rust 1.80], the [`once_cell`] crate, or
+the [`lazy_static`] crate to ensure that regular expressions are compiled
+exactly once. For example:
 
+[`std::sync::LazyLock`]: https://doc.rust-lang.org/std/sync/struct.LazyLock.html
+[Rust 1.80]: https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html
 [`once_cell`]: https://crates.io/crates/once_cell
 [`lazy_static`]: https://crates.io/crates/lazy_static
 
@@ -482,12 +486,12 @@ This example shows how to use `once_cell`:
 
 ```rust
 use {
-    once_cell::sync::Lazy,
+    std::sync::LazyLock,
     regex::Regex,
 };
 
 fn some_helper_function(haystack: &str) -> bool {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"...").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"...").unwrap());
     RE.is_match(haystack)
 }
 


### PR DESCRIPTION
This PR suggests `std::sync::LazyLock` instead of `once_cell::sync::Lazy`.

This issue was discussed three months ago right after the stabilization of `std::sync::LazyLock` in Rust 1.80,
and since two more minor versions of Rust have been released since then,
I think it's about time.

Many thanks,

Closes #1217