### PR TITLE
syntax: fix negation handling in HIR translation

### DIFF
--- a/regex-syntax/src/hir/translate.rs
+++ b/regex-syntax/src/hir/translate.rs
@@ -1047,7 +1047,7 @@ impl<'t, 'p> TranslatorI<'t, 'p> {
         if let Ok(ref mut class) = result {
             self.unicode_fold_and_negate(
                 &ast_class.span,
-                ast_class.negated,
+                ast_class.is_negated(),
                 class,
             )?;
         }
@@ -2471,6 +2471,10 @@ mod tests {
             hir_uclass_query(ClassQuery::Binary("Z"))
         );
         assert_eq!(
+            t(r"\p{gc!=Separator}"),
+            hir_negate(hir_uclass_query(ClassQuery::Binary("Z")))
+        );
+        assert_eq!(
             t(r"\p{Other}"),
             hir_uclass_query(ClassQuery::Binary("Other"))
         );
@@ -2486,7 +2490,7 @@ mod tests {
         );
         assert_eq!(
             t(r"\P{gc!=separator}"),
-            hir_negate(hir_uclass_query(ClassQuery::Binary("Z")))
+            hir_uclass_query(ClassQuery::Binary("Z"))
         );
 
         assert_eq!(t(r"\p{any}"), hir_uclass_query(ClassQuery::Binary("Any")));


### PR DESCRIPTION
The `ast::ClassUnicode` struct has [the following remark](https://github.com/rust-lang/regex/blob/d8761c00ed25c5899e3dcfb0f17e827b8e41530a/regex-syntax/src/ast/mod.rs#L890):

> /// Whether this class is negated or not.
> ///
> /// Note: be careful when using this attribute. This specifically refers
> /// to whether the class is written as `\p` or `\P`, where the latter
> /// is `negated = true`. However, it also possible to write something like
> /// `\P{scx!=Katakana}` which is actually equivalent to
> /// `\p{scx=Katakana}` and is therefore not actually negated even though
> /// `negated = true` here. To test whether this class is truly negated
> /// or not, use the `is_negated` method.

However, [the HIR translation](https://github.com/rust-lang/regex/blob/d8761c00ed25c5899e3dcfb0f17e827b8e41530a/regex-syntax/src/hir/translate.rs#L1050) directly checks `negated` instead of calling `is_negated`, effectively ignoring the `!=` operator.

This commit fixes the issue by calling `ClassUnicode::is_negated`.

## Bug reproducer

[Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=5eb21b315762a6dd2649017f972117a4)

```rust
use regex_syntax;

fn ast_parse(pattern: &str) -> regex_syntax::ast::Ast {
    let mut parser = regex_syntax::ast::parse::Parser::new();
    parser.parse(pattern).unwrap()
}

fn main() {
    // AST parser correctly parses the != operator
    println!("{:#?}", ast_parse("\\p{gc=separator}"));
    println!("{:#?}", ast_parse("\\p{gc!=separator}"));
    
    // The HIR translation forgets !=
    let hir1 = regex_syntax::parse("\\p{gc=separator}");
    let hir2 = regex_syntax::parse("\\p{gc!=separator}");
    println!("hir1 == hir2: {}", hir1 == hir2);
    println!("{:#?}", hir1);
    println!("{:#?}", hir2);
}
```

- Expected behavior: `hir1 == hir2` should be false.
- Actual behavior: `hir1 == hir2` is true.