### PR TITLE
automata: fix leftmost-first miss in the reverse suffix optimization

### DIFF
--- a/regex-automata/src/meta/strategy.rs
+++ b/regex-automata/src/meta/strategy.rs
@@ -1168,6 +1168,35 @@ impl ReverseSuffix {
         }
         let kind = core.info.config().get_match_kind();
         let suffixes = crate::util::prefilter::suffixes(kind, hirs);
+        // An exact suffix literal that is also a proper suffix of another
+        // suffix literal means one alternation branch's complete match can be
+        // nested inside the tail of another branch's match. Candidate *ends*
+        // are then not ordered like match *starts*: the first confirmed
+        // candidate can yield a match that starts *later* than a still
+        // undiscovered overlapping match ending further right, violating
+        // leftmost-first. (Repro: `a|.aa` on `-#aa` reported [(2,3),(3,4)]
+        // instead of [(1,4)].) Decline the optimization in that case.
+        if let Some(lits) = suffixes.literals() {
+            for (i, a) in lits.iter().enumerate() {
+                if !a.is_exact() {
+                    continue;
+                }
+                for (j, b) in lits.iter().enumerate() {
+                    if i != j
+                        && b.as_bytes().len() > a.as_bytes().len()
+                        && b.as_bytes().ends_with(a.as_bytes())
+                    {
+                        debug!(
+                            "skipping reverse suffix optimization because \
+                             an exact suffix literal is a proper suffix of \
+                             another suffix literal (nested-end overlaps \
+                             defeat leftmost-first candidate ordering)"
+                        );
+                        return Err(core);
+                    }
+                }
+            }
+        }
         let lcs = match suffixes.longest_common_suffix() {
             None => {
                 debug!(

--- a/tests/regression_fuzz.rs
+++ b/tests/regression_fuzz.rs
@@ -59,3 +59,20 @@ fn fail_branch_prevents_match() {
     let re = Regex::new(pat).unwrap();
     assert!(re.is_match(hay));
 }
+
+// This was caught by a differential fuzzer (REAL-regex vs this crate), and
+// then minimized by hand.
+//
+// The reverse suffix optimization processes suffix-prefilter candidates in
+// order of match *end*. When one alternation branch's entire match (an exact
+// suffix literal) is a proper suffix of another branch's suffix, a match can
+// be nested inside the tail of an overlapping match that ends later but
+// starts *earlier*. Yielding the first confirmed candidate then skips the
+// true leftmost match, and the anti-quadratic clamp makes the miss permanent.
+#[test]
+fn reverse_suffix_nested_overlap_misses_leftmost() {
+    let re = Regex::new("a|.aa").unwrap();
+    let spans: Vec<(usize, usize)> =
+        re.find_iter("-#aa").map(|m| (m.start(), m.end())).collect();
+    assert_eq!(spans, vec![(1, 4)]);
+}


### PR DESCRIPTION
The reverse suffix optimization can skip a match that starts earlier than the matches it reports, violating leftmost-first semantics.

## Repro (1.12.4, default config)
```rust
let re = regex::Regex::new("a|.aa").unwrap();
let spans: Vec<_> = re.find_iter("-#aa").map(|m| (m.start(), m.end())).collect();
assert_eq!(spans, vec![(1, 4)]);   // FAILS today: [(2, 3), (3, 4)]
```
`[1,4)` (".aa" matching `#aa`) is a match and starts leftmost. (Original fuzz find: `\0|.\0\0` on `"\0\0\0\0\n\x0b\0\0\0"`, missing `(5,8)`; minimized by hand.)

## Root cause
With `RUST_LOG=trace`: suffixes extract as `Seq[E("a"), I("aa")]`, the LCS prefilter is `memchr('a')`, and `ReverseSuffix` is engaged. Candidates are processed in order of match **end**, and the first reverse+forward confirmed match is yielded. That is only correct when the leftmost-starting match also has the smallest candidate end at/after the resume point. Here branch 1's entire match (`E("a")`) is a proper suffix of branch 2's suffix (`"aa"`): a branch-1 match nests inside the tail of an overlapping branch-2 match that ends later but starts earlier. Candidate end 3 confirms `(2,3)` and is yielded; the true leftmost `[1,4)` (candidate end 4) is then behind the (correct in itself) anti-quadratic `min_start` clamp, so the miss is permanent.

## The fix
Conservative: decline the optimization in `ReverseSuffix::new` when any **exact** suffix literal is a proper suffix of another suffix literal — the precise nesting that breaks the end-order ⇒ start-order assumption — falling back to the core engine. Common beneficiaries keep the optimization (single-branch suffixes, all-inexact seqs such as `\w+@\w+`, non-nested alternations like `foo|bar`).

A complete fix that keeps the optimization for these patterns would need candidate look-ahead across ends before yielding when overlap is possible; happy to explore that as a follow-up if you'd prefer.

## Validation
- New regression test in `tests/regression_fuzz.rs` (fails before, passes after).
- `cargo test --test integration` (66) and `cargo test -p regex-automata --lib` (137): pass.

Found by a differential fuzzer (REAL-regex vs this crate).
