### PR TITLE
automata: `Input::haystack` return with original lifetime

### DIFF
--- a/regex-automata/src/util/search.rs
+++ b/regex-automata/src/util/search.rs
@@ -590,7 +590,7 @@ impl<'h> Input<'h> {
     /// assert_eq!(b"foobar", input.haystack());
     /// ```
     #[inline]
-    pub fn haystack(&self) -> &[u8] {
+    pub fn haystack(&self) -> &'h [u8] {
         self.haystack
     }
 


### PR DESCRIPTION
`Input::haystack` currently returns the haystack with the lifetime of `&self`, not `'h`. This sometimes is not enough and can only be worked around by `transmute`. Should we return the original lifetime instead?