### PR TITLE
Fix docs for backtick in inline code

### DIFF
--- a/regex-syntax/src/ast/mod.rs
+++ b/regex-syntax/src/ast/mod.rs
@@ -839,7 +839,7 @@ pub enum ClassAsciiKind {
     Lower,
     /// `[ -~]`
     Print,
-    /// `[!-/:-@\[-`{-~]`
+    /// ``[!-/:-@\[-`{-~]``
     Punct,
     /// `[\t\n\v\f\r ]`
     Space,


### PR DESCRIPTION
Fixes the rendered documentation for [`regex_syntax::ast::ClassAsciiKind::Punct`](https://docs.rs/regex-syntax/0.8.6/regex_syntax/ast/enum.ClassAsciiKind.html#variant.Punct).

A quick survey of all doc comments in the repo with an odd number of backticks, excluding ```` ``` ````, reveals this is the only occurrence of this class of issue: ``rg '//[/!][^`]*`([^`]*`){2}*([^`]+`[^`]*|[^`]*`[^`]+)`([^`]*`){2}*[^`]*$'``.