### PR TITLE
Exclude fuzzing/test data from the published crates.io package

### DIFF
--- a/regex-automata/Cargo.toml
+++ b/regex-automata/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["text-processing"]
 edition = "2021"
 autoexamples = false
 rust-version = "1.65"
+include = ["src/**/*.rs", "Cargo.toml", "/README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 
 [lib]
 bench = false


### PR DESCRIPTION
During a dependency review I noticed that regex-automata includes binary fuzzing and test data. These files are not required for building regex-automata as dependency and make it a hard to review the code. This is similar to https://github.com/rust-lang/regex/pull/1281

This commit introduces a `include` directive in the `Cargo.toml` file to explicitly include only those files required to build `regex-automata`. This excludes the test directory and also reduces the size of the published crate from 122 files, 2.6MiB (610.6KiB compressed) to 77 files, 2.5MiB (584.0KiB compressed) which results in a 150 GB/month traffic reduction for crates.io assuming the current 6 million/month downloads and the difference in the compressed package size.