### PR TITLE
automata: reject dense DFA start states that are match states

### DIFF
--- a/regex-automata/src/dfa/dense.rs
+++ b/regex-automata/src/dfa/dense.rs
@@ -4177,6 +4177,11 @@ impl<T: AsRef<[u32]>> StartTable<T> {
                     "found invalid starting state ID",
                 ));
             }
+            if dfa.special.is_match_state(id) {
+                return Err(DeserializeError::generic(
+                    "start states cannot be match states",
+                ));
+            }
         }
         Ok(())
     }
@@ -5254,6 +5259,23 @@ mod tests {
             pattern_ids: vec![],
             pattern_len: 1,
         };
+        let (buf, _) = dfa.to_bytes_native_endian();
+        DFA::from_bytes(&buf).unwrap_err();
+    }
+
+    // A starting state can never be a match state, since all matches are
+    // delayed by one byte. The search routines rely on this and assert it,
+    // so `from_bytes` must reject a serialized DFA whose start table points
+    // at a match state. The sparse DFA already rejected this; the dense DFA
+    // did not, so searching with such a DFA tripped the assertion in
+    // `dfa::search::init_fwd`.
+    #[test]
+    fn regression_start_state_not_match() {
+        let mut dfa = DFA::new("abc").unwrap();
+        let min_match = dfa.special.min_match;
+        for id in dfa.st.table_mut() {
+            *id = min_match;
+        }
         let (buf, _) = dfa.to_bytes_native_endian();
         DFA::from_bytes(&buf).unwrap_err();
     }

--- a/regex-automata/src/dfa/sparse.rs
+++ b/regex-automata/src/dfa/sparse.rs
@@ -2042,7 +2042,7 @@ impl<T: AsRef<[u8]>> StartTable<T> {
         for (id, _, _) in self.iter() {
             if !seen.contains(&id) {
                 return Err(DeserializeError::generic(
-                    "found invalid start state ID",
+                    "found invalid starting state ID",
                 ));
             }
             if sp.is_match_state(id) {
@@ -2651,5 +2651,23 @@ mod tests {
         let expected = MatchError::quit(0xCE, 3);
         let got = dfa.try_search_rev(&input);
         assert_eq!(Err(expected), got);
+    }
+
+    // A starting state can never be a match state, since all matches are
+    // delayed by one byte. The sparse DFA already rejects a serialized DFA
+    // whose start table points at a match state, but only the dense check
+    // had a regression test. See the test of the same name in
+    // src/dfa/dense.rs.
+    #[test]
+    fn regression_start_state_not_match() {
+        use crate::util::primitives::StateID;
+
+        let mut dfa = DFA::new("abc").unwrap().to_sparse().unwrap();
+        let min_match = dfa.special.min_match.as_u32().to_ne_bytes();
+        for entry in dfa.st.table.chunks_mut(StateID::SIZE) {
+            entry.copy_from_slice(&min_match);
+        }
+        let buf = dfa.to_bytes_native_endian();
+        crate::dfa::sparse::DFA::from_bytes(&buf).unwrap_err();
     }
 }


### PR DESCRIPTION
a serialized dense DFA can have a start-state table entry that points at a match state. dense::DFA::from_bytes checks that each start id indexes a real state, but unlike the sparse DFA it never checks that the id is not a match state, so the bytes are accepted. a later search then trips the debug assertion in dfa::search::init_fwd (start states can't be match states because matches are delayed a byte), and with assertions off it quietly breaks that delay invariant instead. this adds the same guard to StartTable::validate that the sparse DFA already has.