### PR TITLE
fix: prevent panic in cache reset methods when cache is None

### DIFF
--- a/regex-automata/src/meta/wrappers.rs
+++ b/regex-automata/src/meta/wrappers.rs
@@ -489,7 +489,11 @@ impl OnePassCache {
     pub(crate) fn reset(&mut self, builder: &OnePass) {
         #[cfg(feature = "dfa-onepass")]
         if let Some(ref e) = builder.0 {
-            self.0.as_mut().unwrap().reset(&e.0);
+            if let Some(ref mut cache) = self.0 {
+                cache.reset(&e.0);
+            } else {
+                self.0 = Some(e.0.create_cache());
+            }
         }
     }
 
@@ -781,7 +785,11 @@ impl HybridCache {
     pub(crate) fn reset(&mut self, builder: &Hybrid) {
         #[cfg(feature = "hybrid")]
         if let Some(ref e) = builder.0 {
-            self.0.as_mut().unwrap().reset(&e.0);
+            if let Some(ref mut cache) = self.0 {
+                cache.reset(&e.0);
+            } else {
+                self.0 = Some(e.0.create_cache());
+            }
         }
     }
 
@@ -1186,7 +1194,11 @@ impl ReverseHybridCache {
     pub(crate) fn reset(&mut self, builder: &ReverseHybrid) {
         #[cfg(feature = "hybrid")]
         if let Some(ref e) = builder.0 {
-            self.0.as_mut().unwrap().reset(&e.0);
+            if let Some(ref mut cache) = self.0 {
+                cache.reset(&e.0);
+            } else {
+                self.0 = Some(e.0.create_cache());
+            }
         }
     }
 


### PR DESCRIPTION
## Bug
Fixes #1155 — `meta::Cache::reset` can panic if called on a different regex than it was created with.

## Root Cause
The `reset` methods in `OnePassCache`, `HybridCache`, and `ReverseHybridCache` checked if `builder.0` was `Some` but then called `self.0.as_mut().unwrap()` without verifying `self.0` was also `Some`. This could happen when a cache was created with `::none()` (which sets the internal cache to `None`) but then reset with a builder that had an engine.

## Fix
The fix checks if `self.0` is `Some` before calling reset:
- If `Some`, reset the existing cache
- If `None`, create a new cache from the builder's engine

This allows caches to be safely reset with any compatible regex, which is the intended behavior of the `reset` method.

## Testing
The reproduction case from the issue now works without panicking:
```rust
let re1 = Regex::new("").unwrap();
let re2 = Regex::new("\\b").unwrap();
re1.create_cache().reset(&re2); // No longer panics
```

Greetings, saschabuehrle