### PR TITLE
Fix release date for 1.12.3 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-1.12.3 (2025-02-03)
+1.12.3 (2026-02-03)
 ===================
 This release excludes some unnecessary things from the archive published to
 crates.io. Specifically, fuzzing data and various shell scripts are now


### PR DESCRIPTION
The release date is 2026-02-03, so it makes no sense that the changelog says 2025. Seems to be a typo so this fixes it