### PR TITLE
Also exclude tests/fuzz from the package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ finite automata and guarantees linear time matching on all inputs.
 """
 categories = ["text-processing"]
 autotests = false
-exclude = ["/fuzz/*", "/record/*", "/scripts/*", "/.github/*"]
+exclude = ["/fuzz/*", "/record/*", "/scripts/*", "tests/fuzz/*", "/.github/*"]
 edition = "2021"
 rust-version = "1.65"
 


### PR DESCRIPTION
I missed more binary test data `tests/fuzz/` in #1281, which should remove another 56KiB from the regex crate.