### PR TITLE
fix: Return the leftmost match from ReverseSuffix

### DIFF
--- a/regex-automata/src/meta/strategy.rs
+++ b/regex-automata/src/meta/strategy.rs
@@ -1215,9 +1215,10 @@ impl ReverseSuffix {
     ) -> Result<Option<HalfMatch>, RetryError> {
         let mut span = input.get_span();
         let mut min_start = 0;
+        let mut first: Option<HalfMatch> = None;
         loop {
             let litmatch = match self.pre.find(input.haystack(), span) {
-                None => return Ok(None),
+                None => break,
                 Some(span) => span,
             };
             trace!("reverse suffix scan found suffix match at {litmatch:?}");
@@ -1228,7 +1229,13 @@ impl ReverseSuffix {
             if let Some(hm) =
                 self.try_search_half_rev_limited(cache, &revinput, min_start)?
             {
-                return Ok(Some(hm));
+                // We only track the first half-match. We can never find a
+                // half-match with lower offset than the first half-match, it
+                // would mean quadratic behavior. We can only confirm this
+                // half-match or return a quadratic error.
+                if first.is_none() {
+                    first = Some(hm);
+                }
             }
 
             if span.start >= span.end {
@@ -1237,7 +1244,7 @@ impl ReverseSuffix {
             span.start = litmatch.start.checked_add(1).unwrap();
             min_start = litmatch.end;
         }
-        Ok(None)
+        Ok(first)
     }
 
     #[cfg_attr(feature = "perf-inline", inline(always))]
@@ -1623,9 +1630,10 @@ impl ReverseInner {
         let mut span = input.get_span();
         let mut min_match_start = 0;
         let mut min_pre_start = 0;
+        let mut first: Option<Match> = None;
         loop {
             let litmatch = match self.preinner.find(input.haystack(), span) {
-                None => return Ok(None),
+                None => break,
                 Some(span) => span,
             };
             if litmatch.start < min_pre_start {
@@ -1662,10 +1670,12 @@ impl ReverseInner {
                         span.start = litmatch.start.checked_add(1).unwrap();
                     }
                     Ok(hm_end) => {
-                        return Ok(Some(Match::new(
-                            hm_start.pattern(),
-                            hm_start.offset()..hm_end.offset(),
-                        )))
+                        if first.is_none() {
+                            first = Some(Match::new(
+                                hm_start.pattern(),
+                                hm_start.offset()..hm_end.offset(),
+                            ));
+                        }
                     }
                 }
             }
@@ -1676,7 +1686,7 @@ impl ReverseInner {
             span.start = litmatch.start.checked_add(1).unwrap();
             min_match_start = litmatch.end;
         }
-        Ok(None)
+        Ok(first)
     }
 
     #[cfg_attr(feature = "perf-inline", inline(always))]

--- a/regex-automata/src/meta/strategy.rs
+++ b/regex-automata/src/meta/strategy.rs
@@ -1225,17 +1225,16 @@ impl ReverseSuffix {
                 .clone()
                 .anchored(Anchored::Yes)
                 .span(input.start()..litmatch.end);
-            match self
-                .try_search_half_rev_limited(cache, &revinput, min_start)?
+            if let Some(hm) =
+                self.try_search_half_rev_limited(cache, &revinput, min_start)?
             {
-                None => {
-                    if span.start >= span.end {
-                        break;
-                    }
-                    span.start = litmatch.start.checked_add(1).unwrap();
-                }
-                Some(hm) => return Ok(Some(hm)),
+                return Ok(Some(hm));
             }
+
+            if span.start >= span.end {
+                break;
+            }
+            span.start = litmatch.start.checked_add(1).unwrap();
             min_start = litmatch.end;
         }
         Ok(None)
@@ -1648,37 +1647,33 @@ impl ReverseInner {
             // reverse scan goes past the minimum start point. That is, the
             // literal search might not, but the reverse regex search for the
             // prefix might!
-            match self.try_search_half_rev_limited(
+            if let Some(hm_start) = self.try_search_half_rev_limited(
                 cache,
                 &revinput,
                 min_match_start,
             )? {
-                None => {
-                    if span.start >= span.end {
-                        break;
+                let fwdinput = input
+                    .clone()
+                    .anchored(Anchored::Pattern(hm_start.pattern()))
+                    .span(hm_start.offset()..input.end());
+                match self.try_search_half_fwd_stopat(cache, &fwdinput)? {
+                    Err(stopat) => {
+                        min_pre_start = stopat;
+                        span.start = litmatch.start.checked_add(1).unwrap();
                     }
-                    span.start = litmatch.start.checked_add(1).unwrap();
-                }
-                Some(hm_start) => {
-                    let fwdinput = input
-                        .clone()
-                        .anchored(Anchored::Pattern(hm_start.pattern()))
-                        .span(hm_start.offset()..input.end());
-                    match self.try_search_half_fwd_stopat(cache, &fwdinput)? {
-                        Err(stopat) => {
-                            min_pre_start = stopat;
-                            span.start =
-                                litmatch.start.checked_add(1).unwrap();
-                        }
-                        Ok(hm_end) => {
-                            return Ok(Some(Match::new(
-                                hm_start.pattern(),
-                                hm_start.offset()..hm_end.offset(),
-                            )))
-                        }
+                    Ok(hm_end) => {
+                        return Ok(Some(Match::new(
+                            hm_start.pattern(),
+                            hm_start.offset()..hm_end.offset(),
+                        )))
                     }
                 }
             }
+
+            if span.start >= span.end {
+                break;
+            }
+            span.start = litmatch.start.checked_add(1).unwrap();
             min_match_start = litmatch.end;
         }
         Ok(None)

--- a/regex-automata/src/meta/strategy.rs
+++ b/regex-automata/src/meta/strategy.rs
@@ -1127,6 +1127,16 @@ impl ReverseSuffix {
             );
             return Err(core);
         }
+        // Also like the reverse inner optimization, a reverse suffix encodes
+        // leftmost-first match semantics.
+        if core.info.config().get_match_kind() != MatchKind::LeftmostFirst {
+            debug!(
+                "skipping reverse suffix optimization because \
+				 match kind is {:?} but this only supports leftmost-first",
+                core.info.config().get_match_kind(),
+            );
+            return Err(core);
+        }
         // Like the reverse inner optimization, we don't do this for regexes
         // that are always anchored. It could lead to scanning too much, but
         // could say "no match" much more quickly than running the regex

--- a/testdata/regression.toml
+++ b/testdata/regression.toml
@@ -424,6 +424,14 @@ regex = '.abb|b'
 haystack = 'zzzabbz'
 matches = [[2, 6]]
 
+# See: https://github.com/rust-lang/regex/issues/1354
+[[test]]
+name = 'reverse-suffix-all-no-early-matches-010'
+regex = '.abb|b'
+haystack = 'xxfoobarbar'
+match-kind = 'all'
+matches = [[8, 9]]
+
 # See: https://github.com/BurntSushi/ripgrep/issues/1247
 [[test]]
 name = "stops"

--- a/testdata/regression.toml
+++ b/testdata/regression.toml
@@ -409,6 +409,21 @@ matches = []
 unicode = false
 utf8 = false
 
+# See: https://github.com/rust-lang/regex/issues/1354
+[[test]]
+name = 'reverse-suffix-start-of-match-failure-010'
+regex = '.abb|b'
+haystack = 'zabb'
+matches = [[0, 4]]
+
+# See: https://github.com/rust-lang/regex/issues/1354
+# See: https://github.com/rust-lang/regex/pull/1355
+[[test]]
+name = 'reverse-suffix-start-of-match-failure-011'
+regex = '.abb|b'
+haystack = 'zzzabbz'
+matches = [[2, 6]]
+
 # See: https://github.com/BurntSushi/ripgrep/issues/1247
 [[test]]
 name = "stops"
@@ -756,6 +771,21 @@ name = "reverse-inner-short"
 regex = '(?:([0-9][0-9][0-9]):)?([0-9][0-9]):([0-9][0-9])'
 haystack = '102:12:39'
 matches = [[[0, 9], [0, 3], [4, 6], [7, 9]]]
+
+
+# See: https://github.com/rust-lang/regex/issues/1354
+[[test]]
+name = 'reverse-inner-start-of-match-failure-010'
+regex = '(?:..acbb|b)a(?:c|d)'
+haystack = 'xzbacbbac'
+matches = [[1, 9]]
+
+# See: https://github.com/rust-lang/regex/issues/1354
+[[test]]
+name = 'reverse-inner-later-literal-010'
+regex = '(?:..acbb|b)a(?:c|d)'
+haystack = 'xzbacbbac'
+matches = [[1, 9]]
 
 # This regression test was found via the RegexSet APIs. It triggered a
 # particular code path where a regex was compiled with 'All' match semantics


### PR DESCRIPTION
This PR delays returning the first half-start match from `ReverseSuffix` strategy until we confirm that there isn't another match after it that would be more leftmost, which can happen for patterns where alternates are overlapping.

I'm a first time contributor and went with a straightforward way to fix the issue, any feedback is welcome. If there's a better approach to fix it, I'm also happy to rework the PR.

- Fixes #1354