### PR TITLE
github: add FUNDING link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [BurntSushi]


### PR DESCRIPTION
The [regex team just consists of myself right now](https://github.com/rust-lang/team/blob/db2c1ed9fbc0216e533db954cd249045c01c7406/teams/regex.toml#L6). This should be changed
to match team membership whenever that changes.

Ref https://github.com/rust-lang/leadership-council/issues/285#issuecomment-4837769712
