### PR TITLE
meta: fix non-leftmost match in reverse-suffix/inner optimizations

### DIFF
--- a/regex-automata/src/meta/strategy.rs
+++ b/regex-automata/src/meta/strategy.rs
@@ -1214,10 +1214,17 @@ impl ReverseSuffix {
         input: &Input<'_>,
     ) -> Result<Option<HalfMatch>, RetryError> {
         let mut span = input.get_span();
-        let mut min_start = 0;
+        let mut best: Option<HalfMatch> = None;
         loop {
+            // We can't possibly improve on a match that already starts at the
+            // very beginning of the search span.
+            if let Some(b) = best {
+                if b.offset() == input.start() {
+                    return Ok(best);
+                }
+            }
             let litmatch = match self.pre.find(input.haystack(), span) {
-                None => return Ok(None),
+                None => break,
                 Some(span) => span,
             };
             trace!("reverse suffix scan found suffix match at {litmatch:?}");
@@ -1225,20 +1232,33 @@ impl ReverseSuffix {
                 .clone()
                 .anchored(Anchored::Yes)
                 .span(input.start()..litmatch.end);
+            // We bound the reverse scan by the current best start position:
+            // any match at a position >= best.offset() can't improve on the
+            // current candidate, and if the reverse DFA would need to scan
+            // past best.offset() to find a strictly-better start, it returns
+            // Quadratic, which propagates to the caller and falls back to the
+            // core engine. This preserves leftmost-first semantics without
+            // unbounded re-scanning: if the prefix matching is "monotonic" in
+            // the suffix end (the common case), the first iteration's reverse
+            // search already finds the leftmost start and we early-exit;
+            // otherwise we fall back to the core engine.
+            let min_start = best.map_or(input.start(), |b| b.offset());
             match self
                 .try_search_half_rev_limited(cache, &revinput, min_start)?
             {
-                None => {
-                    if span.start >= span.end {
-                        break;
+                None => {}
+                Some(hm) => {
+                    if best.map_or(true, |b| hm.offset() < b.offset()) {
+                        best = Some(hm);
                     }
-                    span.start = litmatch.start.checked_add(1).unwrap();
                 }
-                Some(hm) => return Ok(Some(hm)),
             }
-            min_start = litmatch.end;
+            if span.start >= span.end {
+                break;
+            }
+            span.start = litmatch.start.checked_add(1).unwrap();
         }
-        Ok(None)
+        Ok(best)
     }
 
     #[cfg_attr(feature = "perf-inline", inline(always))]
@@ -1622,11 +1642,18 @@ impl ReverseInner {
         input: &Input<'_>,
     ) -> Result<Option<Match>, RetryError> {
         let mut span = input.get_span();
-        let mut min_match_start = 0;
         let mut min_pre_start = 0;
+        let mut best: Option<Match> = None;
         loop {
+            // We can't possibly improve on a match that already starts at the
+            // very beginning of the search span.
+            if let Some(b) = best {
+                if b.start() == input.start() {
+                    return Ok(best);
+                }
+            }
             let litmatch = match self.preinner.find(input.haystack(), span) {
-                None => return Ok(None),
+                None => break,
                 Some(span) => span,
             };
             if litmatch.start < min_pre_start {
@@ -1642,6 +1669,16 @@ impl ReverseInner {
                 .clone()
                 .anchored(Anchored::Yes)
                 .span(input.start()..litmatch.start);
+            // We bound the reverse scan by the current best match's start: any
+            // match at a position >= best.start() can't improve on the current
+            // candidate, and if the reverse DFA would need to scan past
+            // best.start() to find a strictly-better start, it returns
+            // Quadratic, which propagates to the caller and falls back to the
+            // core engine. This preserves leftmost-first semantics for
+            // patterns where the prefix is non-monotonic in the inner literal
+            // position (i.e., where a later inner-literal occurrence can yield
+            // a strictly-earlier overall start).
+            let min_match_start = best.map_or(0, |m| m.start());
             // Note that in addition to the literal search above scanning past
             // our minimum start point, this routine can also return an error
             // as a result of detecting possible quadratic behavior if the
@@ -1653,12 +1690,7 @@ impl ReverseInner {
                 &revinput,
                 min_match_start,
             )? {
-                None => {
-                    if span.start >= span.end {
-                        break;
-                    }
-                    span.start = litmatch.start.checked_add(1).unwrap();
-                }
+                None => {}
                 Some(hm_start) => {
                     let fwdinput = input
                         .clone()
@@ -1667,21 +1699,27 @@ impl ReverseInner {
                     match self.try_search_half_fwd_stopat(cache, &fwdinput)? {
                         Err(stopat) => {
                             min_pre_start = stopat;
-                            span.start =
-                                litmatch.start.checked_add(1).unwrap();
                         }
                         Ok(hm_end) => {
-                            return Ok(Some(Match::new(
+                            let candidate = Match::new(
                                 hm_start.pattern(),
                                 hm_start.offset()..hm_end.offset(),
-                            )))
+                            );
+                            if best.map_or(true, |b| {
+                                candidate.start() < b.start()
+                            }) {
+                                best = Some(candidate);
+                            }
                         }
                     }
                 }
             }
-            min_match_start = litmatch.end;
+            if span.start >= span.end {
+                break;
+            }
+            span.start = litmatch.start.checked_add(1).unwrap();
         }
-        Ok(None)
+        Ok(best)
     }
 
     #[cfg_attr(feature = "perf-inline", inline(always))]

--- a/testdata/regression.toml
+++ b/testdata/regression.toml
@@ -828,3 +828,17 @@ name = 'improper-reverse-suffix-optimization'
 regex = '(\\N\{[^}]+})|([{}])'
 haystack = 'hiya \N{snowman} bye'
 matches = [[[5, 16], [5, 16], []]]
+
+# Regression test for the meta engine's reverse-suffix (and reverse-inner)
+# optimization returning a non-leftmost match. The first occurrence of the
+# suffix literal ':' is at offset 2, but the leftmost-first match uses the
+# second ':' at offset 4 because the optional group '(?:\([^()]*\))?' can
+# absorb '(:)'. The loop in try_search_half_start used to return on the first
+# successful reverse search, missing the strictly-earlier start.
+#
+# See: https://github.com/rust-lang/regex/issues/1345
+[[test]]
+name = 'non-monotonic-reverse-suffix'
+regex = '[^()]*(?:\([^()]*\))?[^()]*:'
+haystack = '$(:):'
+matches = [[0, 5]]


### PR DESCRIPTION
Closes #1345.

`ReverseSuffix::try_search_half_start` and `ReverseInner::try_search_full` returned on the first successful reverse search, which assumed that the leftmost occurrence of the suffix (resp. inner) literal corresponds to the end of the leftmost-first match. That assumption breaks when the regex prefix is non-monotonic — e.g. an optional group whose body can absorb the literal between consecutive occurrences — so a strictly later literal occurrence may have a strictly earlier overall match start. The minimal repro filed in #1345 is `[^()]*(?:\([^()]*\))?[^()]*:` on `$(:):`: META was returning `2..3`, while the leftmost-first match is `0..5` (the optional group absorbs `(:)` and pins to the second `:`).

Both loops now track the best (smallest-start) candidate and bound each subsequent reverse search by `best.offset()`. The existing limited reverse DFA in `regex-automata/src/meta/limited.rs` returns `RetryError::Quadratic` the moment scanning past the bound is required, which propagates through `?` and triggers the existing `Core` fallback in `Strategy::search`. The loops also early-exit when the candidate already starts at `input.start()`, so the common (monotonic-prefix) cases stay one-shot.

The bug was reduced from real-world `.sublime-syntax` grammars driven through fancy-regex's seek-prefilter approximation; see fancy-regex/fancy-regex#249 for the downstream context.

`testdata/regression.toml` gets the minimal repro as `non-monotonic-reverse-suffix`; it failed against `meta` and passed against `pikevm`/`hybrid` before this change.
