### PR TITLE
perf: Avoid re-canonicalizing the entire IntervalSet on push

### DIFF
--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -86,9 +86,10 @@ impl<I: Interval> IntervalSet<I> {
             return;
         };
 
-        // The search finds us the first index where the previous interval start is less
-        // than or equal to the new interval start. Since the existing intervals are non-overlapping
-        // we only need to try to union this single preceding interval
+        // The search finds us the first index where the previous interval
+        // start is less than or equal to the new interval start. Since the
+        // existing intervals are non-overlapping we only need to try to union
+        // this single preceding interval
         let mut start = i;
         if let Some(before_i) = i.checked_sub(1) {
             let before = &self.ranges[before_i];
@@ -97,19 +98,18 @@ impl<I: Interval> IntervalSet<I> {
                 start = before_i;
             }
         }
-        // `interval` may overlap any number of intervals following the insertion point
-        // so will union each of them until we reach the first non-overlapping interval
+        // `interval` may overlap any number of intervals following the
+        // insertion point so will union each of them until we reach the
+        // first non-overlapping interval
         let mut end = i;
         for after_i in i..self.ranges.len() {
             let after = &self.ranges[after_i];
-            if let Some(union) = interval.union(after) {
-                interval = union;
-                end = after_i + 1;
-            } else {
+            let Some(union) = interval.union(after) else {
                 break;
-            }
+            };
+            interval = union;
+            end = after_i + 1;
         }
-
         self.ranges.splice(start..end, core::iter::once(interval));
 
         // We don't know whether the new interval added here is considered

--- a/regex-syntax/src/hir/interval.rs
+++ b/regex-syntax/src/hir/interval.rs
@@ -80,11 +80,38 @@ impl<I: Interval> IntervalSet<I> {
     }
 
     /// Add a new interval to this set.
-    pub fn push(&mut self, interval: I) {
-        // TODO: This could be faster. e.g., Push the interval such that
-        // it preserves canonicalization.
-        self.ranges.push(interval);
-        self.canonicalize();
+    pub fn push(&mut self, mut interval: I) {
+        let Err(i) = self.ranges.binary_search(&interval) else {
+            // Exact match, `interval` is already in the set.
+            return;
+        };
+
+        // The search finds us the first index where the previous interval start is less
+        // than or equal to the new interval start. Since the existing intervals are non-overlapping
+        // we only need to try to union this single preceding interval
+        let mut start = i;
+        if let Some(before_i) = i.checked_sub(1) {
+            let before = &self.ranges[before_i];
+            if let Some(union) = before.union(&interval) {
+                interval = union;
+                start = before_i;
+            }
+        }
+        // `interval` may overlap any number of intervals following the insertion point
+        // so will union each of them until we reach the first non-overlapping interval
+        let mut end = i;
+        for after_i in i..self.ranges.len() {
+            let after = &self.ranges[after_i];
+            if let Some(union) = interval.union(after) {
+                interval = union;
+                end = after_i + 1;
+            } else {
+                break;
+            }
+        }
+
+        self.ranges.splice(start..end, core::iter::once(interval));
+
         // We don't know whether the new interval added here is considered
         // case folded, so we conservatively assume that the entire set is
         // no longer case folded if it was previously.


### PR DESCRIPTION
Canonicalize is taking up a significant amount due to a regex with a huge amount of character ranges (generated by [lalrpop](https://github.com/lalrpop/lalrpop)'s lexer expanding multiple `\w` in a token). While this could perhaps be fixed in lalrpop I did notice the TODO in the code and after addressing this so we automatically union and compress on each push instead of re-canonicalizing on every push and that fixed the performance problem.

I did see the earlier attempt at this https://github.com/rust-lang/regex/pull/1051 and it seems like that was reverted and regression tests were added so I hope that and the existing tests are enough (I don't have a clear idea on what tests might be missing).