### PR TITLE
Implement `Regex::source_and_options_equals`

### DIFF
--- a/regex-automata/src/util/syntax.rs
+++ b/regex-automata/src/util/syntax.rs
@@ -141,7 +141,7 @@ pub fn parse_many_with<P: AsRef<str>>(
 /// These options are defined as a group since they apply to every regex engine
 /// in this crate. Instead of re-defining them on every engine's builder, they
 /// are instead provided here as one cohesive unit.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Config {
     case_insensitive: bool,
     multi_line: bool,

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -80,7 +80,11 @@ impl Builder {
             .configure(metac)
             .syntax(syntaxc)
             .build(&pattern)
-            .map(|meta| crate::Regex { meta, pattern })
+            .map(|meta| crate::Regex {
+                meta,
+                pattern,
+                syntaxc: Arc::new(self.syntaxc),
+            })
             .map_err(Error::from_meta_build_error)
     }
 

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -82,7 +82,7 @@ impl Builder {
             .build(&pattern)
             .map(|meta| crate::Regex {
                 meta,
-                info: crate::RegexInfo {
+                info: crate::regex::string::RegexInfo {
                     syntax_config: self.syntaxc,
                     pattern,
                 }
@@ -104,7 +104,14 @@ impl Builder {
             .configure(metac)
             .syntax(syntaxc)
             .build(&pattern)
-            .map(|meta| crate::bytes::Regex { meta, pattern })
+            .map(|meta| crate::bytes::Regex {
+                meta,
+                info: crate::regex::bytes::RegexInfo {
+                    syntax_config: syntaxc,
+                    pattern,
+                }
+                .into(),
+            })
             .map_err(Error::from_meta_build_error)
     }
 
@@ -121,7 +128,14 @@ impl Builder {
             .configure(metac)
             .syntax(syntaxc)
             .build_many(&patterns)
-            .map(|meta| crate::RegexSet { meta, patterns })
+            .map(|meta| crate::RegexSet {
+                meta,
+                info: crate::regexset::string::RegexSetInfo {
+                    syntax_config: syntaxc,
+                    patterns,
+                }
+                .into(),
+            })
             .map_err(Error::from_meta_build_error)
     }
 
@@ -138,7 +152,14 @@ impl Builder {
             .configure(metac)
             .syntax(syntaxc)
             .build_many(&patterns)
-            .map(|meta| crate::bytes::RegexSet { meta, patterns })
+            .map(|meta| crate::bytes::RegexSet {
+                meta,
+                info: crate::regexset::bytes::RegexSetInfo {
+                    syntax_config: syntaxc,
+                    patterns,
+                }
+                .into(),
+            })
             .map_err(Error::from_meta_build_error)
     }
 

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -82,8 +82,10 @@ impl Builder {
             .build(&pattern)
             .map(|meta| crate::Regex {
                 meta,
-                pattern,
-                syntaxc: Arc::new(self.syntaxc),
+                info: crate::RegexInfo {
+                    syntax_config: self.syntaxc,
+                    pattern,
+                }.into(),
             })
             .map_err(Error::from_meta_build_error)
     }

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -85,7 +85,8 @@ impl Builder {
                 info: crate::RegexInfo {
                     syntax_config: self.syntaxc,
                     pattern,
-                }.into(),
+                }
+                .into(),
             })
             .map_err(Error::from_meta_build_error)
     }

--- a/src/regex/bytes.rs
+++ b/src/regex/bytes.rs
@@ -98,6 +98,12 @@ use crate::{bytes::RegexBuilder, error::Error};
 #[derive(Clone)]
 pub struct Regex {
     pub(crate) meta: meta::Regex,
+    pub(crate) info: Arc<RegexInfo>,
+}
+
+#[derive(PartialEq)]
+pub(crate) struct RegexInfo {
+    pub(crate) syntax_config: regex_automata::util::syntax::Config,
     pub(crate) pattern: Arc<str>,
 }
 
@@ -1274,7 +1280,32 @@ impl Regex {
     /// ```
     #[inline]
     pub fn as_str(&self) -> &str {
-        &self.pattern
+        &self.info.pattern
+    }
+
+    /// Compares the source strings and syntax compile options of two regexes,
+    /// returning true iff both are equal.
+    /// Such result implies equivalence of the regexes, but the contrary
+    /// provides no information about their equivalence.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use regex::bytes::{Regex, RegexBuilder};
+    ///
+    /// let r1 = Regex::new(r"a+").unwrap();
+    /// let r2 = Regex::new(r"aa*").unwrap();
+    /// assert!(!r1.source_and_options_equals(&r2));
+    ///
+    /// let r3 = RegexBuilder::new(r"a+")
+    ///     .case_insensitive(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(!r1.source_and_options_equals(&r3));
+    /// ```
+    #[inline]
+    pub fn source_and_options_equals(&self, other: &Self) -> bool {
+        self.info == other.info
     }
 
     /// Returns an iterator over the capture names in this regex.

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -101,6 +101,7 @@ use crate::{error::Error, RegexBuilder};
 pub struct Regex {
     pub(crate) meta: meta::Regex,
     pub(crate) pattern: Arc<str>,
+    pub(crate) syntaxc: Arc<regex_automata::util::syntax::Config>,
 }
 
 impl core::fmt::Display for Regex {
@@ -1274,6 +1275,31 @@ impl Regex {
     #[inline]
     pub fn as_str(&self) -> &str {
         &self.pattern
+    }
+
+    /// Compares the source strings and compile options of two regexes,
+    /// returning true iff both are equal.
+    /// Such result implies equivalence of the regexes, but the contrary
+    /// provides no information about their equivalence.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use regex::{Regex, RegexBuilder};
+    ///
+    /// let r1 = Regex::new(r"a+").unwrap();
+    /// let r2 = Regex::new(r"aa*").unwrap();
+    /// assert!(!r1.source_and_options_equals(&r2));
+    ///
+    /// let r3 = RegexBuilder::new(r"a+")
+    ///     .case_insensitive(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(!r1.source_and_options_equals(&r3));
+    /// ```
+    #[inline]
+    pub fn source_and_options_equals(&self, other: &Self) -> bool {
+        self.pattern == other.pattern && self.syntaxc == other.syntaxc
     }
 
     /// Returns an iterator over the capture names in this regex.

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -100,8 +100,13 @@ use crate::{error::Error, RegexBuilder};
 #[derive(Clone)]
 pub struct Regex {
     pub(crate) meta: meta::Regex,
+    pub(crate) info: Arc<RegexInfo>,
+}
+
+#[derive(PartialEq)]
+pub(crate) struct RegexInfo {
+    pub(crate) syntax_config: regex_automata::util::syntax::Config,
     pub(crate) pattern: Arc<str>,
-    pub(crate) syntaxc: Arc<regex_automata::util::syntax::Config>,
 }
 
 impl core::fmt::Display for Regex {
@@ -1274,10 +1279,10 @@ impl Regex {
     /// ```
     #[inline]
     pub fn as_str(&self) -> &str {
-        &self.pattern
+        &self.info.pattern
     }
 
-    /// Compares the source strings and compile options of two regexes,
+    /// Compares the source strings and syntax compile options of two regexes,
     /// returning true iff both are equal.
     /// Such result implies equivalence of the regexes, but the contrary
     /// provides no information about their equivalence.
@@ -1299,7 +1304,7 @@ impl Regex {
     /// ```
     #[inline]
     pub fn source_and_options_equals(&self, other: &Self) -> bool {
-        self.pattern == other.pattern && self.syntaxc == other.syntaxc
+        self.info == other.info
     }
 
     /// Returns an iterator over the capture names in this regex.

--- a/src/regexset/bytes.rs
+++ b/src/regexset/bytes.rs
@@ -135,6 +135,12 @@ use crate::{bytes::RegexSetBuilder, Error};
 #[derive(Clone)]
 pub struct RegexSet {
     pub(crate) meta: meta::Regex,
+    pub(crate) info: alloc::sync::Arc<RegexSetInfo>,
+}
+
+#[derive(PartialEq)]
+pub(crate) struct RegexSetInfo {
+    pub(crate) syntax_config: regex_automata::util::syntax::Config,
     pub(crate) patterns: alloc::sync::Arc<[String]>,
 }
 
@@ -446,7 +452,32 @@ impl RegexSet {
     /// ```
     #[inline]
     pub fn patterns(&self) -> &[String] {
-        &self.patterns
+        &self.info.patterns
+    }
+
+    /// Compares the source strings and syntax compile options of two regex,
+    /// sets returning true iff both are equal.
+    /// Such result implies equivalence of the regex sets, but the contrary
+    /// provides no information about their equivalence.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use regex::bytes::{RegexSet, RegexSetBuilder};
+    ///
+    /// let r1 = RegexSet::new([r"a+", r"aa*"]).unwrap();
+    /// let r2 = RegexSet::new([r"aa*", r"a+"]).unwrap();
+    /// assert!(!r1.source_and_options_equals(&r2));
+    ///
+    /// let r3 = RegexSetBuilder::new([r"a+", r"aa*"])
+    ///     .case_insensitive(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(!r1.source_and_options_equals(&r3));
+    /// ```
+    #[inline]
+    pub fn source_and_options_equals(&self, other: &Self) -> bool {
+        self.info == other.info
     }
 }
 

--- a/src/regexset/string.rs
+++ b/src/regexset/string.rs
@@ -131,6 +131,12 @@ use crate::{Error, RegexSetBuilder};
 #[derive(Clone)]
 pub struct RegexSet {
     pub(crate) meta: meta::Regex,
+    pub(crate) info: alloc::sync::Arc<RegexSetInfo>,
+}
+
+#[derive(PartialEq)]
+pub(crate) struct RegexSetInfo {
+    pub(crate) syntax_config: regex_automata::util::syntax::Config,
     pub(crate) patterns: alloc::sync::Arc<[String]>,
 }
 
@@ -442,7 +448,32 @@ impl RegexSet {
     /// ```
     #[inline]
     pub fn patterns(&self) -> &[String] {
-        &self.patterns
+        &self.info.patterns
+    }
+
+    /// Compares the source strings and syntax compile options of two regex,
+    /// sets returning true iff both are equal.
+    /// Such result implies equivalence of the regex sets, but the contrary
+    /// provides no information about their equivalence.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use regex::{RegexSet, RegexSetBuilder};
+    ///
+    /// let r1 = RegexSet::new([r"a+", r"aa*"]).unwrap();
+    /// let r2 = RegexSet::new([r"aa*", r"a+"]).unwrap();
+    /// assert!(!r1.source_and_options_equals(&r2));
+    ///
+    /// let r3 = RegexSetBuilder::new([r"a+", r"aa*"])
+    ///     .case_insensitive(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(!r1.source_and_options_equals(&r3));
+    /// ```
+    #[inline]
+    pub fn source_and_options_equals(&self, other: &Self) -> bool {
+        self.info == other.info
     }
 }
 


### PR DESCRIPTION
`Regex::source_and_options_equals` provides API for testing regex equivalence while permitting false negatives (closes #1349)