### PR TITLE
Fix clippy clone_on_copy warning in regex-syntax/src/ast/parse.rs

### DIFF
--- a/regex-syntax/src/ast/parse.rs
+++ b/regex-syntax/src/ast/parse.rs
@@ -2283,7 +2283,7 @@ impl<'p, 's, P: Borrow<Parser>> NestLimiter<'p, 's, P> {
     fn increment_depth(&mut self, span: &Span) -> Result<()> {
         let new = self.depth.checked_add(1).ok_or_else(|| {
             self.p.error(
-                span.clone(),
+                *span,
                 ast::ErrorKind::NestLimitExceeded(u32::MAX),
             )
         })?;


### PR DESCRIPTION
Fixes a clippy warning: using `clone` on type `Span` which implements the `Copy` trait.

Changes:
- `regex-syntax/src/ast/parse.rs` line 2286: `span.clone()` → `*span`

Ran `cargo clippy --package regex-syntax` and verified the warning is gone.