### PR TITLE
docs: clarify regex-lite word boundaries

### DIFF
--- a/regex-lite/src/lib.rs
+++ b/regex-lite/src/lib.rs
@@ -364,6 +364,8 @@ The precise set of differences at the syntax level:
 
 * The Perl character classes are limited to ASCII codepoints. That is,
 `\d` is `[0-9]`, `\s` is `[\t\n\v\f\r ]` and `\w` is `[0-9A-Za-z_]`.
+* Word boundary assertions are also limited to ASCII codepoints. For example,
+`\b` is defined in terms of `\w` which is itself ASCII-only.
 * Unicode character classes of the form `\p{...}` and `\P{...}` are not
 supported at all. Note though that things like `[^β]` are still supported and
 will match any Unicode scalar value except for `β`.


### PR DESCRIPTION
Fixes #1356.

This clarifies in the `regex-lite` differences section that word boundary assertions such as `\b` and `\B` are ASCII-only because they are defined in terms of `\w` and `\W`.

Validation:
- `git show --check --oneline HEAD`
- static search for the existing ASCII word boundary syntax table

Not run locally:
- `cargo test -p regex-lite`

Reason: this Windows environment does not currently have `cargo` on PATH. The change is documentation-only and limited to `regex-lite/src/lib.rs`.

AI-assisted contribution: implemented with OpenAI Codex and reviewed locally before submission.