### PR TITLE
automata: call `Vec::shrink_to_fit` in a few strategic places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+1.11.3 (TBD)
+============
+TODO
+
+Improvements:
+
+* [BUG #1297](https://github.com/rust-lang/regex/issues/1297):
+Improve memory usage by trimming excess memory capacity in some spots.
+
+
 1.11.2 (2025-08-24)
 ===================
 This is a new patch release of `regex` with some minor fixes. A larger number

--- a/regex-automata/src/dfa/dense.rs
+++ b/regex-automata/src/dfa/dense.rs
@@ -1274,6 +1274,10 @@ impl Builder {
         }
         // Look for and set the universal starting states.
         dfa.set_universal_starts();
+        dfa.tt.table.shrink_to_fit();
+        dfa.st.table.shrink_to_fit();
+        dfa.ms.slices.shrink_to_fit();
+        dfa.ms.pattern_ids.shrink_to_fit();
         Ok(dfa)
     }
 

--- a/regex-automata/src/dfa/onepass.rs
+++ b/regex-automata/src/dfa/onepass.rs
@@ -722,6 +722,8 @@ impl<'a> InternalBuilder<'a> {
             }
         }
         self.shuffle_states();
+        self.dfa.starts.shrink_to_fit();
+        self.dfa.table.shrink_to_fit();
         Ok(self.dfa)
     }
 

--- a/regex-automata/src/dfa/sparse.rs
+++ b/regex-automata/src/dfa/sparse.rs
@@ -393,6 +393,8 @@ impl DFA<Vec<u8>> {
                 new_state.set_next_at(i, next);
             }
         }
+        new.tt.sparse.shrink_to_fit();
+        new.st.table.shrink_to_fit();
         debug!(
             "created sparse DFA, memory usage: {} (dense memory usage: {})",
             new.memory_usage(),

--- a/regex-automata/src/nfa/thompson/nfa.rs
+++ b/regex-automata/src/nfa/thompson/nfa.rs
@@ -1338,6 +1338,8 @@ impl Inner {
             self.look_set_prefix_any =
                 self.look_set_prefix_any.union(prefix_any);
         }
+        self.states.shrink_to_fit();
+        self.start_pattern.shrink_to_fit();
         NFA(Arc::new(self))
     }
 

--- a/regex-automata/src/util/captures.rs
+++ b/regex-automata/src/util/captures.rs
@@ -1606,6 +1606,9 @@ impl GroupInfo {
             }
         }
         group_info.fixup_slot_ranges()?;
+        group_info.slot_ranges.shrink_to_fit();
+        group_info.name_to_index.shrink_to_fit();
+        group_info.index_to_name.shrink_to_fit();
         Ok(GroupInfo(Arc::new(group_info)))
     }
 


### PR DESCRIPTION
Other parts of `regex-automata` do this implicitly by using `Box<[T]>`,
btu it's not always straight-forward to use `Box<[T]>`. (Or, at least,
non-annoying.) In some of those cases here, we call `Vec::shrink_to_fit`
to decrease memory usage.

These are probably the biggest offenders, but I didn't do a thorough
investigation here.

Fixes #1297
