### PR TITLE
lint: fixes for new lifetime lint

### DIFF
--- a/regex-automata/src/nfa/thompson/compiler.rs
+++ b/regex-automata/src/nfa/thompson/compiler.rs
@@ -230,9 +230,9 @@ impl Config {
     /// # if cfg!(miri) { return Ok(()); } // miri takes too long
     /// use regex_automata::nfa::thompson::NFA;
     ///
-    /// // 400KB isn't enough!
+    /// // 300KB isn't enough!
     /// NFA::compiler()
-    ///     .configure(NFA::config().nfa_size_limit(Some(400_000)))
+    ///     .configure(NFA::config().nfa_size_limit(Some(300_000)))
     ///     .build(r"\w{20}")
     ///     .unwrap_err();
     ///

--- a/regex-automata/src/util/alphabet.rs
+++ b/regex-automata/src/util/alphabet.rs
@@ -469,7 +469,7 @@ impl ByteClasses {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
-    pub fn elements(&self, class: Unit) -> ByteClassElements {
+    pub fn elements(&self, class: Unit) -> ByteClassElements<'_> {
         ByteClassElements { classes: self, class, byte: 0 }
     }
 
@@ -477,7 +477,7 @@ impl ByteClasses {
     ///
     /// That is, a sequence of contiguous ranges are returned. Typically, every
     /// class maps to a single contiguous range.
-    fn element_ranges(&self, class: Unit) -> ByteClassElementRanges {
+    fn element_ranges(&self, class: Unit) -> ByteClassElementRanges<'_> {
         ByteClassElementRanges { elements: self.elements(class), range: None }
     }
 }
@@ -786,12 +786,12 @@ impl ByteSet {
     }
 
     /// Returns an iterator over all bytes in this set.
-    pub(crate) fn iter(&self) -> ByteSetIter {
+    pub(crate) fn iter(&self) -> ByteSetIter<'_> {
         ByteSetIter { set: self, b: 0 }
     }
 
     /// Returns an iterator over all contiguous ranges of bytes in this set.
-    pub(crate) fn iter_ranges(&self) -> ByteSetRangeIter {
+    pub(crate) fn iter_ranges(&self) -> ByteSetRangeIter<'_> {
         ByteSetRangeIter { set: self, b: 0 }
     }
 

--- a/regex-test/lib.rs
+++ b/regex-test/lib.rs
@@ -198,7 +198,7 @@ impl RegexTests {
     /// loaded.
     ///
     /// This is useful to pass to [`TestRunner::test_iter`].
-    pub fn iter(&self) -> RegexTestsIter {
+    pub fn iter(&self) -> RegexTestsIter<'_> {
         RegexTestsIter(self.tests.iter())
     }
 }


### PR DESCRIPTION
This also tweaks a doc test that failed on 32-bit. It likely always
failed, but was only recently surfaced because doc tests previously
weren't run when cross compiling.
