### PR TITLE
docs: clarify unsupported Anchored::Pattern searches

### DIFF
--- a/regex-automata/src/util/search.rs
+++ b/regex-automata/src/util/search.rs
@@ -1879,6 +1879,12 @@ pub enum MatchErrorKind {
     /// An error indicating that a particular type of anchored search was
     /// requested, but that the regex engine does not support it.
     ///
+    /// When this error occurs with [`Anchored::Pattern`], then one common
+    /// cause is that the underlying regex engine was built without support
+    /// for anchored starting states for each pattern. For DFA engines, this
+    /// typically means enabling the `starts_for_each_pattern` configuration
+    /// option when building the searcher.
+    ///
     /// Note that this error should not be returned by a regex engine simply
     /// because the pattern ID is invalid (i.e., equal to or exceeds the number
     /// of patterns in the regex). In that case, the regex engine should report

--- a/regex-automata/src/util/search.rs
+++ b/regex-automata/src/util/search.rs
@@ -1882,8 +1882,11 @@ pub enum MatchErrorKind {
     /// When this error occurs with [`Anchored::Pattern`], then one common
     /// cause is that the underlying regex engine was built without support
     /// for anchored starting states for each pattern. For DFA engines, this
-    /// typically means enabling the `starts_for_each_pattern` configuration
-    /// option when building the searcher.
+    /// typically means enabling the
+    /// [`hybrid::dfa::Config::starts_for_each_pattern`](crate::hybrid::dfa::Config::starts_for_each_pattern)
+    /// or
+    /// [`dfa::dense::Config::starts_for_each_pattern`](crate::dfa::dense::Config::starts_for_each_pattern)
+    /// configuration option when building the searcher.
     ///
     /// Note that this error should not be returned by a regex engine simply
     /// because the pattern ID is invalid (i.e., equal to or exceeds the number

--- a/regex-automata/src/util/search.rs
+++ b/regex-automata/src/util/search.rs
@@ -1886,7 +1886,7 @@ pub enum MatchErrorKind {
     /// [`hybrid::dfa::Config::starts_for_each_pattern`](crate::hybrid::dfa::Config::starts_for_each_pattern)
     /// or
     /// [`dfa::dense::Config::starts_for_each_pattern`](crate::dfa::dense::Config::starts_for_each_pattern)
-    /// configuration option when building the searcher.
+    /// configuration option, depending on which regex engine is being built.
     ///
     /// Note that this error should not be returned by a regex engine simply
     /// because the pattern ID is invalid (i.e., equal to or exceeds the number


### PR DESCRIPTION
Closes #1262.

This expands the MatchErrorKind::UnsupportedAnchored rustdoc with the common Anchored::Pattern failure mode for DFA engines built without per-pattern anchored start states, and points readers at starts_for_each_pattern.

Validation:
- git show --check --oneline HEAD
- Static search for starts_for_each_pattern / Anchored::Pattern terminology in egex-automata

Not run locally:
- cargo fmt --check
- RUSTDOCFLAGS='-D warnings' cargo doc -p regex-automata --no-deps

Reason: this Windows environment does not currently have cargo on PATH. The change is rustdoc-only and limited to egex-automata/src/util/search.rs.