### PR TITLE
fix glob typo in workspace.package.include setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ include = [
   "/UNICODE.md",
   "bench/README.md",
   "src/**/*.rs",
-  "testdata/**.toml",
+  "testdata/**/*.toml",
   "tests/**/*.rs",
   "bench/**/*.rs",
   "benches/**/*.rs",


### PR DESCRIPTION
The "testdata/**.toml" value is wrong glob syntax and only matches files inside "testdata/", not in subdirectories. Fix syntax and make it match other values, making it match files in subdirectories as well.

Fixes #1333

It would be great to get a new release of the `regex` crate with this fix included. The missing test data currently prevents me from updating to regex v1.12.3 in Fedora Linux.