### PR TITLE
Use core::error::Error instead of std::error::Error

### DIFF
--- a/regex-automata/src/dfa/automaton.rs
+++ b/regex-automata/src/dfa/automaton.rs
@@ -2114,8 +2114,7 @@ impl StartError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for StartError {}
+impl core::error::Error for StartError {}
 
 impl core::fmt::Display for StartError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/regex-automata/src/util/primitives.rs
+++ b/regex-automata/src/util/primitives.rs
@@ -384,8 +384,7 @@ impl SmallIndexError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SmallIndexError {}
+impl core::error::Error for SmallIndexError {}
 
 impl core::fmt::Display for SmallIndexError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
@@ -646,8 +645,7 @@ macro_rules! index_type_impls {
             }
         }
 
-        #[cfg(feature = "std")]
-        impl std::error::Error for $err {}
+        impl core::error::Error for $err {}
 
         impl core::fmt::Display for $err {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/regex-automata/src/util/search.rs
+++ b/regex-automata/src/util/search.rs
@@ -1337,8 +1337,8 @@ pub struct PatternSetInsertError {
     capacity: usize,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PatternSetInsertError {}
+#[cfg(feature = "alloc")]
+impl core::error::Error for PatternSetInsertError {}
 
 #[cfg(feature = "alloc")]
 impl core::fmt::Display for PatternSetInsertError {
@@ -1889,8 +1889,7 @@ pub enum MatchErrorKind {
     },
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for MatchError {}
+impl core::error::Error for MatchError {}
 
 impl core::fmt::Display for MatchError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/regex-automata/src/util/wire.rs
+++ b/regex-automata/src/util/wire.rs
@@ -116,8 +116,7 @@ impl core::fmt::Display for SerializeError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SerializeError {}
+impl core::error::Error for SerializeError {}
 
 /// An error that occurs when deserializing an object defined in this crate.
 ///
@@ -211,8 +210,7 @@ impl DeserializeError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DeserializeError {}
+impl core::error::Error for DeserializeError {}
 
 impl core::fmt::Display for DeserializeError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/regex-lite/src/error.rs
+++ b/regex-lite/src/error.rs
@@ -18,8 +18,7 @@ impl Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/regex-syntax/src/ast/mod.rs
+++ b/regex-syntax/src/ast/mod.rs
@@ -189,8 +189,7 @@ pub enum ErrorKind {
     UnsupportedLookAround,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/regex-syntax/src/error.rs
+++ b/regex-syntax/src/error.rs
@@ -34,8 +34,7 @@ impl From<hir::Error> for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/regex-syntax/src/hir/mod.rs
+++ b/regex-syntax/src/hir/mod.rs
@@ -107,8 +107,7 @@ pub enum ErrorKind {
     UnicodeCaseUnavailable,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/regex-syntax/src/unicode.rs
+++ b/regex-syntax/src/unicode.rs
@@ -30,8 +30,7 @@ pub enum Error {
 #[derive(Debug)]
 pub struct CaseFoldError(());
 
-#[cfg(feature = "std")]
-impl std::error::Error for CaseFoldError {}
+impl core::error::Error for CaseFoldError {}
 
 impl core::fmt::Display for CaseFoldError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -51,8 +50,7 @@ impl core::fmt::Display for CaseFoldError {
 #[derive(Debug)]
 pub struct UnicodeWordError(());
 
-#[cfg(feature = "std")]
-impl std::error::Error for UnicodeWordError {}
+impl core::error::Error for UnicodeWordError {}
 
 impl core::fmt::Display for UnicodeWordError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,8 +53,7 @@ impl Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
+impl core::error::Error for Error {
     // TODO: Remove this method entirely on the next breaking semver release.
     #[allow(deprecated)]
     fn description(&self) -> &str {


### PR DESCRIPTION
Hi,

First of all, thanks a lot for writing and maintaining the regex crate!

What do you think about this change that makes all the error types derive `core::error::Error` instead of `std::error::Error` so that they are usable even in `no-std` mode? There are several error handling crates like `anyhow`, `eyre`, etc. which also work in `no-std` mode, and they refuse to accept the error objects defined in these crates then.

Thanks in advance, and keep up the great work!

G'luck,
Peter
