### PR TITLE
automata: make PikeVM cache initialization lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ TODO
 
 Bug fixes:
 
+* [BUG #1116](https://github.com/rust-lang/regex/issues/1116):
+Fixes a memory usage regression for large regexes (introduced in `regex 1.9`).
 * [BUG #1165](https://github.com/rust-lang/regex/issues/1083):
 Fixes a panic in the lazy DFA (can only occur for especially large regexes).
 


### PR DESCRIPTION
Prior to the advent of regex-automata, the PikeVM would decide how much
space it needed at the beginning of every search. In regex-automata, we
did away with that check at search time and moved it to the time at
which the cache is constructed. (The inputs to the sizing are currently
invariant in regex-automata, as they were in the old regex crate.)

The downside of this is that we create the caches for each regex engine
eagerly. So even if we never call the PikeVM (which is actually quite
common, since the lazy DFA handles mostly everything), we end up paying
for the memory of its cache. In many cases, this memory is likely
negligible, but it can be substantial if there are a lot of capture
groups, even if they aren't used. As in #1116.

We fix this by just re-arranging the meta regex engine wrappers to avoid
eagerly creating caches. Instead, they are only initialized when they
are actually needed.

This ends up making memory usage a bit less than `regex 1.7.3`.

Fixes #1116
