### PR TITLE
Exclude development scripts and fuzzing data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ finite automata and guarantees linear time matching on all inputs.
 """
 categories = ["text-processing"]
 autotests = false
-exclude = ["/fuzz/*", "/record/*", "/scripts/*", "tests/fuzz/*", "/.github/*"]
+include.workspace = true
 edition = "2021"
 rust-version = "1.65"
 
@@ -25,6 +25,22 @@ members = [
   "regex-lite",
   "regex-syntax",
   "regex-test",
+]
+
+[workspace.package]
+include = [
+  "/CHANGELOG.md", 
+  "/Cargo.toml", 
+  "/LICENSE-MIT", 
+  "/LICENSE-APACHE", 
+  "/README.md",
+  "/UNICODE.md",
+  "bench/README.md", 
+  "src/**/*.rs",
+  "tests/**/*.rs",
+  "bench/**/*.rs",
+  "LICENSE-UNICODE",
+  "!/tests/fuzz/mod.rs",
 ]
 
 # Features are documented in the "Crate features" section of the crate docs:

--- a/regex-automata/Cargo.toml
+++ b/regex-automata/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["text-processing"]
 edition = "2021"
 autoexamples = false
 rust-version = "1.65"
+include.workspace = true
 
 [lib]
 bench = false

--- a/regex-capi/Cargo.toml
+++ b/regex-capi/Cargo.toml
@@ -13,6 +13,19 @@ A C API for Rust's regular expression library.
 workspace = ".."
 edition = "2021"
 rust-version = "1.65"
+include = [
+  "/Cargo.toml", 
+  "/LICENSE-MIT", 
+  "/LICENSE-APACHE",
+  "/README.md",
+  "/UNICODE.md",
+  "bench/README.md",
+  "src/**/*.rs",
+  "tests/**/*.rs",
+  "include/**/*.h",
+  "ctest/**/*.c",
+  "examples/**/*.{c,txt}",
+]
 
 [lib]
 name = "rure"

--- a/regex-lite/Cargo.toml
+++ b/regex-lite/Cargo.toml
@@ -13,6 +13,7 @@ workspace = ".."
 edition = "2021"
 rust-version = "1.65"
 autotests = false
+include.workspace = true
 
 # Features are documented in the "Crate features" section of the crate docs:
 # https://docs.rs/regex-lite/*/#crate-features

--- a/regex-syntax/Cargo.toml
+++ b/regex-syntax/Cargo.toml
@@ -10,6 +10,7 @@ description = "A regular expression parser."
 workspace = ".."
 edition = "2021"
 rust-version = "1.65"
+include.workspace = true
 
 # Features are documented in the "Crate features" section of the crate docs:
 # https://docs.rs/regex-syntax/*/#crate-features


### PR DESCRIPTION
During a dependency review we noticed that different regex-* crate includes various development scripts and sometimes fuzzing data. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny. The fuzzing data are also not needed for anything.

I opted for using an explicit include list instead of an exclude list to prevent these files from beeing included in the published packages to make sure that everything that's included is an conscious choice.