### PR TITLE
automata: make behavior more consistent when `WhichCaptures::None` is used

### DIFF
--- a/regex-automata/src/nfa/thompson/compiler.rs
+++ b/regex-automata/src/nfa/thompson/compiler.rs
@@ -563,6 +563,28 @@ pub enum WhichCaptures {
     /// This is useful when capture states are either not needed (for example,
     /// if one is only trying to build a DFA) or if they aren't supported (for
     /// example, a reverse NFA).
+    ///
+    /// # Warning
+    ///
+    /// Callers must be exceedingly careful when using this
+    /// option. In particular, not all regex engines support
+    /// reporting match spans when using this option (for example,
+    /// [`PikeVM`](crate::nfa::thompson::pikevm::PikeVM) or
+    /// [`BoundedBacktracker`](crate::nfa::thompson::backtrack::BoundedBacktracker)).
+    ///
+    /// Perhaps more confusingly, using this option with such an
+    /// engine means that an `is_match` routine could report `true`
+    /// when `find` reports `None`. This is generally not something
+    /// that _should_ happen, but the low level control provided by
+    /// this crate makes it possible.
+    ///
+    /// Similarly, any regex engines (like [`meta::Regex`](crate::meta::Regex))
+    /// should always return `None` from `find` routines when this option is
+    /// used, even if _some_ of its internal engines could find the match
+    /// boundaries. This is because inputs from user data could influence
+    /// engine selection, and thus influence whether a match is found or not.
+    /// Indeed, `meta::Regex::find` will always return `None` when configured
+    /// with this option.
     None,
 }
 


### PR DESCRIPTION
Specifically, when used with `meta::Regex`. Before this PR, if callers
built a `meta::Regex` with `WhichCaptures::None`, then it was possible
for `find` to _sometimes_ return `Some` and _sometimes_ return `None`,
just based on the sequence of previous search calls.

In particular, when `WhichCaptures::None` is used, some regex engines
(like the `PikeVM`) cannot report match offsets while some (like the
lazy DFA) can. This meant that if the meta regex engine _happened_ to
select the lazy DFA for a `Regex::find` call, then it would return
`Some`. But if it _happened_ to select the Pike VM, then it would return
`None`. Since engine selection can be influenced by the haystack itself,
this leads to the behavior of `find` being tied to the contents of the
haystack.

Instead, what we should do is make it so anything that returns match
offsets on a `meta::Regex` will always return `None` when
`WhichCaptures::None` is used, _even_ if `Regex::is_match` returns
`true`.

(Yes, this is a weird option and it's crazy that `Regex::is_match` can
return `true` while `Regex::find` can return `None`. This was already
true before this PR and is a result of a very low level option that
optimizes for memory usage in specific circumstances. This sort of
whacky behavior can't be observed in the `regex` crate API. Only in
`regex-automata`.)
