### PR TITLE
Inline format-args for regex-syntax

### DIFF
--- a/regex-syntax/src/ast/mod.rs
+++ b/regex-syntax/src/ast/mod.rs
@@ -1801,9 +1801,7 @@ mod tests {
         let size = core::mem::size_of::<Ast>();
         assert!(
             size <= max,
-            "Ast size of {} bytes is bigger than suggested max {}",
-            size,
-            max
+            "Ast size of {size} bytes is bigger than suggested max {max}",
         );
     }
 }

--- a/regex-syntax/src/ast/parse.rs
+++ b/regex-syntax/src/ast/parse.rs
@@ -484,7 +484,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
         self.pattern()[i..]
             .chars()
             .next()
-            .unwrap_or_else(|| panic!("expected char at offset {}", i))
+            .unwrap_or_else(|| panic!("expected char at offset {i}"))
     }
 
     /// Bump the parser to the next Unicode scalar value.
@@ -2254,7 +2254,7 @@ impl<'s, P: Borrow<Parser>> ParserI<'s, P> {
             'S' => (true, ast::ClassPerlKind::Space),
             'w' => (false, ast::ClassPerlKind::Word),
             'W' => (true, ast::ClassPerlKind::Word),
-            c => panic!("expected valid Perl class but got '{}'", c),
+            c => panic!("expected valid Perl class but got '{c}'"),
         };
         ast::ClassPerl { span, kind, negated }
     }
@@ -4598,7 +4598,7 @@ bar
 
         // We also support superfluous escapes in most cases now too.
         for c in ['!', '@', '%', '"', '\'', '/', ' '] {
-            let pat = format!(r"\{}", c);
+            let pat = format!(r"\{c}");
             assert_eq!(
                 parser(&pat).parse_primitive(),
                 Ok(Primitive::Literal(ast::Literal {
@@ -4713,7 +4713,7 @@ bar
     #[test]
     fn parse_octal() {
         for i in 0..511 {
-            let pat = format!(r"\{:o}", i);
+            let pat = format!(r"\{i:o}");
             assert_eq!(
                 parser_octal(&pat).parse_escape(),
                 Ok(Primitive::Literal(ast::Literal {
@@ -4788,7 +4788,7 @@ bar
     #[test]
     fn parse_hex_two() {
         for i in 0..256 {
-            let pat = format!(r"\x{:02x}", i);
+            let pat = format!(r"\x{i:02x}");
             assert_eq!(
                 parser(&pat).parse_escape(),
                 Ok(Primitive::Literal(ast::Literal {
@@ -4829,7 +4829,7 @@ bar
                 None => continue,
                 Some(c) => c,
             };
-            let pat = format!(r"\u{:04x}", i);
+            let pat = format!(r"\u{i:04x}");
             assert_eq!(
                 parser(&pat).parse_escape(),
                 Ok(Primitive::Literal(ast::Literal {
@@ -4893,7 +4893,7 @@ bar
                 None => continue,
                 Some(c) => c,
             };
-            let pat = format!(r"\U{:08x}", i);
+            let pat = format!(r"\U{i:08x}");
             assert_eq!(
                 parser(&pat).parse_escape(),
                 Ok(Primitive::Literal(ast::Literal {

--- a/regex-syntax/src/ast/print.rs
+++ b/regex-syntax/src/ast/print.rs
@@ -199,9 +199,9 @@ impl<W: fmt::Write> Writer<W> {
     ) -> fmt::Result {
         use crate::ast::RepetitionRange::*;
         match *ast {
-            Exactly(x) => write!(self.wtr, "{{{}}}", x),
-            AtLeast(x) => write!(self.wtr, "{{{},}}", x),
-            Bounded(x, y) => write!(self.wtr, "{{{},{}}}", x, y),
+            Exactly(x) => write!(self.wtr, "{{{x}}}"),
+            AtLeast(x) => write!(self.wtr, "{{{x},}}"),
+            Bounded(x, y) => write!(self.wtr, "{{{x},{y}}}"),
         }
     }
 

--- a/regex-syntax/src/ast/visitor.rs
+++ b/regex-syntax/src/ast/visitor.rs
@@ -488,7 +488,7 @@ impl<'a> core::fmt::Debug for ClassFrame<'a> {
             ClassFrame::BinaryLHS { .. } => "BinaryLHS",
             ClassFrame::BinaryRHS { .. } => "BinaryRHS",
         };
-        write!(f, "{}", x)
+        write!(f, "{x}")
     }
 }
 
@@ -517,6 +517,6 @@ impl<'a> core::fmt::Debug for ClassInduct<'a> {
                 }
             },
         };
-        write!(f, "{}", x)
+        write!(f, "{x}")
     }
 }

--- a/regex-syntax/src/debug.rs
+++ b/regex-syntax/src/debug.rs
@@ -42,7 +42,7 @@ impl<'a> core::fmt::Debug for Bytes<'a> {
             let ch = match result {
                 Ok(ch) => ch,
                 Err(byte) => {
-                    write!(f, r"\x{:02x}", byte)?;
+                    write!(f, r"\x{byte:02x}")?;
                     bytes = &bytes[1..];
                     continue;
                 }

--- a/regex-syntax/src/error.rs
+++ b/regex-syntax/src/error.rs
@@ -93,10 +93,10 @@ impl<'e, E: core::fmt::Display> core::fmt::Display for Formatter<'e, E> {
             let divider = repeat_char('~', 79);
 
             writeln!(f, "regex parse error:")?;
-            writeln!(f, "{}", divider)?;
+            writeln!(f, "{divider}")?;
             let notated = spans.notate();
-            write!(f, "{}", notated)?;
-            writeln!(f, "{}", divider)?;
+            write!(f, "{notated}")?;
+            writeln!(f, "{divider}")?;
             // If we have error spans that cover multiple lines, then we just
             // note the line numbers.
             if !spans.multi_line.is_empty() {
@@ -116,7 +116,7 @@ impl<'e, E: core::fmt::Display> core::fmt::Display for Formatter<'e, E> {
         } else {
             writeln!(f, "regex parse error:")?;
             let notated = Spans::from_formatter(self).notate();
-            write!(f, "{}", notated)?;
+            write!(f, "{notated}")?;
             write!(f, "error: {}", self.err)?;
         }
         Ok(())

--- a/regex-syntax/src/hir/print.rs
+++ b/regex-syntax/src/hir/print.rs
@@ -230,7 +230,7 @@ impl<W: fmt::Write> Visitor for Writer<W> {
             HirKind::Capture(hir::Capture { ref name, .. }) => {
                 self.wtr.write_str("(")?;
                 if let Some(ref name) = *name {
-                    write!(self.wtr, "?P<{}>", name)?;
+                    write!(self.wtr, "?P<{name}>")?;
                 }
             }
             // Why do this? Wrapping concats and alts in non-capturing groups
@@ -276,15 +276,15 @@ impl<W: fmt::Write> Visitor for Writer<W> {
                         return Ok(());
                     }
                     (m, None) => {
-                        write!(self.wtr, "{{{},}}", m)?;
+                        write!(self.wtr, "{{{m},}}")?;
                     }
                     (m, Some(n)) if m == n => {
-                        write!(self.wtr, "{{{}}}", m)?;
+                        write!(self.wtr, "{{{m}}}")?;
                         // a{m} and a{m}? are always exactly equivalent.
                         return Ok(());
                     }
                     (m, Some(n)) => {
-                        write!(self.wtr, "{{{},{}}}", m, n)?;
+                        write!(self.wtr, "{{{m},{n}}}")?;
                     }
                 }
                 if !x.greedy {
@@ -317,7 +317,7 @@ impl<W: fmt::Write> Writer<W> {
         if b <= 0x7F && !b.is_ascii_control() && !b.is_ascii_whitespace() {
             self.write_literal_char(char::try_from(b).unwrap())
         } else {
-            write!(self.wtr, "(?-u:\\x{:02X})", b)
+            write!(self.wtr, "(?-u:\\x{b:02X})")
         }
     }
 
@@ -325,7 +325,7 @@ impl<W: fmt::Write> Writer<W> {
         if b <= 0x7F && !b.is_ascii_control() && !b.is_ascii_whitespace() {
             self.write_literal_char(char::try_from(b).unwrap())
         } else {
-            write!(self.wtr, "\\x{:02X}", b)
+            write!(self.wtr, "\\x{b:02X}")
         }
     }
 }

--- a/regex-syntax/src/hir/translate.rs
+++ b/regex-syntax/src/hir/translate.rs
@@ -254,7 +254,7 @@ impl HirFrame {
         match self {
             HirFrame::Expr(expr) => expr,
             HirFrame::Literal(lit) => Hir::literal(lit),
-            _ => panic!("tried to unwrap expr from HirFrame, got: {:?}", self),
+            _ => panic!("tried to unwrap expr from HirFrame, got: {self:?}"),
         }
     }
 
@@ -291,8 +291,7 @@ impl HirFrame {
             HirFrame::Repetition => {}
             _ => {
                 panic!(
-                    "tried to unwrap repetition from HirFrame, got: {:?}",
-                    self
+                    "tried to unwrap repetition from HirFrame, got: {self:?}"
                 )
             }
         }
@@ -305,7 +304,7 @@ impl HirFrame {
         match self {
             HirFrame::Group { old_flags } => old_flags,
             _ => {
-                panic!("tried to unwrap group from HirFrame, got: {:?}", self)
+                panic!("tried to unwrap group from HirFrame, got: {self:?}")
             }
         }
     }
@@ -316,10 +315,7 @@ impl HirFrame {
         match self {
             HirFrame::AlternationBranch => {}
             _ => {
-                panic!(
-                    "tried to unwrap alt pipe from HirFrame, got: {:?}",
-                    self
-                )
+                panic!("tried to unwrap alt pipe from HirFrame, got: {self:?}")
             }
         }
     }

--- a/regex-syntax/src/utf8.rs
+++ b/regex-syntax/src/utf8.rs
@@ -128,7 +128,7 @@ impl Utf8Sequence {
                 Utf8Range::new(start[2], end[2]),
                 Utf8Range::new(start[3], end[3]),
             ]),
-            n => unreachable!("invalid encoded length: {}", n),
+            n => unreachable!("invalid encoded length: {n}"),
         }
     }
 
@@ -203,7 +203,7 @@ impl fmt::Debug for Utf8Sequence {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::Utf8Sequence::*;
         match *self {
-            One(ref r) => write!(f, "{:?}", r),
+            One(ref r) => write!(f, "{r:?}"),
             Two(ref r) => write!(f, "{:?}{:?}", r[0], r[1]),
             Three(ref r) => write!(f, "{:?}{:?}{:?}", r[0], r[1], r[2]),
             Four(ref r) => {


### PR DESCRIPTION
This makes the code a bit easier to read and smaller.

Some of it was done with this command, and later fixed by hand:

```
 cargo clippy --workspace --allow-dirty --fix --benches --tests --bins -- -A clippy::all -W clippy::uninlined_format_args
 ```