### PR TITLE
Expose Regex memory usage info (fixes #943)

### DIFF
--- a/src/regex/bytes.rs
+++ b/src/regex/bytes.rs
@@ -1482,6 +1482,15 @@ impl Regex {
     pub fn locations(&self) -> CaptureLocations {
         self.capture_locations()
     }
+
+    /// Return the total approximate heap memory, in bytes, used by this `Regex`.
+    ///
+    /// Note that this value is unrelated to [`RegexBuilder::size_limit`], and can
+    /// in many cases exceed it.
+    #[inline]
+    pub fn memory_usage(&self) -> usize {
+        self.meta.memory_usage() + self.pattern.len()
+    }
 }
 
 /// Represents a single match of a regex in a haystack.

--- a/src/regex/bytes.rs
+++ b/src/regex/bytes.rs
@@ -1485,8 +1485,8 @@ impl Regex {
 
     /// Return the total approximate heap memory, in bytes, used by this `Regex`.
     ///
-    /// Note that this value is unrelated to [`RegexBuilder::size_limit`], and can
-    /// in many cases exceed it.
+    /// Note that this value does not have a defined relationship to
+    ///  to [`RegexBuilder::size_limit`].
     #[inline]
     pub fn memory_usage(&self) -> usize {
         self.meta.memory_usage() + self.pattern.len()

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -1484,8 +1484,8 @@ impl Regex {
 
     /// Return the total approximate heap memory, in bytes, used by this `Regex`.
     ///
-    /// Note that this value is unrelated to [`RegexBuilder::size_limit`], and can
-    /// in many cases exceed it.
+    /// Note that this value does not have a defined relationship to
+    ///  to [`RegexBuilder::size_limit`].
     #[inline]
     pub fn memory_usage(&self) -> usize {
         self.meta.memory_usage() + self.pattern.len()

--- a/src/regex/string.rs
+++ b/src/regex/string.rs
@@ -1481,6 +1481,15 @@ impl Regex {
     pub fn locations(&self) -> CaptureLocations {
         self.capture_locations()
     }
+
+    /// Return the total approximate heap memory, in bytes, used by this `Regex`.
+    ///
+    /// Note that this value is unrelated to [`RegexBuilder::size_limit`], and can
+    /// in many cases exceed it.
+    #[inline]
+    pub fn memory_usage(&self) -> usize {
+        self.meta.memory_usage() + self.pattern.len()
+    }
 }
 
 /// Represents a single match of a regex in a haystack.


### PR DESCRIPTION
Based on https://github.com/rust-lang/regex/pull/1180