### PR TITLE
regex-test: bump toml to 0.9

### DIFF
--- a/regex-test/Cargo.toml
+++ b/regex-test/Cargo.toml
@@ -25,4 +25,4 @@ path = "lib.rs"
 anyhow = "1.0.27"
 bstr = { version = "1.3.0", default-features = false, features = ["std", "serde"] }
 serde = { version = "1.0.105", features = ["derive"] }
-toml = { version = "0.8.14", default-features = false, features = ["parse"] }
+toml = { version = "0.9", default-features = false, features = ["parse", "serde"] }


### PR DESCRIPTION
Bumps `regex-test`'s `toml` dependency from `0.8.14` to `0.9` (stable since 2025-08-29).

### API change

`toml::from_str` is now gated behind the `serde` feature in toml 0.9 (it was available under the `parse` feature alone in 0.8). Added `"serde"` to the existing `features = ["parse"]` list. `regex-test` already depends on `serde 1.0` with `derive`, so enabling toml's `serde` feature adds no new transitive dependency.

Single call site: `regex-test/lib.rs:158`, `toml::from_str(&data)`.

### Verification

* `cargo build -p regex-test`: clean
* `cargo test -p regex-test`: 0 passed, 1 ignored, 0 failed (matches master behaviour)
* `cargo fmt --all --check`: clean

The workspace's `cargo clippy --all-targets -- -D warnings` run has 70 pre-existing errors on master (reproducible on vanilla master before this change), unrelated to the bump.

### Context

Part of the Debian Rust team's `toml 0.9` transition (debcargo-conf#147). `regex-test` is listed as a reverse-dependency.
