### PR TITLE
doc: update README doctests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,8 +189,6 @@ default-features = false
 [dev-dependencies]
 # For property based tests.
 quickcheck = { version = "1.0.3", default-features = false }
-# To check README's example
-doc-comment = "0.3"
 # For easy error handling in integration tests.
 anyhow = "1.0.69"
 # A library for testing regex engines.

--- a/regex-automata/Cargo.toml
+++ b/regex-automata/Cargo.toml
@@ -92,7 +92,6 @@ regex-syntax = { path = "../regex-syntax", version = "0.8.5", optional = true, d
 [dev-dependencies]
 anyhow = "1.0.69"
 bstr = { version = "1.3.0", default-features = false, features = ["std"] }
-doc-comment = "0.3.3"
 quickcheck = { version = "1.0.3", default-features = false }
 regex-test = { path = "../regex-test", version = "0.1.0" }
 

--- a/regex-automata/src/lib.rs
+++ b/regex-automata/src/lib.rs
@@ -630,8 +630,9 @@ extern crate std;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[doc = include_str!("../README.md")]
 #[cfg(doctest)]
-doc_comment::doctest!("../README.md");
+pub struct ReadmeDoctests;
 
 #[doc(inline)]
 pub use crate::util::primitives::PatternID;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1324,8 +1324,9 @@ this for literal optimizations.
 #![cfg_attr(docsrs_regex, feature(doc_cfg))]
 #![warn(missing_debug_implementations)]
 
+#[doc = include_str!("../README.md")]
 #[cfg(doctest)]
-doc_comment::doctest!("../README.md");
+pub struct ReadmeDoctests;
 
 extern crate alloc;
 #[cfg(any(test, feature = "std"))]


### PR DESCRIPTION
Using the solution described in the [official documentation](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html) instead of relying on a third-party crate.