### PR TITLE
Reduce crate size by excluding fuzz/ and record/

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ finite automata and guarantees linear time matching on all inputs.
 """
 categories = ["text-processing"]
 autotests = false
-exclude = ["/scripts/*", "/.github/*"]
+exclude = ["/fuzz/*", "/record/*", "/scripts/*", "/.github/*"]
 edition = "2021"
 rust-version = "1.65"
 


### PR DESCRIPTION
The fuzz/ and record/ directories are about 2MiB, and are not used by the end user. This removes them from the crate for future publishes.

Also, this avoids risk of an [xz-style attack] leveraging the binary files produced by fuzzing, where malicious code could be slipped in past review through binary test data.

[zx-style attack]: https://en.wikipedia.org/wiki/XZ_Utils_backdoor