### PR TITLE
automata: Fix crash in `dense::DFA::from_bytes` validation logic

### DIFF
--- a/regex-automata/src/dfa/dense.rs
+++ b/regex-automata/src/dfa/dense.rs
@@ -2340,10 +2340,14 @@ impl<'a> DFA<&'a [u32]> {
         // table, match states and accelerators below. If any validation fails,
         // then we return an error.
         let (dfa, nread) = unsafe { DFA::from_bytes_unchecked(slice)? };
+        // Note: Validation order is important here:
+        // - MatchState::validate can be called with an untrusted DFA.
+        // - TransistionTable::validate uses dfa.ms through match_len
+        // - StartTable::validate needs a valid transition table
+        dfa.accels.validate()?;
+        dfa.ms.validate(&dfa)?;
         dfa.tt.validate(&dfa)?;
         dfa.st.validate(&dfa)?;
-        dfa.ms.validate(&dfa)?;
-        dfa.accels.validate()?;
         // N.B. dfa.special doesn't have a way to do unchecked deserialization,
         // so it has already been validated.
         for state in dfa.states() {

--- a/regex-automata/src/dfa/dense.rs
+++ b/regex-automata/src/dfa/dense.rs
@@ -5230,4 +5230,17 @@ mod tests {
         let got = dfa.try_search_rev(&input);
         assert_eq!(Err(expected), got);
     }
+
+    // This panics in TransitionTable::validate if the match states are not validated first.
+    #[test]
+    fn regression_validation_order() {
+        let mut dfa = DFA::new("abc").unwrap();
+        dfa.ms = MatchStates {
+            slices: vec![],
+            pattern_ids: vec![],
+            pattern_len: 1,
+        };
+        let (buf, _) = dfa.to_bytes_native_endian();
+        DFA::from_bytes(&buf).unwrap_err();
+    }
 }


### PR DESCRIPTION
Hi,

this PR fixes a panic the `dense::DFA::from_bytes` API. The validation step after loading a corrupted DFA currently panics in `TransitionTable::validate` due to an invalid `MatchState`. This PR fixes this by validating the `MatchState` first.

```rust
#[test]
fn regression_validation_order() {
    let mut dfa = DFA::new("abc").unwrap();
    dfa.ms = MatchStates {
        slices: vec![],
        pattern_ids: vec![],
        pattern_len: 1,
    };
    let (buf, _) = dfa.to_bytes_native_endian();
    DFA::from_bytes(&buf).unwrap_err();
}
```

```
thread 'dfa::dense::tests::regression_validation_order' (365737) panicked at regex-automata/src/dfa/dense.rs:4644:9:
index out of bounds: the len is 0 but the index is 1
stack backtrace:
   [...]
   3: regex_automata::dfa::dense::MatchStates<T>::pattern_len
             at ./src/dfa/dense.rs:4644:9
   4: regex_automata::dfa::dense::DFA<T>::match_pattern_len
             at ./src/dfa/dense.rs:3006:17
   5: <regex_automata::dfa::dense::DFA<T> as regex_automata::dfa::automaton::Automaton>::match_len
             at ./src/dfa/dense.rs:3220:14
   6: regex_automata::dfa::dense::TransitionTable<T>::validate
             at ./src/dfa/dense.rs:3629:28
   7: regex_automata::dfa::dense::DFA<&[u32]>::from_bytes
             at ./src/dfa/dense.rs:2343:16
   8: regex_automata::dfa::dense::tests::regression_validation_order
             at ./src/dfa/dense.rs:5244:9
```

I'm assuming that people are not using serialized automata with untrusted inputs, so I hope just opening a PR is fine :slightly_smiling_face: 