### PR TITLE
Fix runaway literal extraction for case-insensitive regex sets (#1310, #1311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+1.12.5 (TBD)
+============
+This release fixes a performance problem when building a `RegexSet` (or even a
+single regex) out of many case-insensitive patterns. Literal extraction could
+blow up combinatorially and build a large prefilter that the chosen search
+strategy would then never use.
+
+Bug fixes:
+
+* [BUG #1310](https://github.com/rust-lang/regex/issues/1310):
+Bound the number of literals extracted across patterns. This fixes runaway
+literal generation (and quadratic build time) for case-insensitive regex sets.
+* [BUG #1311](https://github.com/rust-lang/regex/issues/1311):
+Skip building a prefix prefilter for regexes that are always anchored at the
+end, since those use the reverse anchored strategy and never consult it.
+
+
 1.12.4 (2025-06-09)
 ===================
 This release includes a performance optimization for compilation of regexes

--- a/regex-automata/src/meta/strategy.rs
+++ b/regex-automata/src/meta/strategy.rs
@@ -102,6 +102,24 @@ pub(super) fn new(
         // carry a 'Prefilter' with it, but I moved away from that.)
         debug!("skipping literal extraction since regex is anchored");
         None
+    } else if info.is_always_anchored_end() {
+        // If the regex is always anchored at the end, then the reverse
+        // anchored strategy (selected below) will be used. That strategy does
+        // a reverse anchored search and never makes use of a prefix prefilter.
+        // Building one---which can require constructing a potentially large
+        // Aho-Corasick automaton out of the extracted literals---is therefore
+        // pure wasted work. This mirrors the skip for regexes that are always
+        // anchored at the start above.
+        //
+        // In the rare event that the reverse anchored strategy can't actually
+        // be built (essentially only when neither a lazy DFA nor a full DFA is
+        // available), we just fall back to the core engine without a prefix
+        // prefilter, which is an acceptable trade-off for such a degenerate
+        // case.
+        debug!(
+            "skipping literal extraction since regex is anchored at the end"
+        );
+        None
     } else if let Some(pre) = info.config().get_prefilter() {
         debug!(
             "skipping literal extraction since the caller provided a prefilter"

--- a/regex-automata/src/util/prefilter/mod.rs
+++ b/regex-automata/src/util/prefilter/mod.rs
@@ -629,6 +629,19 @@ impl Choice {
     }
 }
 
+/// A cap on the total number of literals accumulated when unioning the
+/// per-pattern literal sequences in `prefixes` and `suffixes` below.
+///
+/// The per-pattern `Extractor` already bounds the literals produced for a
+/// single pattern, but unioning those sequences across many patterns escapes
+/// that bound. This matters most for case insensitive regexes, where each
+/// pattern contributes an exponential number of *inexact* literals; without a
+/// cap, building a set of N such patterns is quadratic in N (every union
+/// re-scans the growing sequence) and yields a giant, useless prefilter. This
+/// value mirrors the default total limit used by `Extractor` itself.
+#[cfg(feature = "syntax")]
+const TOTAL_LIMIT: usize = 250;
+
 /// Extracts all of the prefix literals from the given HIR expressions into a
 /// single `Seq`. The literals in the sequence are ordered with respect to the
 /// order of the given HIR expressions and consistent with the match semantics
@@ -656,6 +669,33 @@ where
     let mut prefixes = literal::Seq::empty();
     for hir in hirs {
         prefixes.union(&mut extractor.extract(hir.borrow()));
+        // The per-pattern extractor above caps the literals produced for a
+        // single pattern, but unioning across patterns escapes that cap. This
+        // is most acute for case insensitive regexes, where every pattern adds
+        // an exponential number of *inexact* literals (e.g., `(?i)abc` yields
+        // ABC, ABc, AbC, ..., abc). Without a cap, building a set of N such
+        // patterns is quadratic in N and produces a giant, useless prefilter.
+        //
+        // We only cull *inexact* sequences: an exact sequence is a faithful
+        // enumeration of (a subset of) the language and tends to make a good
+        // prefilter (or even a complete matcher) even when large, so we leave
+        // exact-literal behavior completely unchanged.
+        if !prefixes.is_exact()
+            && prefixes.len().map_or(false, |len| len > TOTAL_LIMIT)
+        {
+            // Try to salvage a small prefilter by collapsing everything down
+            // to a short common-ish prefix. We keep 4 bytes since that is the
+            // maximum literal length supported by the Teddy matcher; this is
+            // the same trick used to keep literal sets in check within
+            // `regex-syntax`'s own `Extractor::union`. If even that is still
+            // too big, then we give up on a prefix prefilter entirely.
+            prefixes.keep_first_bytes(4);
+            prefixes.dedup();
+            if prefixes.len().map_or(false, |len| len > TOTAL_LIMIT) {
+                prefixes.make_infinite();
+                break;
+            }
+        }
     }
     debug!(
         "prefixes (len={:?}, exact={:?}) extracted before optimization: {:?}",
@@ -693,6 +733,19 @@ where
     let mut suffixes = literal::Seq::empty();
     for hir in hirs {
         suffixes.union(&mut extractor.extract(hir.borrow()));
+        // See the equivalent cap in `prefixes` above for the rationale. The
+        // only difference here is that suffix literals are collapsed by
+        // keeping their last bytes rather than their first.
+        if !suffixes.is_exact()
+            && suffixes.len().map_or(false, |len| len > TOTAL_LIMIT)
+        {
+            suffixes.keep_last_bytes(4);
+            suffixes.dedup();
+            if suffixes.len().map_or(false, |len| len > TOTAL_LIMIT) {
+                suffixes.make_infinite();
+                break;
+            }
+        }
     }
     debug!(
         "suffixes (len={:?}, exact={:?}) extracted before optimization: {:?}",
@@ -716,4 +769,76 @@ where
         suffixes
     );
     suffixes
+}
+
+// All of these tests exercise `prefixes`/`suffixes`, which only exist when the
+// `syntax` feature is enabled (which in turn enables `alloc`).
+#[cfg(all(test, feature = "syntax"))]
+mod tests {
+    use alloc::{format, vec};
+
+    use super::*;
+
+    // Regression test for https://github.com/rust-lang/regex/issues/1310.
+    //
+    // Unioning prefix literals across many case insensitive patterns used to
+    // produce an enormous (and quadratic-to-build) sequence: each pattern
+    // contributes ~2^k inexact literals, and the cross-pattern union had no
+    // total cap. Here we make sure the extracted sequence stays bounded.
+    #[test]
+    #[cfg(all(feature = "syntax", feature = "unicode-case"))]
+    fn prefixes_case_insensitive_is_bounded() {
+        let mut hirs = vec![];
+        for i in 0..50 {
+            let pat = format!(r"(?i)domain{i}\.com");
+            hirs.push(crate::util::syntax::parse(&pat).unwrap());
+        }
+        let seq = prefixes(MatchKind::All, &hirs);
+        // Without the cap, this would be ~50 * 128 = 6400 inexact literals.
+        // With it, the sequence is either dropped (infinite) or collapsed to a
+        // small shared prefix.
+        assert!(
+            seq.len().map_or(true, |len| len <= TOTAL_LIMIT),
+            "expected a bounded prefix sequence, got len={:?}",
+            seq.len(),
+        );
+    }
+
+    // Same as above, but for suffixes (used by the reverse-suffix strategy).
+    #[test]
+    #[cfg(all(feature = "syntax", feature = "unicode-case"))]
+    fn suffixes_case_insensitive_is_bounded() {
+        let mut hirs = vec![];
+        for i in 0..50 {
+            let pat = format!(r"(?i)www\.domain{i}");
+            hirs.push(crate::util::syntax::parse(&pat).unwrap());
+        }
+        let seq = suffixes(MatchKind::All, &hirs);
+        assert!(
+            seq.len().map_or(true, |len| len <= TOTAL_LIMIT),
+            "expected a bounded suffix sequence, got len={:?}",
+            seq.len(),
+        );
+    }
+
+    // A large *exact* literal alternation must NOT be culled by the cap: such
+    // sequences are faithful enumerations and make good prefilters (or even
+    // complete matchers) even when they exceed TOTAL_LIMIT. This guards the
+    // `is_exact()` guard so we don't regress plain-literal sets.
+    #[test]
+    #[cfg(feature = "syntax")]
+    fn prefixes_exact_set_is_preserved() {
+        let mut hirs = vec![];
+        for i in 0..(TOTAL_LIMIT + 50) {
+            let pat = format!(r"literal{i}");
+            hirs.push(crate::util::syntax::parse(&pat).unwrap());
+        }
+        let seq = prefixes(MatchKind::All, &hirs);
+        assert!(seq.is_exact(), "exact literal set should remain exact");
+        assert!(
+            seq.len().map_or(false, |len| len > TOTAL_LIMIT),
+            "exact literal set should not be culled, got len={:?}",
+            seq.len(),
+        );
+    }
 }

--- a/testdata/regression.toml
+++ b/testdata/regression.toml
@@ -828,3 +828,16 @@ name = 'improper-reverse-suffix-optimization'
 regex = '(\\N\{[^}]+})|([{}])'
 haystack = 'hiya \N{snowman} bye'
 matches = [[[5, 16], [5, 16], []]]
+
+# Regression test for the case-insensitive RegexSet build blowup. A regex that
+# is always anchored at the end (here, case insensitive) selects the reverse
+# anchored strategy, which never uses a prefix prefilter. We now skip building
+# one for such regexes; this makes sure matching is still correct afterwards.
+#
+# See: https://github.com/rust-lang/regex/discussions/1309
+# See: https://github.com/rust-lang/regex/issues/1311
+[[test]]
+name = "case-insensitive-anchored-end"
+regex = '(?i)domain\.com$'
+haystack = "go to DOMAIN.COM"
+matches = [[6, 16]]

--- a/testdata/set.toml
+++ b/testdata/set.toml
@@ -639,3 +639,31 @@ match-kind = "leftmost-first"
 search-kind = "leftmost"
 unicode = false
 utf8 = false
+
+# Regression test for https://github.com/rust-lang/regex/issues/1311. A set of
+# case-insensitive, end-anchored patterns selects the reverse anchored
+# strategy, which does not use a prefix prefilter, so we now skip extracting
+# prefix literals for it. Matching must remain correct.
+[[test]]
+name = "case-insensitive-anchored-end-set"
+regex = ['(?i)domain1\.com$', '(?i)domain2\.com$']
+haystack = "DOMAIN2.COM"
+matches = [
+  { id = 1, span = [0, 11] },
+]
+match-kind = "all"
+search-kind = "overlapping"
+
+# Regression test for https://github.com/rust-lang/regex/issues/1310. A set of
+# case-insensitive (unanchored) patterns used to union an unbounded number of
+# prefix literals across patterns. After bounding that union, matching must
+# remain correct.
+[[test]]
+name = "case-insensitive-contains-set"
+regex = ['(?i)domain1\.com', '(?i)domain2\.com']
+haystack = "see DOMAIN1.COM now"
+matches = [
+  { id = 0, span = [4, 15] },
+]
+match-kind = "all"
+search-kind = "overlapping"


### PR DESCRIPTION
## Summary

Building a `RegexSet` (or even a single regex) out of many **case-insensitive**
patterns could blow up at construction time. This was reported in #1309 and
triaged into two bugs, both fixed here.

**Root cause.** Each case-insensitive pattern yields an exponential number of
*inexact* prefix/suffix literals (`(?i)abc` → `ABC, ABc, …, abc`). The
per-pattern `Extractor` caps these, but `prefixes()`/`suffixes()` union them
**across patterns** with the raw `Seq::union`, which has **no total cap** and
re-`dedup`s the whole growing list each time. So an N-pattern set is
effectively **O(N²)** to build and produces a giant literal set. For
end-anchored patterns (`…$`), that set is then compiled into a large
Aho-Corasick prefilter that the selected **reverse-anchored** strategy never
even uses.

## Changes

- **#1310 — bound the cross-pattern literal union**
  (`regex-automata/src/util/prefilter/mod.rs`). When the running *inexact*
  sequence exceeds a total limit, collapse it to a short shared prefix/suffix
  (the same keep-4-bytes trick as `Extractor::union`), and drop the prefilter
  entirely if it is still too big. **Exact** sequences (faithful enumerations,
  e.g. plain-literal sets) are left untouched, so that behavior is unchanged.
- **#1311 — don't build a prefilter we won't use**
  (`regex-automata/src/meta/strategy.rs`). Skip prefix literal extraction when
  the regex is always anchored at the end; those use the reverse-anchored
  strategy, which never consults a prefix prefilter. This mirrors the existing
  always-anchored-start skip.

Note: #1310 points at `limit_total` in `regex-syntax`; that per-pattern limit
already works — the leak is the cross-pattern union, which is why the fix lives
in `prefixes()`/`suffixes()`.

## Results

`(?i)domainN\.com` sets, build time (M2 Air):

| N | endswith (before → after) | contains (before → after) |
|---|---|---|
| 600 | ~150ms → ~10ms | ~243ms → ~8ms |
| 1200 | — | ~796ms → ~20ms |
| 4000 | super-linear → ~44ms | super-linear → ~37ms |

`debug` logs confirm end-anchored sets now log `skipping literal extraction
since regex is anchored at the end` (no Aho-Corasick built), and unanchored
case-insensitive sets extract a small bounded set (e.g. 16 literals → a fast
Teddy prefilter, vs 1280 → a 2690-state Aho-Corasick before).

## Test plan

- New unit tests in `prefilter/mod.rs`: the case-insensitive prefix/suffix
  sequences stay bounded (verified to produce 6400 literals *without* the cap),
  and a large *exact* set is preserved.
- New correctness cases in `testdata/regression.toml` and `testdata/set.toml`
  for end-anchored and unanchored case-insensitive sets (exercised by all four
  test suites).
- Full workspace suite passes (`regex-automata`: 459 doctests + 140 lib + 58
  integration; top-level integration: 64).

Note: This has been generated with Claude Opus 4.8